### PR TITLE
Fix #240: emit events for occupancy & wakeup setpoint changes

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -243,6 +243,9 @@ _AUTO_EVENT_TYPES = frozenset(
         "warm_day_comfort_gap",
         "nat_vent_ceiling_escalation",
         "nat_vent_away_ceiling_exit",
+        "occupancy_setback",
+        "occupancy_comfort_restored",
+        "morning_wakeup",
     }
 )
 

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -2089,6 +2089,11 @@ class AutomationEngine:
                     f" - modifier {format_temp_delta(c.setback_modifier, unit)})"
                 ),
             )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "occupancy_setback",
+                    {"mode": "cool", "target_f": setback, "occupancy": "away"},
+                )
         elif actual_mode == "heat":
             setback = self.config["setback_heat"] + c.setback_modifier
             await self._set_temperature(
@@ -2099,6 +2104,11 @@ class AutomationEngine:
                     f" + modifier {format_temp_delta(c.setback_modifier, unit)})"
                 ),
             )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "occupancy_setback",
+                    {"mode": "heat", "target_f": setback, "occupancy": "away"},
+                )
         else:
             _LOGGER.info(
                 "Occupancy away — HVAC mode is %r, no setback needed",
@@ -2114,6 +2124,12 @@ class AutomationEngine:
 
         if c.hvac_mode in ("heat", "cool"):
             await self._set_temperature_for_mode(c, reason=f"occupancy home — restoring {c.hvac_mode} comfort")
+            comfort = self.config["comfort_heat"] if c.hvac_mode == "heat" else self.config["comfort_cool"]
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "occupancy_comfort_restored",
+                    {"mode": c.hvac_mode, "target_f": comfort},
+                )
 
         # Check 1: Temperature proximity — skip notification if house already near comfort.
         indoor_temp = self._get_indoor_temp_f()
@@ -2181,6 +2197,11 @@ class AutomationEngine:
                     f" + vacation {format_temp_delta(VACATION_SETBACK_EXTRA, unit)})"
                 ),
             )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "occupancy_setback",
+                    {"mode": "cool", "target_f": setback, "occupancy": "vacation"},
+                )
         elif actual_mode == "heat":
             setback = self.config["setback_heat"] + c.setback_modifier - VACATION_SETBACK_EXTRA
             await self._set_temperature(
@@ -2192,6 +2213,11 @@ class AutomationEngine:
                     f" - vacation {format_temp_delta(VACATION_SETBACK_EXTRA, unit)})"
                 ),
             )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "occupancy_setback",
+                    {"mode": "heat", "target_f": setback, "occupancy": "vacation"},
+                )
         else:
             _LOGGER.info(
                 "Occupancy vacation — HVAC mode is %r, no setback needed",
@@ -2344,15 +2370,27 @@ class AutomationEngine:
             return
 
         if c.hvac_mode == "heat":
+            comfort_heat = self.config["comfort_heat"]
             await self._set_temperature(
-                self.config["comfort_heat"],
+                comfort_heat,
                 reason="morning wake-up — restoring heat comfort",
             )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "morning_wakeup",
+                    {"mode": "heat", "target_f": comfort_heat},
+                )
         elif c.hvac_mode == "cool":
+            comfort_cool = self.config["comfort_cool"]
             await self._set_temperature(
-                self.config["comfort_cool"],
+                comfort_cool,
                 reason="morning wake-up — restoring cool comfort",
             )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "morning_wakeup",
+                    {"mode": "cool", "target_f": comfort_cool},
+                )
 
     async def _activate_fan(self, *, reason: str) -> None:
         """Activate fan based on configured fan_mode."""

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -523,6 +523,17 @@ The `_set_temperature_for_mode()` safety net catches all indirect callers (door/
 
 Fire paths emit `bedtime_setback` with `{mode, target_f, depth_f, adaptive, modifier}`. Both event types are visible in the AI investigator's structured event log.
 
+**Occupancy and wakeup events (Issue #240):** The following events are emitted by occupancy handlers when a setpoint change is actually applied, making these actions visible in the dashboard timeline and AI activity report:
+
+| Event type | Handler | Condition | Payload |
+|---|---|---|---|
+| `occupancy_setback` | `handle_occupancy_away()` | Cool or heat thermostat mode — setpoint applied | `{mode: "cool"\|"heat", target_f: float, occupancy: "away"}` |
+| `occupancy_setback` | `handle_occupancy_vacation()` | Cool or heat thermostat mode — setpoint applied | `{mode: "cool"\|"heat", target_f: float, occupancy: "vacation"}` |
+| `occupancy_comfort_restored` | `handle_occupancy_home()` | Classification `hvac_mode` is `heat` or `cool` | `{mode: "cool"\|"heat", target_f: float}` (comfort setpoint) |
+| `morning_wakeup` | `handle_morning_wakeup()` | Classification `hvac_mode` is `heat` or `cool` | `{mode: "cool"\|"heat", target_f: float}` (comfort setpoint) |
+
+No event is emitted when HVAC is `off` (mild/warm day) — no setpoint change occurs in those cases. All four event types are categorised as `source_label=automation` by `_event_source_label()` in `ai_skills_activity.py`. The skip path (HVAC off, occupancy away at wakeup) continues to emit `morning_wakeup_skipped` as before.
+
 **DailyRecord setback fields (Issue #151):** `handle_bedtime()` writes the following fields to `DailyRecord` on every bedtime pass — fire or skip:
 
 | Field | Type | Set when | Value |
@@ -1560,4 +1571,4 @@ Issue #125 adds a `thermal_pipeline` key to the debug-state API response. This k
 
 ---
 
-_Last Updated: 2026-06-03_
+_Last Updated: 2026-06-08_

--- a/tests/test_daily_record.py
+++ b/tests/test_daily_record.py
@@ -83,41 +83,44 @@ class TestGetRecordByDate:
 
     def test_returns_correct_record(self, tmp_path: Path):
         engine = LearningEngine(tmp_path)
-        rec1 = _make_record("2026-03-18", day_type="cool")
-        rec2 = _make_record("2026-03-19", day_type="mild")
-        rec3 = _make_record("2026-03-20", day_type="warm")
-        engine.record_day(rec1)
-        engine.record_day(rec2)
-        engine.record_day(rec3)
+        # Relative dates so they stay inside the 90-day retention window (issue #242)
+        d1 = (datetime.now() - timedelta(days=3)).strftime("%Y-%m-%d")
+        d2 = (datetime.now() - timedelta(days=2)).strftime("%Y-%m-%d")
+        d3 = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+        engine.record_day(_make_record(d1, day_type="cool"))
+        engine.record_day(_make_record(d2, day_type="mild"))
+        engine.record_day(_make_record(d3, day_type="warm"))
 
-        result = engine.get_record_by_date("2026-03-19")
+        result = engine.get_record_by_date(d2)
         assert result is not None
-        assert result["date"] == "2026-03-19"
+        assert result["date"] == d2
         assert result["day_type"] == "mild"
 
     def test_returns_none_wrong_date(self, tmp_path: Path):
         engine = LearningEngine(tmp_path)
-        engine.record_day(_make_record("2026-03-15"))
-        assert engine.get_record_by_date("2026-03-20") is None
+        engine.record_day(_make_record((datetime.now() - timedelta(days=5)).strftime("%Y-%m-%d")))
+        assert engine.get_record_by_date((datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")) is None
 
     def test_returns_most_recent_if_duplicates(self, tmp_path: Path):
         """If somehow two records share a date, return the most recent one."""
         engine = LearningEngine(tmp_path)
-        engine.record_day(_make_record("2026-03-20", day_type="cool"))
-        engine.record_day(_make_record("2026-03-20", day_type="warm"))
-        result = engine.get_record_by_date("2026-03-20")
+        dup = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+        engine.record_day(_make_record(dup, day_type="cool"))
+        engine.record_day(_make_record(dup, day_type="warm"))
+        result = engine.get_record_by_date(dup)
         assert result is not None
         # reversed() iteration returns the last-appended record first
         assert result["day_type"] == "warm"
 
     def test_persists_through_save_load(self, tmp_path: Path):
         engine = LearningEngine(tmp_path)
-        engine.record_day(_make_record("2026-03-19", day_type="cool"))
+        d = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+        engine.record_day(_make_record(d, day_type="cool"))
         engine.save_state()
 
         engine2 = LearningEngine(tmp_path)
         engine2.load_state()
-        result = engine2.get_record_by_date("2026-03-19")
+        result = engine2.get_record_by_date(d)
         assert result is not None
         assert result["day_type"] == "cool"
 

--- a/tests/test_learning_io.py
+++ b/tests/test_learning_io.py
@@ -7,7 +7,7 @@ callers must explicitly invoke load_state() / save_state().
 from __future__ import annotations
 
 import json
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -24,7 +24,13 @@ from custom_components.climate_advisor.learning import (
 # ---------------------------------------------------------------------------
 
 
-def _make_record(date: str = "2026-03-18", **overrides) -> DailyRecord:
+# Anchor dates to "today" so they always sit inside the 90-day record-retention
+# window (record_day trims older records). Fixed calendar dates age out and turn
+# these into time-bombs — see issue #242.
+_DEFAULT_DATE = (date.today() - timedelta(days=1)).isoformat()
+
+
+def _make_record(date: str = _DEFAULT_DATE, **overrides) -> DailyRecord:
     defaults = dict(day_type="mild", trend_direction="stable")
     defaults.update(overrides)
     return DailyRecord(date=date, **defaults)
@@ -116,7 +122,7 @@ class TestSaveState:
 
         data = json.loads(db_path.read_text())
         assert len(data["records"]) == 1
-        assert data["records"][0]["date"] == "2026-03-18"
+        assert data["records"][0]["date"] == _DEFAULT_DATE
 
     def test_record_day_does_not_write(self, tmp_path: Path):
         """record_day only mutates in-memory state — no disk I/O."""
@@ -143,8 +149,8 @@ class TestRoundTrip:
 
     def test_record_round_trip(self, tmp_path: Path):
         engine1 = LearningEngine(tmp_path)
-        engine1.record_day(_make_record("2026-03-10", day_type="hot"))
-        engine1.record_day(_make_record("2026-03-11", day_type="cold"))
+        engine1.record_day(_make_record((date.today() - timedelta(days=2)).isoformat(), day_type="hot"))
+        engine1.record_day(_make_record((date.today() - timedelta(days=1)).isoformat(), day_type="cold"))
         engine1.save_state()
 
         engine2 = LearningEngine(tmp_path)

--- a/tests/test_occupancy.py
+++ b/tests/test_occupancy.py
@@ -644,16 +644,18 @@ class TestLearningVacationExclusion:
 
     def test_vacation_days_excluded_from_override_pattern(self):
         """Vacation records should not count toward frequent_overrides."""
+        from datetime import datetime, timedelta
         from pathlib import Path
 
         from custom_components.climate_advisor.learning import LearningEngine
 
         engine = LearningEngine(Path("/tmp/fake"))
 
-        # Add 14 vacation days with many overrides — should not trigger suggestion
+        # Add 14 vacation days with many overrides — should not trigger suggestion.
+        # Relative dates so records stay inside the 90-day retention window (issue #242).
         for i in range(14):
             record = DailyRecord(
-                date=f"2026-03-{i + 1:02d}",
+                date=(datetime.now() - timedelta(days=14 - i)).strftime("%Y-%m-%d"),
                 day_type="warm",
                 trend_direction="stable",
                 manual_overrides=5,

--- a/tests/test_occupancy_setback_mode.py
+++ b/tests/test_occupancy_setback_mode.py
@@ -55,7 +55,7 @@ def _make_engine(config_overrides: dict | None = None) -> AutomationEngine:
 def _make_classification(hvac_mode: str = "cool", setback_modifier: float = 0.0) -> DayClassification:
     """Create a minimal DayClassification bypassing __post_init__."""
     obj = object.__new__(DayClassification)
-    obj.day_type = "warm" if hvac_mode == "cool" else "cold"
+    obj.day_type = "warm" if hvac_mode in ("cool", "off") else "cold"
     obj.hvac_mode = hvac_mode
     obj.trend_direction = "stable"
     obj.trend_magnitude = 0
@@ -205,3 +205,248 @@ class TestHandleOccupancyVacationActualMode:
 
         temp = _last_set_temperature(engine)
         assert temp is None, f"Expected no setpoint when HVAC is off, got {temp}"
+
+
+# ── Event emission — Issue #240 ──────────────────────────────────
+
+
+class TestOccupancyAwayEmitsEvent:
+    """handle_occupancy_away() must emit occupancy_setback when a setpoint is applied."""
+
+    def test_cool_mode_emits_occupancy_setback_away(self):
+        """Cool thermostat → occupancy_setback with mode=cool, occupancy=away."""
+        engine = _make_engine()
+        engine._current_classification = _make_classification(hvac_mode="cool")
+        engine.hass.states.get.return_value = _thermostat_state("cool")
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_occupancy_away())
+
+        assert len(events) == 1, f"Expected 1 event, got {events}"
+        evt_name, evt_data = events[0]
+        assert evt_name == "occupancy_setback"
+        assert evt_data["mode"] == "cool"
+        assert evt_data["occupancy"] == "away"
+        assert evt_data["target_f"] == engine.config["setback_cool"]
+
+    def test_heat_mode_emits_occupancy_setback_away(self):
+        """Heat thermostat → occupancy_setback with mode=heat, occupancy=away."""
+        engine = _make_engine()
+        engine._current_classification = _make_classification(hvac_mode="heat")
+        engine.hass.states.get.return_value = _thermostat_state("heat")
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_occupancy_away())
+
+        assert len(events) == 1
+        evt_name, evt_data = events[0]
+        assert evt_name == "occupancy_setback"
+        assert evt_data["mode"] == "heat"
+        assert evt_data["occupancy"] == "away"
+        assert evt_data["target_f"] == engine.config["setback_heat"]
+
+    def test_off_mode_emits_no_event(self):
+        """HVAC off → no event (no setpoint applied)."""
+        engine = _make_engine()
+        engine._current_classification = _make_classification(hvac_mode="cool")
+        engine.hass.states.get.return_value = _thermostat_state("off")
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_occupancy_away())
+
+        assert events == [], f"Expected no events when HVAC is off, got {events}"
+
+
+class TestOccupancyVacationEmitsEvent:
+    """handle_occupancy_vacation() must emit occupancy_setback when a setpoint is applied."""
+
+    def test_cool_mode_emits_occupancy_setback_vacation(self):
+        """Cool thermostat → occupancy_setback with mode=cool, occupancy=vacation."""
+        from custom_components.climate_advisor.automation import VACATION_SETBACK_EXTRA
+
+        engine = _make_engine()
+        engine._current_classification = _make_classification(hvac_mode="cool")
+        engine.hass.states.get.return_value = _thermostat_state("cool")
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_occupancy_vacation())
+
+        assert len(events) == 1
+        evt_name, evt_data = events[0]
+        assert evt_name == "occupancy_setback"
+        assert evt_data["mode"] == "cool"
+        assert evt_data["occupancy"] == "vacation"
+        expected_target = engine.config["setback_cool"] + VACATION_SETBACK_EXTRA
+        assert evt_data["target_f"] == expected_target
+
+    def test_heat_mode_emits_occupancy_setback_vacation(self):
+        """Heat thermostat → occupancy_setback with mode=heat, occupancy=vacation."""
+        from custom_components.climate_advisor.automation import VACATION_SETBACK_EXTRA
+
+        engine = _make_engine()
+        engine._current_classification = _make_classification(hvac_mode="heat")
+        engine.hass.states.get.return_value = _thermostat_state("heat")
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_occupancy_vacation())
+
+        assert len(events) == 1
+        evt_name, evt_data = events[0]
+        assert evt_name == "occupancy_setback"
+        assert evt_data["mode"] == "heat"
+        assert evt_data["occupancy"] == "vacation"
+        expected_target = engine.config["setback_heat"] - VACATION_SETBACK_EXTRA
+        assert evt_data["target_f"] == expected_target
+
+    def test_off_mode_emits_no_event(self):
+        """HVAC off → no event."""
+        engine = _make_engine()
+        engine._current_classification = _make_classification(hvac_mode="cool")
+        engine.hass.states.get.return_value = _thermostat_state("off")
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_occupancy_vacation())
+
+        assert events == [], f"Expected no events when HVAC is off, got {events}"
+
+
+class TestOccupancyHomeEmitsEvent:
+    """handle_occupancy_home() must emit occupancy_comfort_restored after restoring comfort."""
+
+    def test_heat_mode_emits_occupancy_comfort_restored(self):
+        """Heat classification → occupancy_comfort_restored with mode=heat."""
+        engine = _make_engine()
+        engine._current_classification = _make_classification(hvac_mode="heat")
+        engine.hass.states.get.return_value = _thermostat_state("heat")
+        engine._natural_vent_active = False
+        engine._fan_override_active = False
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_occupancy_home())
+
+        comfort_events = [(n, d) for n, d in events if n == "occupancy_comfort_restored"]
+        assert len(comfort_events) == 1, f"Expected 1 occupancy_comfort_restored event, got {events}"
+        evt_data = comfort_events[0][1]
+        assert evt_data["mode"] == "heat"
+        assert evt_data["target_f"] == engine.config["comfort_heat"]
+
+    def test_cool_mode_emits_occupancy_comfort_restored(self):
+        """Cool classification → occupancy_comfort_restored with mode=cool."""
+        engine = _make_engine()
+        engine._current_classification = _make_classification(hvac_mode="cool")
+        engine.hass.states.get.return_value = _thermostat_state("cool")
+        engine._natural_vent_active = False
+        engine._fan_override_active = False
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_occupancy_home())
+
+        comfort_events = [(n, d) for n, d in events if n == "occupancy_comfort_restored"]
+        assert len(comfort_events) == 1, f"Expected 1 occupancy_comfort_restored event, got {events}"
+        evt_data = comfort_events[0][1]
+        assert evt_data["mode"] == "cool"
+        assert evt_data["target_f"] == engine.config["comfort_cool"]
+
+    def test_hvac_off_emits_no_comfort_event(self):
+        """HVAC off classification → no occupancy_comfort_restored event."""
+        engine = _make_engine()
+        engine._current_classification = _make_classification(hvac_mode="off")
+        engine.hass.states.get.return_value = _thermostat_state("off")
+        engine._natural_vent_active = False
+        engine._fan_override_active = False
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_occupancy_home())
+
+        comfort_events = [(n, d) for n, d in events if n == "occupancy_comfort_restored"]
+        assert comfort_events == [], f"Expected no comfort event for off mode, got {events}"
+
+
+class TestMorningWakeupEmitsEvent:
+    """handle_morning_wakeup() must emit morning_wakeup on the success path."""
+
+    def test_heat_mode_emits_morning_wakeup(self):
+        """Heat classification → morning_wakeup with mode=heat."""
+        engine = _make_engine()
+        engine._current_classification = _make_classification(hvac_mode="heat")
+        engine._fan_active = False
+        engine._fan_override_active = False
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_morning_wakeup())
+
+        wakeup_events = [(n, d) for n, d in events if n == "morning_wakeup"]
+        assert len(wakeup_events) == 1, f"Expected 1 morning_wakeup event, got {events}"
+        evt_data = wakeup_events[0][1]
+        assert evt_data["mode"] == "heat"
+        assert evt_data["target_f"] == engine.config["comfort_heat"]
+
+    def test_cool_mode_emits_morning_wakeup(self):
+        """Cool classification → morning_wakeup with mode=cool."""
+        engine = _make_engine()
+        engine._current_classification = _make_classification(hvac_mode="cool")
+        engine._fan_active = False
+        engine._fan_override_active = False
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_morning_wakeup())
+
+        wakeup_events = [(n, d) for n, d in events if n == "morning_wakeup"]
+        assert len(wakeup_events) == 1, f"Expected 1 morning_wakeup event, got {events}"
+        evt_data = wakeup_events[0][1]
+        assert evt_data["mode"] == "cool"
+        assert evt_data["target_f"] == engine.config["comfort_cool"]
+
+    def test_skipped_when_occupancy_away_emits_no_event(self):
+        """Wakeup skipped (away) → no morning_wakeup event."""
+        from custom_components.climate_advisor.const import OCCUPANCY_AWAY
+
+        engine = _make_engine()
+        engine._current_classification = _make_classification(hvac_mode="heat")
+        engine._occupancy_mode = OCCUPANCY_AWAY
+        engine._fan_active = False
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_morning_wakeup())
+
+        wakeup_events = [(n, d) for n, d in events if n == "morning_wakeup"]
+        assert wakeup_events == [], f"Expected no morning_wakeup when away, got {events}"
+
+    def test_hvac_off_classification_emits_no_event(self):
+        """HVAC off (mild/warm day) → no morning_wakeup event."""
+        engine = _make_engine()
+        engine._current_classification = _make_classification(hvac_mode="off")
+        engine._fan_active = False
+        engine._fan_override_active = False
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_morning_wakeup())
+
+        wakeup_events = [(n, d) for n, d in events if n == "morning_wakeup"]
+        assert wakeup_events == [], f"Expected no morning_wakeup for off-mode day, got {events}"

--- a/tests/test_state_persistence.py
+++ b/tests/test_state_persistence.py
@@ -631,12 +631,15 @@ class TestSuggestionTracking:
         engine = LearningEngine(tmp_path)
 
         # Add enough records to trigger suggestions (need MIN_DATA_POINTS_FOR_SUGGESTION)
+        from datetime import datetime, timedelta
+
         from custom_components.climate_advisor.const import MIN_DATA_POINTS_FOR_SUGGESTION
 
+        # Relative dates so records stay inside the 90-day retention window (issue #242).
         for i in range(MIN_DATA_POINTS_FOR_SUGGESTION):
             engine.record_day(
                 DailyRecord(
-                    date=f"2026-03-{i + 1:02d}",
+                    date=(datetime.now() - timedelta(days=MIN_DATA_POINTS_FOR_SUGGESTION - i)).strftime("%Y-%m-%d"),
                     day_type="mild",
                     trend_direction="stable",
                     manual_overrides=5,  # Trigger frequent_overrides pattern


### PR DESCRIPTION
@
## Occupant impact
When the occupant leaves, returns, or wakes up, the thermostat sets back / restores comfort correctly — but until now those actions were **invisible** in the dashboard timeline and daily AI report. This makes them visible and explained, honoring the "explain every automated action" principle.

## Changes
- `automation.py`: `handle_occupancy_away`/`vacation` emit `occupancy_setback`; `handle_occupancy_home` emits `occupancy_comfort_restored`; `handle_morning_wakeup` success path emits `morning_wakeup`. (HVAC-off and skip paths emit nothing, unchanged.)
- `ai_skills_activity.py`: the three new event types added to `_AUTO_EVENT_TYPES` → categorized as automation-sourced in the timeline/AI report.
- +13 tests; `docs/08-COMPUTATION-REFERENCE.md` §6a updated.

## Also fixes #242 (pre-existing CI date-boundary time-bombs)
Initial CI run failed on `test_learning_io.py::test_record_round_trip` — **unrelated to this PR**: `record_day` trims records older than 90 days, and several learning tests hardcoded `2026-03-xx` dates that age out as the calendar advances (first detonation 2026-06-09; siblings due 2026-06-13..18). Anchored all `record_day` test dates to `today` minus small offsets. Test-only; production trim unchanged.

## Verification
Full suite **2385 passed**. Surfaced by the issue #236 differential harness; once merged, that harness reads occupancy/wakeup outcomes from events directly.

Closes #240
Closes #242
@