### PR TITLE
Fix #162: Chart forward navigation after historical re-fetch

### DIFF
--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -917,6 +917,7 @@
   let _windowOffset = 0;          // ms pan offset from now-centered position
   let _dataWindowStart = null;    // earliest ts (ms) of currently loaded chart data
   let _dataWindowEnd   = null;    // latest ts (ms) of currently loaded chart data
+  let _isHistoricalView = false;  // true when _lastChartData came from a before_ts fetch
   let _touchStartX = 0;           // touch start x for swipe navigation
 
   // Colour palette (matches the dark theme screenshot)
@@ -1009,12 +1010,22 @@
     // Clamp forward: don't navigate past now
     if (_windowOffset > 0) _windowOffset = 0;
     const { min: vpStart, max: vpEnd } = _rangeToWindow(_chartRange);
-    // If viewport has drifted before the loaded data window, re-fetch anchored to vpEnd
+    // Backward: viewport start before data window — re-fetch past
     if (_dataWindowStart !== null && vpStart < _dataWindowStart) {
       loadChart(vpEnd);
       return;
     }
-    // If we've navigated back to present, drop the anchor and re-fetch live data
+    // Forward: viewport end past historical data window — re-fetch newer window or snap live
+    if (_isHistoricalView && _dataWindowEnd !== null && vpEnd > _dataWindowEnd) {
+      if (vpEnd >= Date.now() - step) {
+        _windowOffset = 0;
+        loadChart();  // snap to live
+      } else {
+        loadChart(vpEnd);  // load next historical window
+      }
+      return;
+    }
+    // Snap to live when close enough to now (handles live-mode forward clamp)
     if (_windowOffset >= -step / 2 && _dataWindowEnd !== null) {
       _windowOffset = 0;
       loadChart();
@@ -1832,6 +1843,7 @@
       const data = await apiFetch(url);
       _dataWindowStart = _getDataMinTs(data);
       _dataWindowEnd   = _getDataMaxTs(data);
+      _isHistoricalView = (beforeTs !== null);
       _lastChartData   = data;
       drawChart(data);
       updateThermalPanel(data.thermal_model || null);


### PR DESCRIPTION
## Regression fix for #160

After navigating backward (triggering a historical re-fetch), clicking `›` did nothing — the chart wouldn't advance.

## Root cause

`shiftChartWindow()` had a backward overflow guard but no symmetric forward guard. After a historical re-fetch, `_dataWindowEnd` is set to a past timestamp. Clicking `›` called `drawChart(_lastChartData)` with data that didn't cover the new viewport end. The snap-to-live condition (`_windowOffset >= -step/2`) was too narrow to fire after multi-step backward navigation.

## Fix

Three additions to `index.html` only — no Python changes, no version bump:

1. `let _isHistoricalView = false` state variable
2. `_isHistoricalView = (beforeTs !== null)` set in `loadChart()` after each fetch
3. Symmetric forward overflow guard in `shiftChartWindow()`: when `_isHistoricalView && vpEnd > _dataWindowEnd`, re-fetch anchored to `vpEnd` (or snap to live if `vpEnd` is within one step of now)

Closes #162

## Test plan

- [x] Navigate back several steps → forward navigation loads newer historical windows
- [x] Navigate forward all the way to present → snaps to live data
- [x] Forward at live view → no change (existing behaviour preserved)
- [x] 2229/2229 tests pass ✓