### PR TITLE
Fix #158: Investigation history full report + AI deduplication (v0.3.51)

### DIFF
--- a/custom_components/climate_advisor/ai_skills_investigator.py
+++ b/custom_components/climate_advisor/ai_skills_investigator.py
@@ -84,10 +84,29 @@ INVESTIGATION PROCEDURE
  coverage status.
 
 OUTPUT FORMAT
+SECTION ROLES ARE EXCLUSIVE — each section contains only what belongs to it:\
+ do not repeat content already stated in a prior section.\
+ A one-line cross-reference ("see Hypotheses above") is acceptable;\
+ copying or paraphrasing the same analysis verbatim is not.
+- INVESTIGATION SUMMARY: 3–5 sentence overview of the most significant finding and whether\
+ action is required. No analysis detail, no hypothesis reasoning, no action items.
+- INCONGRUITIES FOUND: Specific data mismatches or contradictions only. Do NOT re-explain\
+ anything already stated in Summary.
+- DATA QUALITY ISSUES: Missing data, sensor gaps, stale readings, unreliable values only.\
+ Do NOT repeat incongruities.
+- SYSTEM ERRORS / WARNINGS: Log errors and warnings verbatim (with counts if repeated).\
+ Do NOT analyze causes — that belongs in Hypotheses.
+- HYPOTHESES: Ranked explanations. Reference specific data from earlier sections by name\
+ and value; do NOT restate the same findings verbatim.
+- RECOMMENDED ACTIONS: Specific, actionable steps only. Do NOT re-state problem context —\
+ just the action and which hypothesis or finding it addresses.
+- ASSUMPTIONS & CONFIDENCE: List assumptions and confidence level only.\
+ Do NOT repeat findings or recommendations.
+
 Return your investigation using these exact section headers (## prefix, exact capitalisation):
 
 ## INVESTIGATION SUMMARY
-2–4 sentence overview of the most important finding. If nothing is wrong, say so plainly\
+3–5 sentence overview of the most important finding. If nothing is wrong, say so plainly\
  — do not fabricate issues.
 
 ## INCONGRUITIES FOUND

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,7 +4,7 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.3.49"
+VERSION = "0.3.51"
 
 RELEASE_NOTES: dict[str, list[str]] = {
     "0.3.47": [

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -2699,10 +2699,32 @@
       _cachedInvestigationReports = sorted;
       container.innerHTML = sorted.map((entry, idx) => {
         const ts = new Date(entry.timestamp).toLocaleString();
-        const summary = (entry.result && entry.result.data && entry.result.data.summary)
-          ? entry.result.data.summary
-          : (entry.result && entry.result.error ? entry.result.error : 'No summary available');
         const source = (entry.result && entry.result.source) ? entry.result.source : 'unknown';
+        const data = (entry.result && entry.result.data) ? entry.result.data : {};
+        const invSections = [
+          { key: 'summary',             label: 'Investigation Summary' },
+          { key: 'incongruities',       label: 'Incongruities Found' },
+          { key: 'data_quality',        label: 'Data Quality Issues' },
+          { key: 'errors_warnings',     label: 'System Errors / Warnings' },
+          { key: 'hypotheses',          label: 'Hypotheses' },
+          { key: 'recommended_actions', label: 'Recommended Actions' },
+          { key: 'assumptions',         label: 'Assumptions & Confidence' },
+        ];
+        const sectionsHtml = invSections.map(({ key, label }) => {
+          const content = (data[key] || '').trim();
+          if (!content) return '';
+          return '<div style="margin-top:0.75rem;">'
+            + '<div style="font-size:0.75rem; font-weight:600; color:var(--text-primary);'
+            + ' text-transform:uppercase; letter-spacing:0.05em; margin-bottom:0.25rem;">'
+            + escapeHtml(label) + '</div>'
+            + '<p style="font-size:0.8rem; margin:0; color:var(--text-secondary);'
+            + ' white-space:pre-wrap; line-height:1.5;">' + escapeHtml(content) + '</p>'
+            + '</div>';
+        }).join('');
+        const bodyHtml = sectionsHtml
+          || (entry.result && entry.result.error
+            ? '<p style="font-size:0.8rem; margin:0.5rem 0 0; color:var(--text-secondary);">' + escapeHtml(entry.result.error) + '</p>'
+            : '<p style="font-size:0.8rem; margin:0.5rem 0 0; color:var(--text-secondary);">No report data available.</p>');
         return '<details style="margin-bottom:0.5rem;">'
           + '<summary style="cursor:pointer; font-size:0.85rem; padding:0.25rem 0; display:flex; align-items:center; gap:0.5rem;">'
           + '<span><strong>' + escapeHtml(ts) + '</strong>'
@@ -2710,7 +2732,7 @@
           + '<button class="btn secondary" style="font-size:0.75rem; padding:0.15rem 0.5rem; margin-left:auto;" '
           + 'onclick="event.stopPropagation(); downloadInvestigationReportByIndex(' + idx + ')">⬇ Download</button>'
           + '</summary>'
-          + '<p style="font-size:0.8rem; margin:0.5rem 0 0; color:var(--text-secondary);">' + escapeHtml(summary) + '</p>'
+          + '<div style="padding:0 0.25rem 0.5rem;">' + bodyHtml + '</div>'
           + '</details>';
       }).join('');
     } catch (_err) {

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/yourgithubuser/ha-climate-advisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.3.50"
+  "version": "0.3.51"
 }


### PR DESCRIPTION
## Summary

- **UI fix**: Investigation History panel now renders all 7 sections inline when an entry is expanded (Summary, Incongruities, Data Quality, Errors/Warnings, Hypotheses, Recommended Actions, Assumptions). Previously only the summary was shown; the remaining sections were only accessible via Download.
- **AI prompt fix**: Added `SECTION ROLES ARE EXCLUSIVE` + deduplication rule to the investigator `_SYSTEM_PROMPT`. Each section now has an explicit exclusivity definition — content stated in an earlier section must not be restated verbatim in a later one. Matches the pattern already used in the activity report (added in Fix #149).
- **Version sync**: `const.py` was at `0.3.49` while `manifest.json` was at `0.3.50` (diverged in #156). Both bumped to `0.3.51`.

Closes #158

## Test plan

- [x] Deploy to HA → run an investigation → expand a history entry → all non-empty sections render inline
- [x] Verify new AI investigations produce non-repetitive reports (each section adds new info only)
- [x] ruff clean ✓ — 2225/2225 tests pass ✓