### PR TITLE
Fix #286: add hvac_mode to dual setpoint service call so Ecobee holds setpoints

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -1323,6 +1323,7 @@ class AutomationEngine:
                 "set_temperature",
                 {
                     "entity_id": self.climate_entity,
+                    "hvac_mode": "heat_cool",
                     "target_temp_low": service_low,
                     "target_temp_high": service_high,
                 },
@@ -1330,9 +1331,11 @@ class AutomationEngine:
         finally:
             self._temp_command_pending = False
         _LOGGER.warning(
-            "Set dual temperature [%s / %s] — %s",
+            "Set dual temperature [%s / %s] (service: %.4g / %.4g) — %s",
             format_temp(low, unit),
             format_temp(high, unit),
+            service_low,
+            service_high,
             reason,
         )
         self._record_action(f"Set dual temp [{format_temp(low, unit)}/{format_temp(high, unit)}]", reason)

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -229,6 +229,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self.automation_engine._revisit_callback = self.async_request_refresh
         self.automation_engine._sensor_check_callback = self._any_sensor_open
         self.automation_engine._emit_event_callback = self._emit_event
+        _LOGGER.debug(
+            "Climate Advisor startup: temp_unit=%s, comfort_heat=%.1f, comfort_cool=%.1f",
+            config.get("temp_unit", "fahrenheit"),
+            config.get("comfort_heat", 0),
+            config.get("comfort_cool", 0),
+        )
 
         # Event log ring buffer (Issue #76) — timestamped automation events for debug download
         self._event_log: list[dict] = []

--- a/tests/test_automation_celsius.py
+++ b/tests/test_automation_celsius.py
@@ -160,3 +160,84 @@ class TestSetTemperatureCelsius:
         call_args = engine.hass.services.async_call.call_args
         data = call_args[0][2]
         assert data["entity_id"] == "climate.test_thermostat"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _set_temperature_dual() service payload
+# ---------------------------------------------------------------------------
+
+
+class TestSetTemperatureDual:
+    """Verify _set_temperature_dual() sends a well-formed service call.
+
+    The service data must include:
+      - hvac_mode: "heat_cool"  (so Ecobee accepts the setpoints atomically)
+      - target_temp_low / target_temp_high in the user's unit
+      - entity_id
+
+    Regression for Issue #286: missing hvac_mode caused Ecobee to snap back to
+    its internal hold values within 1 second of CA's write.
+    """
+
+    def test_dual_includes_hvac_mode_heat_cool(self):
+        """Service data for _set_temperature_dual must include hvac_mode='heat_cool'.
+
+        Without this key the Ecobee ignores the setpoints and reverts to its
+        own hold within seconds — observed as 74/68 → 77/67 in 1 second.
+        """
+        engine = _make_automation(temp_unit="fahrenheit", comfort_heat=68.0, comfort_cool=74.0)
+
+        asyncio.run(engine._set_temperature_dual(68.0, 74.0, reason="test"))
+
+        call_args = engine.hass.services.async_call.call_args
+        domain, service, data = call_args[0]
+        assert domain == "climate"
+        assert service == "set_temperature"
+        assert data.get("hvac_mode") == "heat_cool", (
+            "hvac_mode='heat_cool' must be present in set_temperature payload "
+            "so Ecobee processes mode and setpoints atomically"
+        )
+
+    def test_dual_fahrenheit_passthrough(self):
+        """Fahrenheit config: service receives the exact float values passed in."""
+        engine = _make_automation(temp_unit="fahrenheit")
+
+        asyncio.run(engine._set_temperature_dual(68.0, 74.0, reason="test"))
+
+        call_args = engine.hass.services.async_call.call_args
+        data = call_args[0][2]
+        assert data["target_temp_low"] == 68.0
+        assert data["target_temp_high"] == 74.0
+
+    def test_dual_celsius_conversion(self):
+        """Celsius config: service receives °C-converted values.
+
+        68.0°F → 20.0°C, 74.0°F → 23.333...°C.
+        """
+        engine = _make_automation(temp_unit="celsius")
+
+        asyncio.run(engine._set_temperature_dual(68.0, 74.0, reason="test"))
+
+        call_args = engine.hass.services.async_call.call_args
+        data = call_args[0][2]
+        assert abs(data["target_temp_low"] - 20.0) < 0.01, f"Expected 20.0°C, got {data['target_temp_low']}"
+        assert abs(data["target_temp_high"] - 23.333) < 0.01, f"Expected 23.333°C, got {data['target_temp_high']}"
+
+    def test_dual_entity_id_forwarded(self):
+        """The correct climate entity ID is always included in dual service call."""
+        engine = _make_automation(temp_unit="fahrenheit")
+
+        asyncio.run(engine._set_temperature_dual(68.0, 74.0, reason="entity check"))
+
+        call_args = engine.hass.services.async_call.call_args
+        data = call_args[0][2]
+        assert data["entity_id"] == "climate.test_thermostat"
+
+    def test_dual_dry_run_skips_service_call(self):
+        """In dry_run mode, _set_temperature_dual never calls climate.set_temperature."""
+        engine = _make_automation(temp_unit="fahrenheit")
+        engine.dry_run = True
+
+        asyncio.run(engine._set_temperature_dual(68.0, 74.0, reason="dry run"))
+
+        engine.hass.services.async_call.assert_not_called()


### PR DESCRIPTION
## Summary

- **Root cause:** `_set_temperature_dual()` sent only `target_temp_low`/`target_temp_high` to `climate.set_temperature`, omitting `hvac_mode`. The HA Ecobee integration requires `hvac_mode='heat_cool'` alongside dual setpoints for the thermostat to hold them atomically. Without it, the Ecobee reverts to its internal hold values within ~1 second.
- **Observed symptom:** CA writes 74/68, thermostat shows 74/68 for 1 second, then snaps to 77/67 (the Ecobee's prior hold).
- **Log masking gap:** The log message used `format_temp(low, unit)` — the internal Fahrenheit display string — rather than the actual `service_low`/`service_high` values sent to HA. If `temp_unit` were mis-configured as Celsius, the log would still say "74°F" while the service received 23.3. Fixed to show both display and service values.
- **Startup visibility:** Added `temp_unit` / `comfort_heat` / `comfort_cool` DEBUG log at coordinator startup so any unit misconfiguration is visible immediately.

## Changes

- `automation.py` — `_set_temperature_dual()`: add `"hvac_mode": "heat_cool"` to service payload; log shows `(service: X / Y)` actual sent values
- `coordinator.py` — startup DEBUG log: `temp_unit=..., comfort_heat=..., comfort_cool=...`
- `tests/test_automation_celsius.py` — `TestSetTemperatureDual` class: 5 TDD tests (hvac_mode present, fahrenheit passthrough, celsius conversion, entity ID, dry-run)

## Test plan

- [x] `test_dual_includes_hvac_mode_heat_cool` — confirmed FAIL before fix, PASS after
- [x] All 13 `test_automation_celsius.py` tests pass
- [x] Full suite: 2520/2520 pass, 0 new failures

Closes #286