### PR TITLE
Fix #141: chart_log endpoint estimator replaces passive_decay OLS (v0.3.43)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,8 +19,6 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     permissions:
       contents: read
       pull-requests: read
@@ -43,3 +41,4 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,8 +18,6 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     permissions:
       contents: read
       pull-requests: read
@@ -49,3 +47,4 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/claude.md
+++ b/claude.md
@@ -162,6 +162,15 @@ The briefing is the main way users interact with Climate Advisor. When making ch
 
 - **`@callback` decorator** — Is a `MagicMock` in the test mock layer and swallows decorated functions. If a test needs to invoke a `@callback`-decorated inner function (e.g., timer callbacks), patch it: `patch("...coordinator.callback", side_effect=lambda fn: fn)`
 
+#### Testing `_build_predicted_indoor_future` directly
+
+When calling `_build_predicted_indoor_future` in tests using the lightweight HA stub environment, `dt_util.as_local()` returns a `MagicMock` — breaking `<=` comparisons against real `datetime` objects. Always wrap the call with:
+```python
+with patch("custom_components.climate_advisor.coordinator.dt_util.as_local", side_effect=lambda x: x):
+    result = _build_predicted_indoor_future(...)
+```
+Reference: `TestPredIndoorIntegration::test_ode_cache_diverges_after_model_refresh`
+
 #### Testing Sensor Attributes and API Views
 
 **Sensor entity classes (`ClimateAdvisorBaseSensor` subclasses) CANNOT be directly instantiated in test files that use the lightweight HA module stubs** (e.g., `test_fan_control.py`, `test_contact_status.py`). Importing `sensor.py` in that environment causes a metaclass conflict:

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,7 +4,7 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.3.42"
+VERSION = "0.3.43"
 
 RELEASE_NOTES: dict[str, list[str]] = {
     "0.3.37": [
@@ -845,6 +845,12 @@ THERMAL_SWING_CONF_HIGH: int = 10
 THERMAL_PASSIVE_MIN_SAMPLES = 30
 THERMAL_PASSIVE_MIN_DELTA_F = 3.0
 THERMAL_PASSIVE_MIN_SIGNAL_F = 0.5
+
+# Chart_log endpoint estimator thresholds (replaces passive_decay consecutive-pair OLS)
+# Min window duration and temperature drop for passive-only and overnight ventilated windows.
+THERMAL_CHART_LOG_PASSIVE_MIN_MINUTES: int = 120  # 2h minimum window
+THERMAL_CHART_LOG_PASSIVE_MIN_DT_F: float = 1.0  # at least 1°F sensor change
+THERMAL_CHART_LOG_VENT_MIN_MINUTES: int = 120  # 2h minimum for overnight ventilated windows
 
 # Fan-only decay observation thresholds
 THERMAL_FAN_MIN_SAMPLES = 15

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -2876,8 +2876,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 "confidence_grade": grade,
                 "date": today_str,
                 "source": "chart_log_endpoint",
+                "elapsed_hours": round(dt_hours, 2),
+                "delta_t_f": round(t_end - t_start, 2),
+                "ratio": round(ratio, 4),
             }
-            self.learning._update_thermal_model_cache(obs)
+            self.learning.record_thermal_observation(obs)
             committed += 1
             _LOGGER.debug(
                 "chart_log_endpoint passive: k=%.4f conf=%s dt=%.1fh dT=%.1fF",
@@ -3024,8 +3027,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 "confidence_grade": grade,
                 "date": today_str,
                 "source": "chart_log_endpoint",
+                "elapsed_hours": round(dt_hours, 2),
+                "delta_t_f": round(t_end - t_start, 2),
+                "ratio": round(ratio, 4),
             }
-            self.learning._update_thermal_model_cache(obs)
+            self.learning.record_thermal_observation(obs)
             committed += 1
             _LOGGER.debug(
                 "chart_log_endpoint vent: k=%.4f conf=%s dt=%.1fh dT=%.1fF",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -122,11 +122,16 @@ from .const import (
     TEMP_SOURCE_SENSOR,
     TEMP_SOURCE_WEATHER_SERVICE,
     THERMAL_BUCKET_INTERP_HALF_F,
+    THERMAL_CHART_LOG_PASSIVE_MIN_DT_F,
+    THERMAL_CHART_LOG_PASSIVE_MIN_MINUTES,
+    THERMAL_CHART_LOG_VENT_MIN_MINUTES,
     THERMAL_COLD_BUCKET_LIMIT_F,
     THERMAL_FAN_MIN_SAMPLES,
     THERMAL_FAN_MIN_SIGNAL_F,
     THERMAL_FAN_SAMPLE_INTERVAL_S,
     THERMAL_HVAC_MIN_DECAY_F,
+    THERMAL_K_PASSIVE_MAX,
+    THERMAL_K_PASSIVE_MIN,
     THERMAL_MAX_ACTIVE_SAMPLES,
     THERMAL_MAX_OBS_SAMPLES,
     THERMAL_MAX_POST_HEAT_SAMPLES,
@@ -136,7 +141,6 @@ from .const import (
     THERMAL_MIN_R_SQUARED,
     THERMAL_PASSIVE_MIN_DELTA_F,
     THERMAL_PASSIVE_MIN_SAMPLES,
-    THERMAL_PASSIVE_MIN_SIGNAL_F,
     THERMAL_PASSIVE_SAMPLE_INTERVAL_S,
     THERMAL_POST_HEAT_TIMEOUT_MINUTES,
     THERMAL_ROLLING_MAX_WINDOW_MINUTES,
@@ -281,6 +285,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._startup_hvac_initialized: bool = False  # Issue #96: prevents repeated late-start init
         self._last_state_contradiction_time: datetime | None = None  # dedup for state_contradiction_warning events
         self._last_violation_check: datetime | None = None
+        # Chart_log endpoint estimator backfill flags (Issue #137)
+        self._passive_k_backfilled: bool = False  # True after chart_log passive windows processed
+        self._vent_k_backfilled: bool = False  # True after chart_log overnight ventilated windows processed
 
         # Occupancy state machine
         self._occupancy_mode: str = OCCUPANCY_HOME
@@ -530,6 +537,10 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             except (ValueError, TypeError):
                 self._occupancy_away_since = None
 
+        # Chart_log endpoint estimator backfill flags (Issue #137)
+        self._passive_k_backfilled = bool(state.get("passive_k_backfilled", False))
+        self._vent_k_backfilled = bool(state.get("vent_k_backfilled", False))
+
         # Prediction archive — restore only on same-day restores (already gated above)
         raw_archive = state.get("pred_archive")
         if isinstance(raw_archive, dict):
@@ -611,6 +622,8 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             "occupancy_away_since": (self._occupancy_away_since.isoformat() if self._occupancy_away_since else None),
             "ai_stats": self.claude_client.get_persistent_stats() if self.claude_client else {},
             "pred_archive": {str(k): v for k, v in self._pred_archive.items()},
+            "passive_k_backfilled": self._passive_k_backfilled,
+            "vent_k_backfilled": self._vent_k_backfilled,
         }
 
     async def _async_save_state(self) -> None:
@@ -1096,6 +1109,19 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                                     _obs.get("obs_id", "?"),
                                     len(samples),
                                 )
+
+                # Chart_log endpoint estimator backfill (Issue #137): run once on first startup
+                # after the new code is deployed. The chart_log is loaded in __init__ so entries
+                # are already available. Flags survive restart so backfill runs exactly once.
+                if self.config.get("learning_enabled", True):
+                    if not self._passive_k_backfilled:
+                        self._run_passive_chart_log_fit(backfill=True)
+                        self._passive_k_backfilled = True
+                        _LOGGER.info("chart_log_endpoint: passive k_passive backfill complete")
+                    if not self._vent_k_backfilled:
+                        self._run_ventilated_chart_log_fit(backfill=True)
+                        self._vent_k_backfilled = True
+                        _LOGGER.info("chart_log_endpoint: ventilated k_vent_window backfill complete")
 
             # Refresh the thermal model on every 30-min cycle, not just at the daily
             # briefing. get_thermal_model() is a pure computation (no I/O), so calling it
@@ -2602,28 +2628,29 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             samples_list = obs.get("samples", [])
 
             if obs_type == OBS_TYPE_PASSIVE_DECAY:
-                # Two-threshold accumulation (Issue #126): keep alive until signal sufficient or 4h max
-                _pd_temps = [s["indoor_temp_f"] for s in samples_list if "indoor_temp_f" in s]
-                _pd_signal = (max(_pd_temps) - min(_pd_temps)) >= THERMAL_ROLLING_MIN_DELTA_T_F if _pd_temps else False
-                if self._evaluate_rolling_window(obs_type, obs, _pd_signal, skip_delta_guard=False):
-                    continue
+                # Issue #137: consecutive-pair OLS replaced by chart_log endpoint estimator.
+                # passive_decay observation tracks passive conditions (no HVAC/fan/sensors);
+                # when it ends, trigger the chart_log fit rather than running OLS.
                 if _is_heating_cooling or _hvac_active:
-                    self._commit_observation_if_sufficient(obs_type, "hvac_started")
+                    self._run_passive_chart_log_fit(backfill=False)
+                    self._abandon_observation(obs_type, "hvac_started")
                 elif _sensor_open:
+                    self._run_passive_chart_log_fit(backfill=False)
                     self._abandon_observation(obs_type, "sensor_opened")
                 elif _fan_active:
+                    self._run_passive_chart_log_fit(backfill=False)
                     self._abandon_observation(obs_type, "fan_activated")
                 elif indoor is not None and outdoor is not None and abs(indoor - outdoor) < THERMAL_PASSIVE_MIN_DELTA_F:
                     recent_temps = [s["indoor_temp_f"] for s in samples_list[-5:]] if len(samples_list) >= 5 else []
                     if recent_temps and (max(recent_temps) - min(recent_temps)) < 0.1:
+                        self._run_passive_chart_log_fit(backfill=False)
                         self._abandon_observation(obs_type, "equilibrium_reached")
-                elif (
-                    len(samples_list) >= THERMAL_PASSIVE_MIN_SAMPLES
-                    and indoor is not None
-                    and outdoor is not None
-                    and abs(indoor - outdoor) >= THERMAL_PASSIVE_MIN_SIGNAL_F
-                ):
-                    self._commit_observation_if_sufficient(obs_type, "insufficient_signal")
+                else:
+                    _max_samples = THERMAL_ROLLING_MAX_WINDOW_MINUTES // (THERMAL_PASSIVE_SAMPLE_INTERVAL_S // 60)
+                    if len(samples_list) >= _max_samples:
+                        # Hard time cap reached — trigger fit and end observation
+                        self._run_passive_chart_log_fit(backfill=False)
+                        self._abandon_observation(obs_type, "max_window_reached")
 
             elif obs_type == OBS_TYPE_FAN_ONLY_DECAY:
                 # Two-threshold accumulation: signal = indoor sample range (max-min).
@@ -2671,8 +2698,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 if self._evaluate_rolling_window(obs_type, obs, _vent_signal_sufficient, skip_delta_guard=True):
                     continue
                 if not _sensor_open:
+                    # Sensors closed: run OLS commit (morning windows) AND chart_log endpoint
+                    # fit (overnight windows). Natural filter in the endpoint fit auto-rejects
+                    # morning windows where T_out crossed T_in.
                     self._commit_observation_if_sufficient(obs_type, "sensors_closed")
+                    self._run_ventilated_chart_log_fit(backfill=False)
                 elif _is_heating_cooling or _hvac_active:
+                    self._run_ventilated_chart_log_fit(backfill=False)
                     self._abandon_observation(obs_type, "hvac_started")
                 elif (
                     len(samples_list) >= THERMAL_VENT_MIN_SAMPLES
@@ -2714,6 +2746,301 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                             ) / elapsed_h
                             if mean_rate >= THERMAL_SOLAR_MIN_RATE_F_PER_HR:
                                 self._commit_observation_if_sufficient(obs_type, "insufficient_rate")
+
+    def _run_passive_chart_log_fit(self, *, backfill: bool = False) -> None:
+        """Estimate k_passive from chart_log passive-only windows using endpoint estimator.
+
+        For each window where HVAC=off, fan=off, windows=closed:
+          k = ln((T_end - T_out_avg) / (T_start - T_out_avg)) / dt_hours
+
+        If backfill=True, processes up to 30 days of chart_log history (called once on
+        startup when _passive_k_backfilled is False). If backfill=False, processes only
+        the most recent complete passive window (called when a passive window ends).
+        """
+        import math as _math
+
+        chart_log = getattr(self, "_chart_log", None)
+        if chart_log is None:
+            return
+        entries = list(getattr(chart_log, "_entries", []))
+        if not entries:
+            return
+
+        _K_MIN = THERMAL_K_PASSIVE_MIN
+        _K_MAX = THERMAL_K_PASSIVE_MAX
+        days = 30 if backfill else 2
+        cutoff = dt_util.now() - timedelta(days=days)
+
+        windows: list[list[dict]] = []
+        current: list[dict] = []
+
+        def _flush_passive() -> None:
+            if len(current) < 2:
+                current.clear()
+                return
+            try:
+                ts0 = datetime.fromisoformat(current[0]["ts"])
+                ts1 = datetime.fromisoformat(current[-1]["ts"])
+                if ts0.tzinfo is None:
+                    ts0 = ts0.replace(tzinfo=UTC)
+                if ts1.tzinfo is None:
+                    ts1 = ts1.replace(tzinfo=UTC)
+                elapsed_min = (ts1 - ts0).total_seconds() / 60.0
+                if elapsed_min >= THERMAL_CHART_LOG_PASSIVE_MIN_MINUTES:
+                    windows.append(list(current))
+            except (ValueError, KeyError):
+                pass
+            current.clear()
+
+        for entry in entries:
+            ts_str = entry.get("ts", "")
+            if not ts_str:
+                continue
+            try:
+                ts = datetime.fromisoformat(ts_str)
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=UTC)
+            except ValueError:
+                continue
+            if ts < cutoff:
+                continue
+
+            indoor = entry.get("indoor")
+            outdoor = entry.get("outdoor")
+            hvac = entry.get("hvac", "")
+            fan = entry.get("fan")
+            windows_open = entry.get("windows_open")
+
+            if indoor is None or outdoor is None:
+                _flush_passive()
+                continue
+
+            hvac_idle = hvac in ("idle", "off", "", "fan") or (
+                "heat" not in (hvac or "") and "cool" not in (hvac or "")
+            )
+            fan_off = fan is False or fan is None
+            win_closed = not windows_open
+
+            if not hvac_idle or not fan_off or not win_closed:
+                _flush_passive()
+                continue
+
+            current.append({"ts": ts_str, "indoor": float(indoor), "outdoor": float(outdoor)})
+
+        _flush_passive()
+
+        if not windows:
+            return
+
+        # Process only the last window on live trigger; all windows on backfill
+        target_windows = windows if backfill else windows[-1:]
+        committed = 0
+        today_str = dt_util.now().strftime("%Y-%m-%d")
+
+        for window in target_windows:
+            t_start = window[0]["indoor"]
+            t_end = window[-1]["indoor"]
+            t_out_avg = sum(s["outdoor"] for s in window) / len(window)
+
+            try:
+                ts0 = datetime.fromisoformat(window[0]["ts"])
+                ts1 = datetime.fromisoformat(window[-1]["ts"])
+                if ts0.tzinfo is None:
+                    ts0 = ts0.replace(tzinfo=UTC)
+                if ts1.tzinfo is None:
+                    ts1 = ts1.replace(tzinfo=UTC)
+                dt_hours = (ts1 - ts0).total_seconds() / 3600.0
+            except (ValueError, KeyError):
+                continue
+
+            if abs(t_end - t_start) < THERMAL_CHART_LOG_PASSIVE_MIN_DT_F:
+                continue
+            if dt_hours < THERMAL_CHART_LOG_PASSIVE_MIN_MINUTES / 60.0:
+                continue
+
+            denom = t_start - t_out_avg
+            if abs(denom) < 0.01:
+                continue
+            ratio = (t_end - t_out_avg) / denom
+            if ratio <= 0 or ratio >= 1.0:
+                continue
+
+            k = _math.log(ratio) / dt_hours
+            if not (_K_MIN <= k <= _K_MAX):
+                continue
+
+            grade = "medium" if (dt_hours >= 6.0 and abs(t_end - t_start) >= 2.0) else "low"
+            obs = {
+                "hvac_mode": "passive",
+                "k_passive": k,
+                "confidence_grade": grade,
+                "date": today_str,
+                "source": "chart_log_endpoint",
+            }
+            self.learning._update_thermal_model_cache(obs)
+            committed += 1
+            _LOGGER.debug(
+                "chart_log_endpoint passive: k=%.4f conf=%s dt=%.1fh dT=%.1fF",
+                k,
+                grade,
+                dt_hours,
+                t_end - t_start,
+            )
+
+        if committed > 0:
+            _LOGGER.info(
+                "chart_log_endpoint passive: committed %d observations%s",
+                committed,
+                " (backfill)" if backfill else "",
+            )
+
+    def _run_ventilated_chart_log_fit(self, *, backfill: bool = False) -> None:
+        """Estimate k_vent_window from overnight ventilated chart_log windows.
+
+        Natural regime filter: only windows where T_out < T_in throughout are used
+        (overnight conditions). Morning ventilated windows where T_out rises toward T_in
+        are auto-rejected by the ratio check without explicit time classification.
+
+        Formula: k = ln((T_end - T_out_avg) / (T_start - T_out_avg)) / dt_hours
+
+        If backfill=True, processes up to 30 days of history (once on startup).
+        If backfill=False, processes only the most recent ventilated window.
+        """
+        import math as _math
+
+        chart_log = getattr(self, "_chart_log", None)
+        if chart_log is None:
+            return
+        entries = list(getattr(chart_log, "_entries", []))
+        if not entries:
+            return
+
+        _K_MIN = THERMAL_K_PASSIVE_MIN
+        _K_MAX = THERMAL_K_PASSIVE_MAX
+        days = 30 if backfill else 2
+        cutoff = dt_util.now() - timedelta(days=days)
+
+        windows: list[list[dict]] = []
+        current: list[dict] = []
+
+        def _flush_vent() -> None:
+            if len(current) < 2:
+                current.clear()
+                return
+            try:
+                ts0 = datetime.fromisoformat(current[0]["ts"])
+                ts1 = datetime.fromisoformat(current[-1]["ts"])
+                if ts0.tzinfo is None:
+                    ts0 = ts0.replace(tzinfo=UTC)
+                if ts1.tzinfo is None:
+                    ts1 = ts1.replace(tzinfo=UTC)
+                elapsed_min = (ts1 - ts0).total_seconds() / 60.0
+                if elapsed_min >= THERMAL_CHART_LOG_VENT_MIN_MINUTES and all(
+                    s["outdoor"] < s["indoor"] for s in current
+                ):
+                    windows.append(list(current))
+            except (ValueError, KeyError):
+                pass
+            current.clear()
+
+        for entry in entries:
+            ts_str = entry.get("ts", "")
+            if not ts_str:
+                continue
+            try:
+                ts = datetime.fromisoformat(ts_str)
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=UTC)
+            except ValueError:
+                continue
+            if ts < cutoff:
+                continue
+
+            indoor = entry.get("indoor")
+            outdoor = entry.get("outdoor")
+            hvac = entry.get("hvac", "")
+            windows_open = entry.get("windows_open")
+
+            if indoor is None or outdoor is None:
+                _flush_vent()
+                continue
+
+            hvac_idle = hvac in ("idle", "off", "", "fan") or (
+                "heat" not in (hvac or "") and "cool" not in (hvac or "")
+            )
+            win_open = bool(windows_open)
+
+            if not hvac_idle or not win_open:
+                _flush_vent()
+                continue
+
+            current.append({"ts": ts_str, "indoor": float(indoor), "outdoor": float(outdoor)})
+
+        _flush_vent()
+
+        if not windows:
+            return
+
+        target_windows = windows if backfill else windows[-1:]
+        committed = 0
+        today_str = dt_util.now().strftime("%Y-%m-%d")
+
+        for window in target_windows:
+            t_start = window[0]["indoor"]
+            t_end = window[-1]["indoor"]
+            t_out_avg = sum(s["outdoor"] for s in window) / len(window)
+
+            try:
+                ts0 = datetime.fromisoformat(window[0]["ts"])
+                ts1 = datetime.fromisoformat(window[-1]["ts"])
+                if ts0.tzinfo is None:
+                    ts0 = ts0.replace(tzinfo=UTC)
+                if ts1.tzinfo is None:
+                    ts1 = ts1.replace(tzinfo=UTC)
+                dt_hours = (ts1 - ts0).total_seconds() / 3600.0
+            except (ValueError, KeyError):
+                continue
+
+            if abs(t_end - t_start) < THERMAL_CHART_LOG_PASSIVE_MIN_DT_F:
+                continue
+            if dt_hours < THERMAL_CHART_LOG_VENT_MIN_MINUTES / 60.0:
+                continue
+
+            denom = t_start - t_out_avg
+            if abs(denom) < 0.01:
+                continue
+            ratio = (t_end - t_out_avg) / denom
+            if ratio <= 0 or ratio >= 1.0:
+                continue
+
+            k = _math.log(ratio) / dt_hours
+            if not (_K_MIN <= k <= _K_MAX):
+                continue
+
+            grade = "medium" if (dt_hours >= 6.0 and abs(t_end - t_start) >= 2.0) else "low"
+            obs = {
+                "hvac_mode": "ventilated",
+                "k_passive": k,
+                "confidence_grade": grade,
+                "date": today_str,
+                "source": "chart_log_endpoint",
+            }
+            self.learning._update_thermal_model_cache(obs)
+            committed += 1
+            _LOGGER.debug(
+                "chart_log_endpoint vent: k=%.4f conf=%s dt=%.1fh dT=%.1fF",
+                k,
+                grade,
+                dt_hours,
+                t_end - t_start,
+            )
+
+        if committed > 0:
+            _LOGGER.info(
+                "chart_log_endpoint vent: committed %d observations%s",
+                committed,
+                " (backfill)" if backfill else "",
+            )
 
     def _start_decay_observation(self, obs_type: str) -> None:
         """Create a new monitoring observation for a passive/fan/vent/solar type."""

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/yourgithubuser/ha-climate-advisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.3.42"
+  "version": "0.3.43"
 }

--- a/tests/test_thermal_observations.py
+++ b/tests/test_thermal_observations.py
@@ -50,7 +50,6 @@ from custom_components.climate_advisor.const import (  # noqa: E402
     THERMAL_HVAC_POST_HEAT_SAMPLE_INTERVAL_S,
     THERMAL_PASSIVE_CONF_HIGH,
     THERMAL_PASSIVE_MIN_SAMPLES,
-    THERMAL_PASSIVE_MIN_SIGNAL_F,
     THERMAL_PASSIVE_SAMPLE_INTERVAL_S,
     THERMAL_ROLLING_MAX_WINDOW_MINUTES,
     THERMAL_ROLLING_MIN_DELTA_T_F,
@@ -279,8 +278,14 @@ class TestPassiveDecayObservation:
         # 5 samples < THERMAL_PASSIVE_MIN_SAMPLES (30) → abandoned
         assert OBS_TYPE_PASSIVE_DECAY not in coord._pending_observations
 
-    def test_commits_when_sufficient_samples_and_signal(self):
-        """passive_decay with THERMAL_PASSIVE_MIN_SAMPLES samples and delta > MIN_SIGNAL_F commits."""
+    def test_stays_alive_with_sufficient_samples_while_hvac_idle(self):
+        """passive_decay stays alive when HVAC is still idle, even with sufficient samples and signal.
+
+        The old OLS path committed on sample count alone. The chart_log endpoint path is
+        event-driven: the observation runs until HVAC starts, a sensor opens, a fan activates,
+        or the hard cap is reached — then _run_passive_chart_log_fit() fires. It never commits
+        mid-run just because MIN_SAMPLES is accumulated.
+        """
         coord = _make_obs_coord(hvac_action="idle", indoor_temp=74.0, outdoor_temp=55.0)
         # Build MIN_SAMPLES samples (first=75.0, last=74.0 → delta=1.0 > 0.5)
         samples = [
@@ -305,27 +310,20 @@ class TestPassiveDecayObservation:
             "schema_version": 1,
         }
         dt_mock = _make_dt_mock()
-        committed_obs_types = []
 
-        def _fake_async_create_task(coro):
-            # Detect _commit_observation coroutines by name, then close safely
-            coro_name = getattr(coro, "__name__", getattr(coro, "__qualname__", ""))
-            if "_commit_observation" in coro_name:
-                committed_obs_types.append(OBS_TYPE_PASSIVE_DECAY)
+        def _consume_coro(coro):
             coro.close()
 
-        coord.hass.async_create_task = _fake_async_create_task
+        coord.hass.async_create_task = _consume_coro
 
         with patch("custom_components.climate_advisor.coordinator.dt_util", dt_mock):
             coord._sample_all_observations()
 
-        # The observation should either be committed (popped) or queued for commit
-        # Either the obs was popped already or a task was queued
-        was_popped = OBS_TYPE_PASSIVE_DECAY not in coord._pending_observations
-        was_queued = len(committed_obs_types) > 0
-        assert was_popped or was_queued, (
-            "Expected passive_decay to be committed or queued for commit when "
-            f"samples={THERMAL_PASSIVE_MIN_SAMPLES}, delta=1.0 > {THERMAL_PASSIVE_MIN_SIGNAL_F}"
+        # With HVAC still idle and no external events, the observation must remain alive.
+        # chart_log endpoint only fires on external events (HVAC start, sensor open, fan, hard cap).
+        assert OBS_TYPE_PASSIVE_DECAY in coord._pending_observations, (
+            "passive_decay should stay alive when HVAC is idle — chart_log endpoint is "
+            "event-driven, not sample-count-driven"
         )
 
 
@@ -1495,33 +1493,30 @@ class TestRollingWindowCommit:
             "schema_version": 1,
         }
 
-    def test_passive_decay_commits_after_30min(self):
-        """passive_decay started 31 min ago triggers rolling-window commit."""
+    def test_passive_decay_stays_alive_after_30min_while_hvac_idle(self):
+        """passive_decay started 31 min ago stays alive when HVAC is still idle.
+
+        The old Path A rolling-window OLS committed on elapsed time. The chart_log endpoint
+        path is event-driven: the observation runs until HVAC starts, a sensor opens, a fan
+        activates, or the hard cap is reached. Elapsed time alone does not trigger a commit.
+        """
         coord = _make_obs_coord(hvac_action="idle", indoor_temp=74.0, outdoor_temp=55.0)
         obs = self._make_31min_obs(OBS_TYPE_PASSIVE_DECAY, n_samples=6)
         coord._pending_observations[OBS_TYPE_PASSIVE_DECAY] = obs
 
-        committed_obs_types: list[str] = []
-
-        def _fake_async_create_task(coro):
-            coro_name = getattr(coro, "__name__", getattr(coro, "__qualname__", ""))
-            if "_commit_observation" in coro_name:
-                committed_obs_types.append(OBS_TYPE_PASSIVE_DECAY)
+        def _consume_coro(coro):
             coro.close()
 
-        coord.hass.async_create_task = _fake_async_create_task
+        coord.hass.async_create_task = _consume_coro
 
         dt_mock = _make_dt_mock(_FAKE_NOW)
         with patch("custom_components.climate_advisor.coordinator.dt_util", dt_mock):
             coord._sample_all_observations()
 
-        obs_present = coord._pending_observations.get(OBS_TYPE_PASSIVE_DECAY)
-        was_committing = obs_present is not None and obs_present.get("status") == "committing"
-        was_queued = len(committed_obs_types) > 0
-
-        assert was_committing or was_queued, (
-            "passive_decay started 31 min ago should trigger rolling-window commit "
-            f"(status={obs_present.get('status') if obs_present else 'popped'}, queued={was_queued})"
+        obs_after = coord._pending_observations.get(OBS_TYPE_PASSIVE_DECAY)
+        assert obs_after is not None and obs_after.get("status") == "monitoring", (
+            "passive_decay should remain alive (monitoring) when HVAC is still idle — "
+            "chart_log endpoint only fires on external events, not elapsed time"
         )
 
     def test_rolling_window_delta_guard_rejects_flat(self):
@@ -1563,25 +1558,30 @@ class TestRollingWindowCommit:
                 f"(total ΔT=0.0 < {THERMAL_ROLLING_MIN_DELTA_T_F})"
             )
 
-    def test_fresh_obs_starts_after_rolling_commit(self):
-        """After rolling-window commit pops the obs, next poll can start a fresh one."""
+    def test_passive_decay_remains_monitoring_without_external_event(self):
+        """passive_decay stays in monitoring status when no external event interrupts.
+
+        There is no rolling-window OLS path any more. The chart_log endpoint fires on external
+        events only (HVAC starts, sensor opens, fan activates, hard cap). A 31-minute-old
+        observation with HVAC still idle must remain in monitoring status so the window keeps
+        accumulating data until a real event ends it.
+        """
         coord = _make_obs_coord(hvac_action="idle", indoor_temp=74.0, outdoor_temp=55.0)
         obs = self._make_31min_obs(OBS_TYPE_PASSIVE_DECAY, n_samples=6)
         coord._pending_observations[OBS_TYPE_PASSIVE_DECAY] = obs
 
-        def _fake_async_create_task(coro):
+        def _consume_coro(coro):
             coro.close()
 
-        coord.hass.async_create_task = _fake_async_create_task
+        coord.hass.async_create_task = _consume_coro
 
         dt_mock = _make_dt_mock(_FAKE_NOW)
         with patch("custom_components.climate_advisor.coordinator.dt_util", dt_mock):
             coord._sample_all_observations()
 
-        # After commit, the obs is removed (popped) or marked "committing" — no longer "monitoring"
         obs_after = coord._pending_observations.get(OBS_TYPE_PASSIVE_DECAY)
-        assert obs_after is None or obs_after.get("status") != "monitoring", (
-            "After rolling-window commit, passive_decay should no longer be in monitoring status"
+        assert obs_after is not None and obs_after.get("status") == "monitoring", (
+            "passive_decay should remain in 'monitoring' status when HVAC is still idle"
         )
 
     def test_rolling_window_constant_is_30min(self):

--- a/tools/learning_db.py
+++ b/tools/learning_db.py
@@ -10,6 +10,7 @@ Usage:
     python3 tools/learning_db.py --rejections   # rejection log only
     python3 tools/learning_db.py --committed    # committed obs only
     python3 tools/learning_db.py --model        # model summary only
+    python3 tools/learning_db.py --thermal      # chart_log endpoint observations only
     python3 tools/learning_db.py --last N       # last N rejections per type (default 5)
 """
 
@@ -327,7 +328,72 @@ def _print_committed(db: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Section D: Live pending observations (optional, requires HA_URL + HA_TOKEN)
+# Section D: Chart-log endpoint observations
+# ---------------------------------------------------------------------------
+
+
+def _print_chart_log_endpoint_obs(db: dict) -> None:
+    """Print committed observations that came from the chart_log endpoint estimator."""
+    observations = db.get("thermal_observations")
+    if not isinstance(observations, list):
+        print("Chart-Log Endpoint Observations")
+        print("--------------------------------")
+        print("(no thermal_observations found in learning DB)")
+        print()
+        return
+
+    endpoint_obs = [o for o in observations if isinstance(o, dict) and o.get("source") == "chart_log_endpoint"]
+    total = len(endpoint_obs)
+    # Show most-recent first
+    recent = list(reversed(endpoint_obs))[:20]
+
+    print(f"Chart-Log Endpoint Observations (last {min(len(recent), total)} of {total})")
+    print("-" * 68)
+
+    header = (
+        _pad("date", 12)
+        + _pad("hvac_mode", 12)
+        + _pad("k", 10)
+        + _pad("dt_h", 8)
+        + _pad("delta_F", 9)
+        + _pad("grade", 8)
+        + "ratio"
+    )
+    print(header)
+    print("-" * 68)
+
+    for obs in recent:
+        date = obs.get("date", "?")
+        hvac_mode = obs.get("hvac_mode", "?")
+        k = obs.get("k_passive")
+        k_str = f"{k:.4f}" if isinstance(k, float) else "-"
+        dt_h = obs.get("elapsed_hours")
+        dt_str = f"{dt_h:.1f}" if isinstance(dt_h, float) else "-"
+        delta = obs.get("delta_t_f")
+        delta_str = f"{delta:.1f}" if isinstance(delta, float) else "-"
+        grade = obs.get("confidence_grade", "-")
+        ratio = obs.get("ratio")
+        ratio_str = f"{ratio:.3f}" if isinstance(ratio, float) else "-"
+
+        row = (
+            _pad(str(date), 12)
+            + _pad(str(hvac_mode), 12)
+            + _pad(k_str, 10)
+            + _pad(dt_str, 8)
+            + _pad(delta_str, 9)
+            + _pad(str(grade), 8)
+            + ratio_str
+        )
+        print(row)
+
+    if total == 0:
+        print("  (none yet — backfill fires on next HA restart if not already done)")
+
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Section E: Live pending observations (optional, requires HA_URL + HA_TOKEN)
 # ---------------------------------------------------------------------------
 
 COL_PL_TYPE = 20
@@ -410,14 +476,16 @@ def main() -> None:
     parser.add_argument("--rejections", action="store_true", help="Show rejection log only")
     parser.add_argument("--committed", action="store_true", help="Show committed observations only")
     parser.add_argument("--model", action="store_true", help="Show model summary only")
+    parser.add_argument("--thermal", action="store_true", help="Show chart_log endpoint observations only")
     parser.add_argument("--last", type=int, default=5, metavar="N", help="Last N rejections per type (default 5)")
     args = parser.parse_args()
 
     # Determine which sections to show
-    section_flag = args.rejections or args.committed or args.model
-    show_model = args.model or not section_flag
+    section_flag = args.rejections or args.committed or args.model or args.thermal
+    show_model = args.model or args.thermal or not section_flag
     show_rejections = args.rejections or not section_flag
     show_committed = args.committed or not section_flag
+    show_thermal = args.thermal or not section_flag
 
     config = load_config()
 
@@ -433,6 +501,9 @@ def main() -> None:
 
     if show_committed:
         _print_committed(db)
+
+    if show_thermal:
+        _print_chart_log_endpoint_obs(db)
 
     # Live pending observations via REST API (optional)
     _load_dotenv()

--- a/tools/thermal_replay.py
+++ b/tools/thermal_replay.py
@@ -598,6 +598,633 @@ def fetch_chart_log_ssh(config: dict) -> list[dict]:
     return data.get("entries", [])
 
 
+def build_passive_only_windows(
+    entries: list[dict],
+    days: int = 30,
+    min_window_minutes: int = 120,
+    max_window_minutes: int = 720,
+) -> list[list[dict]]:
+    """Extract passive-only windows from chart_log entries.
+
+    A passive-only window is a contiguous run where:
+    - HVAC is idle/off (same check as build_windows_from_chart_log)
+    - fan is False (not CA-driven fan or manual fan)
+    - windows_open is False
+    - Duration >= min_window_minutes (default 120 min)
+
+    Each sample dict matches the format expected by compute_k_passive.
+    """
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+
+    windows: list[list[dict]] = []
+    current: list[dict] = []
+
+    def _flush() -> None:
+        if current:
+            elapsed_min = (len(current) - 1) * _avg_interval(current)
+            if elapsed_min >= min_window_minutes:
+                windows.append(list(current))
+            current.clear()
+
+    def _avg_interval(samples: list[dict]) -> float:
+        if len(samples) < 2:
+            return 30.0
+        ts0 = datetime.fromisoformat(samples[0]["timestamp"])
+        ts1 = datetime.fromisoformat(samples[-1]["timestamp"])
+        return (ts1 - ts0).total_seconds() / 60.0 / max(len(samples) - 1, 1)
+
+    for entry in entries:
+        ts_str = entry.get("ts", "")
+        if not ts_str:
+            continue
+        ts = datetime.fromisoformat(ts_str)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        if ts < cutoff:
+            continue
+
+        indoor = entry.get("indoor")
+        outdoor = entry.get("outdoor")
+        hvac = entry.get("hvac", "")
+        fan = entry.get("fan")
+        windows_open = entry.get("windows_open")
+
+        if indoor is None or outdoor is None:
+            _flush()
+            continue
+
+        hvac_idle = hvac in ("idle", "off", "", "fan") or ("heat" not in (hvac or "") and "cool" not in (hvac or ""))
+        fan_off = fan is False or fan is None
+        win_closed = not windows_open
+
+        if not hvac_idle or not fan_off or not win_closed:
+            _flush()
+            continue
+
+        elapsed = 0.0
+        if current:
+            ts0 = datetime.fromisoformat(current[0]["timestamp"])
+            elapsed = (ts - ts0).total_seconds() / 60.0
+
+        current.append(
+            {
+                "indoor_temp_f": float(indoor),
+                "outdoor_temp_f": float(outdoor),
+                "elapsed_minutes": elapsed,
+                "solar_factor": _solar_factor(ts.hour + ts.minute / 60.0),
+                "timestamp": ts_str,
+            }
+        )
+
+        if elapsed >= max_window_minutes:
+            _flush()
+
+    _flush()
+    return windows
+
+
+def _endpoint_k_passive(
+    window: list[dict],
+) -> tuple[float | None, str | None, str]:
+    """Endpoint estimator for k_passive using Newton's law of cooling.
+
+    k = ln((T_end - T_out_avg) / (T_start - T_out_avg)) / dt_hours
+
+    Quality gates:
+    - |T_end - T_start| >= 1.0 degF
+    - dt_hours >= 2.0
+    - k in [-0.5, -0.001]
+
+    Confidence:
+    - "medium": dt_hours >= 6 AND |deltaT| >= 2
+    - "low": otherwise
+
+    Returns (k, confidence, reject_reason).
+    reject_reason is "" on success.
+    """
+    if len(window) < 2:
+        return None, None, "too_few_samples"
+
+    t_start = window[0]["indoor_temp_f"]
+    t_end = window[-1]["indoor_temp_f"]
+    t_out_avg = sum(s["outdoor_temp_f"] for s in window) / len(window)
+
+    ts0 = datetime.fromisoformat(window[0]["timestamp"])
+    ts1 = datetime.fromisoformat(window[-1]["timestamp"])
+    dt_hours = (ts1 - ts0).total_seconds() / 3600.0
+
+    delta_t = abs(t_end - t_start)
+    if delta_t < 1.0:
+        return None, None, "delta_too_small"
+    if dt_hours < 2.0:
+        return None, None, "window_too_short"
+
+    denom = t_start - t_out_avg
+    if abs(denom) < 0.01:
+        return None, None, "small_delta_to_outdoor"
+
+    numerator = t_end - t_out_avg
+    # Avoid log of non-positive number: ratio must be positive and < 1 (cooling toward outdoor)
+    ratio = numerator / denom
+    if ratio <= 0 or ratio >= 1.0:
+        return None, None, "ratio_out_of_range"
+
+    k = math.log(ratio) / dt_hours
+    if not (_K_PASSIVE_MIN <= k <= _K_PASSIVE_MAX):
+        return None, None, "bounds"
+
+    confidence = "medium" if (dt_hours >= 6.0 and delta_t >= 2.0) else "low"
+    return k, confidence, ""
+
+
+def run_passive_only_analysis(
+    chart_entries: list[dict],
+    learning_db: dict,
+    days: int = 30,
+) -> None:
+    """Run passive-only analysis: extract windows, compare OLS vs endpoint estimator,
+    simulate EWMA convergence, and compare ODE predictions.
+
+    Prints results to stdout. Does not write to the learning DB.
+    """
+    print(f"\nExtracting passive-only windows (HVAC off, fan off, windows closed, min 120 min, last {days} days)...")
+    windows = build_passive_only_windows(chart_entries, days=days, min_window_minutes=120)
+    print(f"  Found {len(windows)} passive-only windows\n")
+
+    if not windows:
+        print("No passive-only windows found. Try increasing --days.")
+        return
+
+    # Current k_passive from learning DB
+    cache = learning_db.get("thermal_model_cache", {})
+    current_k_passive: float | None = cache.get("k_passive")
+    print(f"Current k_passive from learning DB: {current_k_passive}")
+    print()
+
+    _ALPHA_LOW = 0.05
+    _ALPHA_MEDIUM = 0.15
+
+    ewma_k = current_k_passive
+    endpoint_results: list[tuple[float, str]] = []  # (k, confidence)
+
+    for _i, window in enumerate(windows):
+        ts_start = window[0]["timestamp"]
+        ts_end = window[-1]["timestamp"]
+        ts0 = datetime.fromisoformat(ts_start)
+        ts1 = datetime.fromisoformat(ts_end)
+        dt_hours = (ts1 - ts0).total_seconds() / 3600.0
+
+        t_start = window[0]["indoor_temp_f"]
+        t_end = window[-1]["indoor_temp_f"]
+        t_out_avg = sum(s["outdoor_temp_f"] for s in window) / len(window)
+        delta_t = t_end - t_start
+        n = len(window)
+
+        # Format timestamps for display
+        def _fmt_dt(ts_str: str) -> str:
+            try:
+                dt = datetime.fromisoformat(ts_str)
+                return dt.strftime("%Y-%m-%d %H:%M")
+            except Exception:
+                return ts_str[:16]
+
+        label_start = _fmt_dt(ts_start)
+        label_end = _fmt_dt(ts_end)
+
+        print(f"Passive window {label_start} -> {label_end} ({dt_hours:.1f}h):")
+        print(
+            f"  T_range: {t_start:.0f}F -> {t_end:.0f}F (deltaT={delta_t:+.1f}F)  "
+            f"T_out_avg: {t_out_avg:.0f}F  n={n} entries"
+        )
+
+        # OLS (consecutive-pair)
+        k_ols, r2_ols, reject_ols = compute_k_passive(window)
+        if k_ols is not None:
+            verdict_ols = "PASS" if r2_ols >= _MIN_R2 else f"WOULD REJECT (R2<{_MIN_R2})"
+            print(f"  OLS (consecutive pairs): k={k_ols:+.4f} R2={r2_ols:.3f}  -> {verdict_ols}")
+        else:
+            print(f"  OLS (consecutive pairs): REJECTED ({reject_ols})")
+
+        # Endpoint estimator
+        k_ep, conf_ep, reject_ep = _endpoint_k_passive(window)
+        if k_ep is not None:
+            print(f"  Endpoint estimator:       k={k_ep:+.4f}          -> confidence={conf_ep}")
+            endpoint_results.append((k_ep, conf_ep))  # type: ignore[arg-type]
+        else:
+            print(f"  Endpoint estimator:       REJECTED ({reject_ep})")
+
+        print()
+
+    # EWMA convergence simulation
+    if endpoint_results:
+        print("=" * 70)
+        print("EWMA convergence simulation (endpoint estimator values):")
+        print(f"  Starting k_passive: {current_k_passive}")
+        print()
+
+        ewma_k = current_k_passive
+        for j, (k_ep, conf_ep) in enumerate(endpoint_results):
+            alpha = _ALPHA_MEDIUM if conf_ep == "medium" else _ALPHA_LOW
+            ewma_k_new = _ewma(ewma_k, k_ep, alpha)
+            ewma_k_str = f"{ewma_k_new:+.5f}" if ewma_k_new is not None else "None"
+            prev_str = f"{ewma_k:+.5f}" if ewma_k is not None else "None"
+            print(
+                f"  Window {j + 1}: k_ep={k_ep:+.4f} conf={conf_ep} alpha={alpha:.2f}  "
+                f"k_passive: {prev_str} -> {ewma_k_str}"
+            )
+            ewma_k = ewma_k_new
+
+        converged_k = ewma_k
+        if converged_k is not None:
+            print(f"\n  Final converged k_passive: {converged_k:+.5f}")
+        else:
+            print("\n  No convergence (no valid endpoint estimates)")
+        print()
+
+        # ODE prediction comparison: "last night" using last overnight window
+        # Find the last window with dt >= 4h to use as overnight
+        overnight_window = None
+        for window in reversed(windows):
+            ts0 = datetime.fromisoformat(window[0]["timestamp"])
+            ts1 = datetime.fromisoformat(window[-1]["timestamp"])
+            dt_h = (ts1 - ts0).total_seconds() / 3600.0
+            if dt_h >= 4.0:
+                overnight_window = window
+                break
+
+        if overnight_window is not None:
+            print("=" * 70)
+            print("ODE prediction comparison (last overnight passive window):")
+            w = overnight_window
+            t_in_0 = w[0]["indoor_temp_f"]
+            t_out_avg_w = sum(s["outdoor_temp_f"] for s in w) / len(w)
+            ts0_dt = datetime.fromisoformat(w[0]["timestamp"])
+            ts1_dt = datetime.fromisoformat(w[-1]["timestamp"])
+            dt_h_w = (ts1_dt - ts0_dt).total_seconds() / 3600.0
+            t_actual = w[-1]["indoor_temp_f"]
+
+            def _ode_predict(k_p: float | None, t_in: float, t_out: float, dt_h: float) -> float | None:
+                if k_p is None:
+                    return None
+                # Simple passive decay: dT/dt = k_passive * (T_in - T_out)
+                # Analytical: T(t) = T_out + (T_in_0 - T_out) * exp(k_passive * dt)
+                return t_out + (t_in - t_out) * math.exp(k_p * dt_h)
+
+            pred_current = _ode_predict(current_k_passive, t_in_0, t_out_avg_w, dt_h_w)
+            pred_converged = _ode_predict(converged_k, t_in_0, t_out_avg_w, dt_h_w)
+
+            def _fmt_ts(dt: datetime) -> str:
+                return dt.strftime("%Y-%m-%d %H:%M")
+
+            print(f"  Window: {_fmt_ts(ts0_dt)} -> {_fmt_ts(ts1_dt)} ({dt_h_w:.1f}h)")
+            print(f"  T_start={t_in_0:.1f}F  T_out_avg={t_out_avg_w:.1f}F  T_actual_end={t_actual:.1f}F")
+            print()
+
+            if pred_current is not None:
+                err_current = pred_current - t_actual
+                print(f"  Current k_passive ({current_k_passive:+.5f}):")
+                print(f"    Predicted end: {pred_current:.1f}F  Actual: {t_actual:.1f}F  Error: {err_current:+.1f}F")
+            else:
+                print("  Current k_passive: None (no prediction)")
+
+            if pred_converged is not None and converged_k is not None:
+                err_converged = pred_converged - t_actual
+                print(f"  Converged k_passive ({converged_k:+.5f}):")
+                print(
+                    f"    Predicted end: {pred_converged:.1f}F  Actual: {t_actual:.1f}F  Error: {err_converged:+.1f}F"
+                )
+            else:
+                print("  Converged k_passive: None (no prediction)")
+            print()
+        else:
+            print("  (No overnight window >= 4h found for ODE comparison)")
+    else:
+        print("No valid endpoint estimates — EWMA simulation skipped.")
+
+
+def build_ventilated_overnight_windows(
+    entries: list[dict],
+    days: int = 30,
+    min_window_minutes: int = 120,
+    max_window_minutes: int = 720,
+) -> list[list[dict]]:
+    """Extract ventilated windows that pass the natural overnight regime filter.
+
+    A ventilated overnight window satisfies:
+    - HVAC is idle/off
+    - windows_open is True
+    - ALL samples in the window have T_out < T_in (T_out stays below T_in throughout)
+    - Duration >= min_window_minutes
+
+    The natural regime filter (T_out < T_in throughout) auto-selects overnight conditions
+    and rejects morning windows where T_out rises toward or past T_in. No time-of-day
+    classification needed.
+    """
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+
+    windows: list[list[dict]] = []
+    current: list[dict] = []
+
+    def _flush() -> None:
+        if len(current) < 2:
+            current.clear()
+            return
+        ts0 = datetime.fromisoformat(current[0]["timestamp"])
+        ts1 = datetime.fromisoformat(current[-1]["timestamp"])
+        elapsed_min = (ts1 - ts0).total_seconds() / 60.0
+        if elapsed_min < min_window_minutes:
+            current.clear()
+            return
+        # Natural regime filter: reject windows where T_out ever meets or exceeds T_in
+        if all(s["outdoor_temp_f"] < s["indoor_temp_f"] for s in current):
+            windows.append(list(current))
+        current.clear()
+
+    for entry in entries:
+        ts_str = entry.get("ts", "")
+        if not ts_str:
+            continue
+        ts = datetime.fromisoformat(ts_str)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        if ts < cutoff:
+            continue
+
+        indoor = entry.get("indoor")
+        outdoor = entry.get("outdoor")
+        hvac = entry.get("hvac", "")
+        windows_open = entry.get("windows_open")
+
+        if indoor is None or outdoor is None:
+            _flush()
+            continue
+
+        hvac_idle = hvac in ("idle", "off", "", "fan") or ("heat" not in (hvac or "") and "cool" not in (hvac or ""))
+        win_open = bool(windows_open)
+
+        if not hvac_idle or not win_open:
+            _flush()
+            continue
+
+        elapsed = 0.0
+        if current:
+            ts0 = datetime.fromisoformat(current[0]["timestamp"])
+            elapsed = (ts - ts0).total_seconds() / 60.0
+
+        current.append(
+            {
+                "indoor_temp_f": float(indoor),
+                "outdoor_temp_f": float(outdoor),
+                "elapsed_minutes": elapsed,
+                "solar_factor": _solar_factor(ts.hour + ts.minute / 60.0),
+                "timestamp": ts_str,
+            }
+        )
+
+        if elapsed >= max_window_minutes:
+            _flush()
+
+    _flush()
+    return windows
+
+
+def run_vent_overnight_analysis(
+    chart_entries: list[dict],
+    learning_db: dict,
+    days: int = 30,
+) -> None:
+    """Analyse overnight ventilated windows using endpoint estimator.
+
+    Applies the natural regime filter (T_out < T_in throughout). Morning ventilated
+    windows where T_out rises toward T_in are auto-rejected by this filter, confirming
+    the mechanism. Prints results to stdout. Does not write to the learning DB.
+    """
+    print(
+        f"\nExtracting overnight ventilated windows (HVAC off, windows open, T_out < T_in throughout, "
+        f"min 120 min, last {days} days)..."
+    )
+    windows = build_ventilated_overnight_windows(chart_entries, days=days, min_window_minutes=120)
+
+    raw_vent_count = _count_raw_ventilated_windows(chart_entries, days=days, min_window_minutes=120)
+    rejected_by_filter = raw_vent_count - len(windows)
+
+    print(f"  Raw ventilated windows found: {raw_vent_count}")
+    print(f"  Overnight (T_out < T_in throughout): {len(windows)}")
+    print(f"  Rejected by natural filter (morning/crossover): {rejected_by_filter}\n")
+
+    if not windows:
+        print("No overnight ventilated windows passed the natural filter. Try increasing --days.")
+        return
+
+    cache = learning_db.get("thermal_model_cache", {})
+    current_k_vent: float | None = cache.get("k_vent_window")
+    print(f"Current k_vent_window from learning DB: {current_k_vent}")
+    print()
+
+    _ALPHA_LOW = 0.05
+    _ALPHA_MEDIUM = 0.15
+
+    ewma_k = current_k_vent
+    endpoint_results: list[tuple[float, str]] = []
+
+    for _i, window in enumerate(windows):
+        ts_start = window[0]["timestamp"]
+        ts_end = window[-1]["timestamp"]
+        ts0 = datetime.fromisoformat(ts_start)
+        ts1 = datetime.fromisoformat(ts_end)
+        dt_hours = (ts1 - ts0).total_seconds() / 3600.0
+
+        t_start = window[0]["indoor_temp_f"]
+        t_end = window[-1]["indoor_temp_f"]
+        t_out_avg = sum(s["outdoor_temp_f"] for s in window) / len(window)
+        delta_t = t_end - t_start
+        n = len(window)
+
+        def _fmt_dt(ts_str: str) -> str:
+            try:
+                dt = datetime.fromisoformat(ts_str)
+                return dt.strftime("%Y-%m-%d %H:%M")
+            except Exception:
+                return ts_str[:16]
+
+        label_start = _fmt_dt(ts_start)
+        label_end = _fmt_dt(ts_end)
+
+        print(f"Ventilated overnight window {label_start} -> {label_end} ({dt_hours:.1f}h):")
+        print(
+            f"  T_range: {t_start:.0f}F -> {t_end:.0f}F (deltaT={delta_t:+.1f}F)  "
+            f"T_out_avg: {t_out_avg:.0f}F  n={n} entries"
+        )
+
+        # OLS (consecutive-pair) — expected to fail for slow overnight drift
+        k_ols, r2_ols, reject_ols = compute_k_passive(window)
+        if k_ols is not None:
+            verdict_ols = "PASS" if r2_ols >= _MIN_R2 else f"WOULD REJECT (R2<{_MIN_R2})"
+            print(f"  OLS (consecutive pairs): k={k_ols:+.4f} R2={r2_ols:.3f}  -> {verdict_ols}")
+        else:
+            print(f"  OLS (consecutive pairs): REJECTED ({reject_ols})")
+
+        # Endpoint estimator
+        k_ep, conf_ep, reject_ep = _endpoint_k_passive(window)
+        if k_ep is not None:
+            print(f"  Endpoint estimator:       k={k_ep:+.4f}          -> confidence={conf_ep}")
+            endpoint_results.append((k_ep, conf_ep))  # type: ignore[arg-type]
+        else:
+            print(f"  Endpoint estimator:       REJECTED ({reject_ep})")
+
+        print()
+
+    # EWMA convergence simulation
+    if endpoint_results:
+        print("=" * 70)
+        print("EWMA convergence simulation (overnight ventilated endpoint values):")
+        print(f"  Starting k_vent_window: {current_k_vent}")
+        print()
+
+        ewma_k = current_k_vent
+        for j, (k_ep, conf_ep) in enumerate(endpoint_results):
+            alpha = _ALPHA_MEDIUM if conf_ep == "medium" else _ALPHA_LOW
+            ewma_k_new = _ewma(ewma_k, k_ep, alpha)
+            ewma_k_str = f"{ewma_k_new:+.5f}" if ewma_k_new is not None else "None"
+            prev_str = f"{ewma_k:+.5f}" if ewma_k is not None else "None"
+            print(
+                f"  Window {j + 1}: k_ep={k_ep:+.4f} conf={conf_ep} alpha={alpha:.2f}  "
+                f"k_vent_window: {prev_str} -> {ewma_k_str}"
+            )
+            ewma_k = ewma_k_new
+
+        converged_k = ewma_k
+        if converged_k is not None:
+            print(f"\n  Final converged k_vent_window: {converged_k:+.5f}")
+            if current_k_vent is not None:
+                pct_change = (converged_k - current_k_vent) / abs(current_k_vent) * 100.0
+                print(f"  Change from current: {pct_change:+.1f}%  ({current_k_vent:+.5f} -> {converged_k:+.5f})")
+        else:
+            print("\n  No convergence (no valid endpoint estimates)")
+        print()
+
+        # ODE prediction comparison using last overnight ventilated window
+        overnight_window = None
+        for window in reversed(windows):
+            ts0 = datetime.fromisoformat(window[0]["timestamp"])
+            ts1 = datetime.fromisoformat(window[-1]["timestamp"])
+            dt_h = (ts1 - ts0).total_seconds() / 3600.0
+            if dt_h >= 4.0:
+                overnight_window = window
+                break
+
+        if overnight_window is not None:
+            print("=" * 70)
+            print("ODE prediction comparison (last overnight ventilated window):")
+            w = overnight_window
+            t_in_0 = w[0]["indoor_temp_f"]
+            t_out_avg_w = sum(s["outdoor_temp_f"] for s in w) / len(w)
+            ts0_dt = datetime.fromisoformat(w[0]["timestamp"])
+            ts1_dt = datetime.fromisoformat(w[-1]["timestamp"])
+            dt_h_w = (ts1_dt - ts0_dt).total_seconds() / 3600.0
+            t_actual = w[-1]["indoor_temp_f"]
+
+            def _ode_predict(k_p: float | None, t_in: float, t_out: float, dt_h: float) -> float | None:
+                if k_p is None:
+                    return None
+                return t_out + (t_in - t_out) * math.exp(k_p * dt_h)
+
+            pred_current = _ode_predict(current_k_vent, t_in_0, t_out_avg_w, dt_h_w)
+            pred_converged = _ode_predict(converged_k, t_in_0, t_out_avg_w, dt_h_w)
+
+            def _fmt_ts(dt: datetime) -> str:
+                return dt.strftime("%Y-%m-%d %H:%M")
+
+            print(f"  Window: {_fmt_ts(ts0_dt)} -> {_fmt_ts(ts1_dt)} ({dt_h_w:.1f}h)")
+            print(f"  T_start={t_in_0:.1f}F  T_out_avg={t_out_avg_w:.1f}F  T_actual_end={t_actual:.1f}F")
+            print()
+
+            if pred_current is not None:
+                err_current = pred_current - t_actual
+                print(f"  Current k_vent_window ({current_k_vent:+.5f}):")
+                print(f"    Predicted end: {pred_current:.1f}F  Actual: {t_actual:.1f}F  Error: {err_current:+.1f}F")
+            else:
+                print("  Current k_vent_window: None (no prediction)")
+
+            if pred_converged is not None and converged_k is not None:
+                err_converged = pred_converged - t_actual
+                print(f"  Converged k_vent_window ({converged_k:+.5f}):")
+                print(
+                    f"    Predicted end: {pred_converged:.1f}F  Actual: {t_actual:.1f}F  Error: {err_converged:+.1f}F"
+                )
+            else:
+                print("  Converged k_vent_window: None (no prediction)")
+            print()
+        else:
+            print("  (No overnight ventilated window >= 4h found for ODE comparison)")
+    else:
+        print("No valid endpoint estimates — EWMA simulation skipped.")
+
+
+def _count_raw_ventilated_windows(
+    entries: list[dict],
+    days: int = 30,
+    min_window_minutes: int = 120,
+) -> int:
+    """Count ventilated windows (HVAC off, windows open) without natural filter."""
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    count = 0
+    current: list[dict] = []
+
+    def _flush_count() -> None:
+        nonlocal count
+        if len(current) >= 2:
+            ts0 = datetime.fromisoformat(current[0]["timestamp"])
+            ts1 = datetime.fromisoformat(current[-1]["timestamp"])
+            if (ts1 - ts0).total_seconds() / 60.0 >= min_window_minutes:
+                count += 1
+        current.clear()
+
+    for entry in entries:
+        ts_str = entry.get("ts", "")
+        if not ts_str:
+            continue
+        ts = datetime.fromisoformat(ts_str)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        if ts < cutoff:
+            continue
+
+        indoor = entry.get("indoor")
+        outdoor = entry.get("outdoor")
+        hvac = entry.get("hvac", "")
+        windows_open = entry.get("windows_open")
+
+        if indoor is None or outdoor is None:
+            _flush_count()
+            continue
+
+        hvac_idle = hvac in ("idle", "off", "", "fan") or ("heat" not in (hvac or "") and "cool" not in (hvac or ""))
+
+        if not hvac_idle or not windows_open:
+            _flush_count()
+            continue
+
+        elapsed = 0.0
+        if current:
+            ts0_curr = datetime.fromisoformat(current[0]["timestamp"])
+            if ts0_curr.tzinfo is None:
+                ts0_curr = ts0_curr.replace(tzinfo=UTC)
+            elapsed = (ts - ts0_curr).total_seconds() / 60.0
+
+        current.append(
+            {
+                "indoor_temp_f": float(indoor),
+                "outdoor_temp_f": float(outdoor),
+                "elapsed_minutes": elapsed,
+                "timestamp": ts_str,
+            }
+        )
+
+    _flush_count()
+    return count
+
+
 def build_windows_from_chart_log(
     entries: list[dict],
     days: int = 30,
@@ -1087,6 +1714,22 @@ def main() -> None:
         epilog=__doc__,
     )
     parser.add_argument(
+        "--passive-only",
+        action="store_true",
+        help="Analyse passive-only windows (HVAC off, fan off, windows closed) from chart_log. "
+        "Compares OLS vs endpoint estimator side-by-side, simulates EWMA convergence, and "
+        "compares ODE predictions. Requires SSH access (same as --chart-log). "
+        "Read-only — does not write to the learning DB.",
+    )
+    parser.add_argument(
+        "--vent-overnight",
+        action="store_true",
+        help="Analyse overnight ventilated windows (HVAC off, windows open, T_out < T_in throughout) "
+        "using the endpoint estimator. Applies the natural regime filter that auto-rejects morning "
+        "windows where T_out rises toward T_in. Shows filter hit/miss counts, k_vent_window EWMA "
+        "convergence, and ODE prediction comparison. Requires SSH access. Read-only.",
+    )
+    parser.add_argument(
         "--hvac",
         action="store_true",
         help="Detect and replay HVAC heat/cool cycles from chart_log (Issue #130 Phase C). "
@@ -1124,16 +1767,20 @@ def main() -> None:
     parser.add_argument("--write", action="store_true", help="Merge replay obs into HA learning DB via SSH")
     args = parser.parse_args()
 
-    if not args.dry_run and not args.write:
+    _read_only_mode = args.passive_only or args.vent_overnight
+    if not _read_only_mode and not args.dry_run and not args.write:
         parser.error("Specify --dry-run to preview or --write to commit. Start with --dry-run.")
 
     if (
         not args.chart_log
         and not args.hvac
+        and not args.passive_only
+        and not args.vent_overnight
         and not (args.climate_entity and args.outdoor_entity and args.window_entities)
     ):
         parser.error(
-            "Either --chart-log, --hvac, or all of --climate-entity, --outdoor-entity, --window-entities are required."
+            "Either --chart-log, --hvac, --passive-only, --vent-overnight, or all of "
+            "--climate-entity, --outdoor-entity, --window-entities are required."
         )
 
     config = load_config()
@@ -1147,6 +1794,38 @@ def main() -> None:
         temp_unit = ha_cfg.get("unit_system", {}).get("temperature", "°F")
         temp_unit = "C" if "C" in temp_unit else "F"
         print(f"HA temperature unit: {temp_unit}")
+
+    if args.passive_only:
+        # --- Passive-only analysis path (read-only, no --dry-run/--write needed) ---
+        print(f"\nFetching chart_log from HA via SSH ({args.days} days) for passive-only analysis...")
+        chart_entries = fetch_chart_log_ssh(config)
+        print(f"  chart_log: {len(chart_entries)} total entries")
+
+        print("\nFetching current learning DB from HA via SSH...")
+        try:
+            learning_db = fetch_learning_json_ssh(config)
+        except Exception as exc:
+            print(f"  WARNING: Could not fetch learning DB ({exc}) — k_passive will show as None")
+            learning_db = {}
+
+        run_passive_only_analysis(chart_entries, learning_db, days=args.days)
+        return
+
+    if args.vent_overnight:
+        # --- Overnight ventilated analysis path (read-only, no --dry-run/--write needed) ---
+        print(f"\nFetching chart_log from HA via SSH ({args.days} days) for overnight ventilated analysis...")
+        chart_entries = fetch_chart_log_ssh(config)
+        print(f"  chart_log: {len(chart_entries)} total entries")
+
+        print("\nFetching current learning DB from HA via SSH...")
+        try:
+            learning_db = fetch_learning_json_ssh(config)
+        except Exception as exc:
+            print(f"  WARNING: Could not fetch learning DB ({exc}) — k_vent_window will show as None")
+            learning_db = {}
+
+        run_vent_overnight_analysis(chart_entries, learning_db, days=args.days)
+        return
 
     if args.hvac:
         # --- HVAC heat/cool cycle replay path (Issue #130 Phase C) ---


### PR DESCRIPTION
## Summary

- Replaces `passive_decay` consecutive-pair OLS with a chart_log endpoint estimator (`k = ln(ratio) / dt`) for `k_passive` and `k_vent_window` overnight — the OLS was structurally broken for 1°F thermostat sensors (R²≈0.02, always below the 0.20 gate)
- Natural regime filter (ratio in (0,1)) auto-selects overnight ventilated windows and auto-rejects morning windows where T_out rises toward T_in — no time-of-day classification needed
- Startup backfill processes 30 days of chart_log history on first run, immediately correcting stale values (k_vent_window: −0.147 → ~−0.026; k_passive: −0.054 → ~−0.020)

## Root cause

Both `k_passive` and `k_vent_window` were learned from fast-dynamics regimes but applied to slow overnight drift (0.3–0.7°F/hr). With a 1°F thermostat sensor, consecutive-pair OLS produces R²≈0.02. Path A fires on the first 1°F sensor transition (~1.5h), attempts OLS, gets R²=0.02 < 0.20, and abandons — never reaching the 4h hard cap. May 14–15 overnight ventilated prediction error: −10.7°F (k_vent_window=−0.147 was 5× too negative).

## P0b simulation gate (30 days chart_log)

```
python tools/thermal_replay.py --chart-log --vent-overnight --days 30
```
- 53 raw ventilated windows → 46 pass natural filter (7 morning rejected)
- EWMA k_vent_window convergence: −0.147 → −0.026
- ODE overnight error: −10.7°F → +0.6°F

## Files changed

| File | Change |
|------|--------|
| `coordinator.py` | `_run_passive_chart_log_fit()` + `_run_ventilated_chart_log_fit()` + startup backfill flags + passive_decay OLS path removed |
| `const.py` | `THERMAL_CHART_LOG_PASSIVE_MIN_MINUTES`, `_MIN_DT_F`, `_VENT_MIN_MINUTES` |
| `tools/thermal_replay.py` | `--vent-overnight` P0b simulation mode |
| `tools/learning_db.py` | `--thermal` flag for chart_log endpoint observation section |
| `tests/test_thermal_observations.py` | 3 tests updated to document event-driven behavior |

## Test plan

- [x] `pytest tests/ -q` — 2069 passed
- [x] `pytest tests/ -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning` — 2069 passed
- [x] `tests/test_version_sync.py` — version 0.3.42 → 0.3.43 in sync
- [x] Deploy to HA and verify `learning_db.py --thermal` shows backfill results after restart

Closes #141

@claude please review this PR