### PR TITLE
Fix #237: restore #230 grace-expiry convergence test on main

### DIFF
--- a/tests/test_windows_recommended_integration.py
+++ b/tests/test_windows_recommended_integration.py
@@ -372,7 +372,14 @@ class TestWindowsRecommendedPauseSuppression:
         assert engine._paused_by_door is False, (
             "_re_pause_for_open_sensor must be suppressed during a planned window period"
         )
-        engine.hass.async_create_task.assert_not_called()
+        # _apply_current_scheduled_state is allowed (grace expiry convergence fix #230).
+        # What must NOT be called is _re_pause_for_open_sensor.
+        for call_args in engine.hass.async_create_task.call_args_list:
+            coro = call_args[0][0]
+            coro_name = getattr(coro, "__qualname__", "") or getattr(coro, "__name__", "")
+            assert "_re_pause_for_open_sensor" not in coro_name, (
+                "_re_pause_for_open_sensor must be suppressed during a planned window period"
+            )
 
     # ------------------------------------------------------------------
     # Test 6 — classification changes warm→hot: pause re-enabled


### PR DESCRIPTION
@
## Why

`main` CI is red on one test: `tests/test_windows_recommended_integration.py::TestWindowsRecommendedPauseSuppression::test_grace_expiry_no_repause_during_window_period`.

**Occupant behavior is correct and unchanged** — `automation.py` on `main` still schedules `_apply_current_scheduled_state()` on grace expiry (lines 1852–1853), so a person with windows intentionally open during a "windows recommended" period gets no nuisance re-pause AND the thermostat converges to the right setpoint for the time of day. This PR fixes only a **stale test**, not behavior.

## Root cause

Fix #230s production change landed on `main` via PR #232, but its test update lived only on the throwaway `deploy/staging` branch (commit `bf01e3e`) and was never in PR #232. The stale test asserted `engine.hass.async_create_task.assert_not_called()` — a blanket "nothing scheduled at all" that the legitimate convergence task now violates.

## Fix

Narrow the assertion to the tests true invariant: `_re_pause_for_open_sensor` must **not** be scheduled during a planned window period; `_apply_current_scheduled_state` is allowed.

## Three-exercise rubric

- **Effectiveness:** still FAILS if `_re_pause_for_open_sensor` is wrongly scheduled (the occupant-harming regression) — masks nothing.
- **Three-way alignment:** production (#230 convergence) ↔ test (allows convergence, forbids re-pause) ↔ docs (grace-periods-spec convergence section).
- **User outcome:** keeping the stale assertion would force reverting #230 (occupant sleeps at wrong temperature) or block CI; the narrowed assertion is the occupant-correct choice.

## Test-infra justification

The old assertion was semantically wrong, not just inconvenient: it conflated "no re-pause" (the documented invariant, per the test name) with "no scheduling at all" (an over-broad proxy that only held before #230). Narrowing restores the true invariant.

## Verification

- `deploy/staging` control: 2370 passed.
- `main` (pre-fix): 1 failed (this test) + 2371 passed.
- `main` + this fix: **2372 passed**, lint + format clean.

Closes #237
@