### PR TITLE
Feat #258: Overnight trend-aware pre-cool with nat-vent coordination

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -110,6 +110,44 @@ The briefing is the main way users interact with Climate Advisor. When making ch
 - Out-of-scope writes can cause data loss, config corruption, or security issues
 - This rule makes the integration safe to install, update, and uninstall cleanly
 
+### Observability Requirements (CRITICAL)
+
+**Decision**: Every new automation behavior in Climate Advisor MUST include logging, status page visibility, and chart coverage. These are not optional polish — they are part of the definition of done for every feature.
+
+#### Logging
+
+Every decision point in a new or modified automation flow must emit a log line:
+
+- **INFO** at the entry of any scheduled trigger: include the trigger name, relevant inputs (indoor temp, outdoor temp, computed target, modifier), and the resolved trigger time
+- **INFO** at each decision outcome: applied / suppressed / skipped — include the reason and the key values that drove the decision
+- **WARNING** when a target value is clamped or overridden by a guard (e.g., floor/ceiling clamping, occupancy redirect, morning heat guard)
+- **WARNING** when a safety guard fires that would otherwise have left the HVAC in an unexpected state
+- **NEVER** log credentials, tokens, entity names that reveal personal info, or partial API keys (see Security Requirements)
+
+Log format rule: lead with the decision outcome as a short phrase (e.g., `"Setpoint applied"`, `"Feature suppressed: free cooling achieved target"`), then key values as `key=value` pairs. This makes grep filtering easy and predictable.
+
+#### Status Page Visibility
+
+Any new automation phase or state that the occupant (or developer) would want to know about MUST appear in the dashboard Status tab via the existing status card infrastructure — **no new cards**. Use existing cards by extending the API fields they read from:
+
+- New state fields belong in the coordinator's `data` dict (returned by `_async_update_data()`)
+- Expose them via the status API (`api.py`) under a descriptive key (e.g., `pre_cool_status`, `grace_status`, `nat_vent_status`)
+- Wire into the relevant existing `.status-item` card in `loadStatus()` in `index.html` as an additional `.value` line, shown only when non-null
+- Follow the existing pattern: `automation_status` carries the primary state string; feature-specific fields append context when the feature is active
+
+Typical state values a status field should express: `"scheduled (X°F @ HH:MM)"`, `"active (X°F)"`, `"suppressed — reason"`, `null` when inactive (hidden from UI).
+
+#### Chart Coverage
+
+Any automation phase that changes the thermostat setpoint (even temporarily) MUST be reflected in the chart's Target Band:
+
+- The `_compute_target_band_schedule()` function in `coordinator.py` is the single source of truth
+- A setpoint that applies at a specific time window → the band must show the corresponding ceiling/floor change during that window
+- The ODE prediction curve (`_build_predicted_indoor_future()`) must also receive the same setpoint so the predicted indoor curve tracks the actual intended setpoint
+- Never let the chart show a band that conflicts with what the engine is actually doing
+
+**Violation protocol**: Same as Security — stop, flag, and ask before shipping if a proposed feature lacks logging, status page wiring, or chart coverage.
+
 ### Security Requirements (CRITICAL)
 
 **Decision**: All code written for Climate Advisor MUST follow these security rules. They apply to the integration, deployment tools, and tests.

--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -134,6 +134,7 @@ class ClimateAdvisorStatusView(HomeAssistantView):
                 "paused_by_door": ae.is_paused_by_door,
                 "ca_target_heat": coordinator.config.get("comfort_heat"),
                 "ca_target_cool": coordinator.config.get("comfort_cool"),
+                "pre_cool_status": data.get("pre_cool_status"),
             }
         )
 

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -291,7 +291,8 @@ def compute_bedtime_setback(
         floor = config.get("setback_cool", 80)
         rate = (thermal_model or {}).get("cooling_rate_f_per_hour")
         default_depth = DEFAULT_SETBACK_DEPTH_COOL_F
-        setback_modifier = -setback_modifier  # cool setback goes up, not down
+        # Note: warming trend (setback_modifier < 0) intentionally lowers the cool ceiling
+        # to bank cold thermal mass before a hot day. No sign flip needed.
         # Explicit sleep temp takes priority over adaptive calculation
         _explicit = config.get(CONF_SLEEP_COOL)
         if _explicit is not None:
@@ -2636,7 +2637,114 @@ class AutomationEngine:
             reason=f"bedtime — sleep band [{_sleep_band.floor:.0f}/{_sleep_band.ceiling:.0f}]",
         )
 
-    async def handle_morning_wakeup(self) -> None:
+    async def handle_pre_cool(self, indoor_temp: float | None, nat_vent_just_closed: bool) -> str:
+        """Apply overnight pre-cool setpoint to bank cold thermal mass before a hot day.
+
+        Fires at the pre-cool trigger time (nat-vent close + delay, or wake_time - 4h).
+        Suppressed when nat-vent already brought indoor to or below the target.
+        Returns a short status string for logging.
+        """
+        from .const import CONF_SLEEP_COOL, PRE_COOL_MIN_HEADROOM_F
+
+        c = self._current_classification
+        if not c or c.setback_modifier >= 0:
+            _LOGGER.info(
+                "Pre-cool trigger fired: skipped — no warming trend (modifier=%s)",
+                getattr(c, "setback_modifier", "n/a"),
+            )
+            return "skipped: no warming trend"
+
+        if self._occupancy_mode in (OCCUPANCY_VACATION, OCCUPANCY_AWAY):
+            _LOGGER.info("Pre-cool skipped — %s mode (setback already active)", self._occupancy_mode)
+            return f"skipped: {self._occupancy_mode}"
+
+        if self._manual_override_active:
+            _LOGGER.info(
+                "Pre-cool skipped — manual override active (mode=%s since %s)",
+                self._manual_override_mode,
+                self._manual_override_time,
+            )
+            return "skipped: manual override"
+
+        sleep_cool = float(self.config.get(CONF_SLEEP_COOL) or self.config.get("sleep_cool", 78.0))
+        comfort_heat = float(self.config.get("comfort_heat", 70.0))
+        raw_target = sleep_cool + c.setback_modifier  # setback_modifier is negative for warming trend
+        floor = comfort_heat + PRE_COOL_MIN_HEADROOM_F
+        pre_cool_target = max(raw_target, floor)
+
+        _LOGGER.info(
+            "Pre-cool trigger fired: indoor=%s°F, target=%.1f°F, modifier=%.1f (sleep_cool=%.1f, floor=%.1f)",
+            f"{indoor_temp:.1f}" if indoor_temp is not None else "unknown",
+            pre_cool_target,
+            c.setback_modifier,
+            sleep_cool,
+            floor,
+        )
+
+        if raw_target < floor:
+            _LOGGER.warning(
+                "Pre-cool target %.1f°F below floor %.1f°F (comfort_heat=%.1f + headroom=%.1f); clamped to %.1f°F",
+                raw_target,
+                floor,
+                comfort_heat,
+                PRE_COOL_MIN_HEADROOM_F,
+                pre_cool_target,
+            )
+
+        # If nat-vent just closed and already achieved target: suppress AC
+        if nat_vent_just_closed and indoor_temp is not None and indoor_temp <= pre_cool_target:
+            _LOGGER.info(
+                "Pre-cool suppressed: nat-vent brought indoor to %.1f°F (target %.1f°F) — no AC needed",
+                indoor_temp,
+                pre_cool_target,
+            )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "pre_cool_suppressed_nat_vent",
+                    {"indoor": indoor_temp, "target": pre_cool_target, "modifier": c.setback_modifier},
+                )
+            return f"suppressed: nat-vent achieved {indoor_temp:.1f}°F (target {pre_cool_target:.1f}°F)"
+
+        # Get sleep heat floor from current sleep band so we preserve it
+        _sleep_band = select_comfort_band(
+            c,
+            self.config,
+            occupancy_mode=self._occupancy_mode,
+            in_sleep_window=True,
+            aggressive_savings=bool(self.config.get("aggressive_savings", False)),
+        )
+        _pre_cool_band = ComfortBand(
+            floor=_sleep_band.floor,
+            ceiling=pre_cool_target,
+            active="ceiling",
+            reason=f"pre-cool — warming trend thermal mass banking (target {pre_cool_target:.0f}°F)",
+        )
+
+        if self._emit_event_callback:
+            self._emit_event_callback(
+                "pre_cool_applied",
+                {
+                    "target": pre_cool_target,
+                    "modifier": c.setback_modifier,
+                    "sleep_cool": sleep_cool,
+                    "floor": floor,
+                    "indoor": indoor_temp,
+                    "nat_vent_suppressed": False,
+                },
+            )
+
+        _LOGGER.info(
+            "Pre-cool setpoint applied: cool ceiling %.1f°F (heat floor unchanged at %.1f°F)",
+            pre_cool_target,
+            _sleep_band.floor,
+        )
+        await self._apply_comfort_band(
+            _pre_cool_band,
+            reason=f"pre-cool — warming trend [{_sleep_band.floor:.0f}/{pre_cool_target:.0f}]",
+        )
+        return f"applied: {pre_cool_target:.1f}°F"
+
+    async def handle_morning_wakeup(self, indoor_temp: float | None = None) -> None:
         """Restore comfort for morning wake-up."""
         # Issue #85: skip comfort restore when nobody is home
         if self._occupancy_mode not in (OCCUPANCY_HOME, OCCUPANCY_GUEST):
@@ -2666,6 +2774,28 @@ class AutomationEngine:
         c = self._current_classification
         if not c:
             return
+
+        # Morning pre-cool overshoot guard: warn if indoor is below comfort_heat (heat may fire)
+        _current_indoor = indoor_temp
+        _comfort_heat = float(self.config.get("comfort_heat", 70.0))
+        if _current_indoor is not None:
+            if _current_indoor < _comfort_heat:
+                _LOGGER.warning(
+                    "Morning check: indoor %.1f°F below comfort_heat %.1f°F — pre-cool overshoot; heat may fire",
+                    _current_indoor,
+                    _comfort_heat,
+                )
+                if self._emit_event_callback:
+                    self._emit_event_callback(
+                        "pre_cool_overshoot",
+                        {"indoor": _current_indoor, "comfort_heat": _comfort_heat},
+                    )
+            else:
+                _LOGGER.info(
+                    "Morning check: indoor %.1f°F ≥ comfort_heat %.1f°F — within guard",
+                    _current_indoor,
+                    _comfort_heat,
+                )
 
         # Arm the daytime comfort band — waking up exits the sleep window.
         _wakeup_band = select_comfort_band(

--- a/custom_components/climate_advisor/briefing.py
+++ b/custom_components/climate_advisor/briefing.py
@@ -149,6 +149,7 @@ def generate_briefing(
                 temp_unit=temp_unit,
                 predicted_indoor_future=predicted_indoor_future,
                 predicted_outdoor_future=predicted_outdoor_future,
+                pre_cool_target=bedtime_setback_cool,
             )
         )
     elif c.day_type == DAY_TYPE_MILD:
@@ -594,6 +595,7 @@ def _warm_day_plan(
     temp_unit: str = FAHRENHEIT,
     predicted_indoor_future: list[dict] | None = None,
     predicted_outdoor_future: list[dict] | None = None,
+    pre_cool_target: float | None = None,
 ) -> list[str]:
     """Conversational plan for warm days (75-85\u00b0F)."""
     lines = []
@@ -660,6 +662,15 @@ def _warm_day_plan(
         lines.append(
             f"The AC will step in above {format_temp(comfort_cool, temp_unit)} as a safety net if"
             f" needed, but with good airflow you probably won't need it."
+        )
+
+    # Pre-cool night mention: warming trend + a lower sleep ceiling is planned
+    if pre_cool_target is not None and getattr(c, "setback_modifier", 0.0) < 0:
+        lines.append("")
+        lines.append(
+            f"Tonight I'll cool the home to {format_temp(pre_cool_target, temp_unit)} while"
+            f" you sleep to build up cold thermal mass before tomorrow's heat — so the house"
+            f" coasts longer before the AC needs to kick in."
         )
 
     if _nat_vent_recovers and _events is not None:

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.18"
+VERSION = "0.4.19"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.19": [
+        "Feat #258: Trend-aware overnight pre-cool — on warming-trend nights CA now banks cold"
+        " thermal mass by lowering the AC ceiling mid-night (after nat-vent window closes or"
+        " 4h before wake, whichever is later). Nat-vent suppresses AC pre-cool when it already"
+        " achieved the target. A morning guard prevents the pre-cool target from dropping below"
+        " comfort_heat + 2°F. Status card and chart target band both show the pre-cool dip."
+        " Sign-convention bug fixed: warm-trend modifier now correctly lowers the sleep ceiling"
+        " (pre-cool) instead of raising it (energy setback).",
+    ],
     "0.4.18": [
         "Fix #321: HA restart no longer causes spurious manual overrides. A 5-minute startup"
         " coalescing window suppresses override detection; at the 5-minute mark CA evaluates"
@@ -1406,6 +1415,34 @@ KNOWN_FIXES: dict[int, dict] = {
             " not addressed by the confidence fix alone",
         ],
     },
+    258: {
+        "version_fixed": "0.4.19",
+        "title": "Trend-aware overnight pre-cool with nat-vent coordination",
+        "scope_covered": [
+            "automation.py compute_bedtime_setback(): sign-convention fix — warming trend now lowers"
+            " sleep ceiling (pre-cool) instead of raising it (energy setback)",
+            "automation.py handle_pre_cool(): new method applies cooler ceiling at pre-cool trigger"
+            " time; suppressed when nat-vent already achieved target; respects occupancy and override guards",
+            "coordinator.py _compute_pre_cool_trigger_time(): trigger = nat-vent close + 30min or"
+            " wake_time - 4h fallback; only fires when setback_modifier < 0",
+            "coordinator.py: pre-cool scheduled in _async_update_data() when classification becomes"
+            " available; cancelled and reset at end-of-day",
+            "coordinator.py _compute_target_band_schedule(): chart target band dips to pre_cool_target"
+            " from trigger_time to wake_time on warming-trend nights",
+            "coordinator.py _compute_automation_status() + _async_update_data(): pre_cool_status"
+            " field exposes scheduled/active/suppressed states",
+            "api.py + index.html: pre_cool_status wired into existing Automation Status card",
+            "briefing.py: warm-day section mentions pre-cool plan with target and time",
+            "CLAUDE.md: Observability Requirements (logging + status page + chart) codified as"
+            " universal standing standard for all future features",
+        ],
+        "scope_not_covered": [
+            "Adaptive trigger timing from thermal model (wake-4h fallback is fixed, not k_active_cool-derived)",
+            "Pre-cool depth does not account for forecast peak hour or solar gains",
+            "Cooling-trend nights (setback_modifier > 0): relaxed setback sign fix also corrects"
+            " those (higher ceiling = less cooling = energy savings) but no new timed phase added",
+        ],
+    },
     321: {
         "version_fixed": "0.4.18",
         "title": "Startup false override, stuck grace, nat-vent thermostat cycling",
@@ -2348,6 +2385,14 @@ DEFAULT_SLEEP_HEAT = 66.0  # comfort_heat(70) - DEFAULT_SETBACK_DEPTH_F(4)
 DEFAULT_SLEEP_COOL = 78.0  # comfort_cool(75) + DEFAULT_SETBACK_DEPTH_COOL_F(3)
 MAX_SETBACK_DEPTH_F = 8.0  # never set back more than this
 SETBACK_RECOVERY_BUFFER_MINUTES = 30  # pre-heat leads wake_time by this much
+
+# ---------------------------------------------------------------------------
+# Overnight Pre-Cool Phase (Issue #258)
+# On warming-trend nights, CA applies a cooler ceiling mid-night to bank thermal mass.
+# ---------------------------------------------------------------------------
+PRE_COOL_POST_NAT_VENT_DELAY_MINUTES: int = 30  # delay after nat-vent window closes before AC pre-cool fires
+PRE_COOL_WAKE_OFFSET_HOURS: float = 4.0  # fallback trigger: this many hours before wake_time
+PRE_COOL_MIN_HEADROOM_F: float = 2.0  # pre-cool target floor = comfort_heat + this (prevents morning heat firing)
 THERMAL_OBS_CAP = 200  # max observations in LearningState
 
 # ---------------------------------------------------------------------------

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -6244,7 +6244,8 @@ def _build_predicted_indoor_future(
     # Compute pre-cool band parameters so the prediction curve tracks the pre-cool setpoint
     _ode_pc_trigger_h: float | None = None
     _ode_pc_target: float | None = None
-    if classification is not None and getattr(classification, "setback_modifier", 0.0) < 0:
+    _setback_mod = getattr(classification, "setback_modifier", None)
+    if isinstance(_setback_mod, (int, float)) and _setback_mod < 0:
         from .const import (
             CONF_SLEEP_COOL,
             PRE_COOL_MIN_HEADROOM_F,

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.event import (
     async_call_later,
+    async_track_point_in_time,
     async_track_state_change_event,
     async_track_time_change,
     async_track_time_interval,
@@ -290,6 +291,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._briefing_day_type: str | None = None
         self._door_open_timers: dict[str, Any] = {}
         self._door_open_timer_expiry: dict[str, str] = {}
+
+        # Overnight pre-cool phase (Issue #258): scheduled once per warming-trend day
+        self._pre_cool_trigger_scheduled: bool = False
+        self._pre_cool_trigger_cancel: Any | None = None
+        self._pre_cool_status: str | None = None  # surfaced in status API
 
         # Startup coalescing (Issue #321): suppress override detection for 5 min after restart
         self._startup_coalesce_active: bool = True
@@ -1552,6 +1558,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         _indoor_temp = self._get_indoor_temp()
         _outdoor_temp = forecast.current_outdoor_temp if forecast else None
 
+        # Schedule overnight pre-cool if a warming trend is active (idempotent — runs once per day)
+        self._maybe_schedule_pre_cool()
+
         next_auto = self._compute_next_automation_action(c)
         fan_running = self.automation_engine._fan_active
         result = {
@@ -1584,6 +1593,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             ATTR_FORECAST_LOW: c.today_low if c else None,
             ATTR_FORECAST_HIGH_TOMORROW: c.tomorrow_high if c else None,
             ATTR_FORECAST_LOW_TOMORROW: c.tomorrow_low if c else None,
+            "pre_cool_status": self._pre_cool_status,
         }
 
         # Append chart log entry (every coordinator tick — 30-min cadence)
@@ -2140,11 +2150,118 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
     async def _async_morning_wakeup(self, now: datetime) -> None:
         """Handle morning wake-up."""
-        await self.automation_engine.handle_morning_wakeup()
+        await self.automation_engine.handle_morning_wakeup(indoor_temp=self._get_indoor_temp())
 
     async def _async_bedtime(self, now: datetime) -> None:
         """Handle bedtime setback."""
         await self.automation_engine.handle_bedtime()
+
+    def _compute_pre_cool_trigger_time(self) -> datetime | None:
+        """Compute the pre-cool trigger time for tonight.
+
+        Primary: nat-vent window close time + PRE_COOL_POST_NAT_VENT_DELAY_MINUTES.
+        Fallback: wake_time - PRE_COOL_WAKE_OFFSET_HOURS.
+        Returns None if there is no warming trend today.
+        """
+        from .const import (
+            CONF_SLEEP_COOL,
+            PRE_COOL_MIN_HEADROOM_F,
+            PRE_COOL_POST_NAT_VENT_DELAY_MINUTES,
+            PRE_COOL_WAKE_OFFSET_HOURS,
+        )
+
+        c = self._current_classification
+        if not c or c.setback_modifier >= 0:
+            return None
+
+        # Verify the pre-cool target would actually differ from sleep_cool
+        sleep_cool = float(self.config.get(CONF_SLEEP_COOL) or self.config.get("sleep_cool", 78.0))
+        comfort_heat = float(self.config.get("comfort_heat", 70.0))
+        pre_cool_target = max(sleep_cool + c.setback_modifier, comfort_heat + PRE_COOL_MIN_HEADROOM_F)
+        if pre_cool_target >= sleep_cool:
+            _LOGGER.info(
+                "Pre-cool scheduling: clamped target (%.1f°F) == sleep_cool (%.1f°F); skipping",
+                pre_cool_target,
+                sleep_cool,
+            )
+            return None
+
+        now = dt_util.now()
+        today = now.date()
+
+        # Primary: nat-vent window close time + delay
+        if c.window_close_time is not None:
+            wct_dt = dt_util.as_local(datetime.combine(today, c.window_close_time).replace(tzinfo=None))
+            # If window close is before midnight (typical), use today; else tomorrow
+            if wct_dt < now:
+                wct_dt = wct_dt + timedelta(days=1)
+            trigger = wct_dt + timedelta(minutes=PRE_COOL_POST_NAT_VENT_DELAY_MINUTES)
+            _LOGGER.info(
+                "Pre-cool scheduled for %s (nat-vent close %s + %dmin); target %.1f°F",
+                trigger.strftime("%H:%M"),
+                c.window_close_time.strftime("%H:%M"),
+                PRE_COOL_POST_NAT_VENT_DELAY_MINUTES,
+                pre_cool_target,
+            )
+            return trigger
+
+        # Fallback: wake_time - offset
+        wake_str = self.config.get("wake_time", "06:30")
+        wake_h, wake_m = int(wake_str.split(":")[0]), int(wake_str.split(":")[1])
+        wake_dt = dt_util.as_local(datetime.combine(today, time(wake_h, wake_m)).replace(tzinfo=None))
+        # If wake_time already passed, schedule for tomorrow night
+        if wake_dt < now:
+            wake_dt = wake_dt + timedelta(days=1)
+        trigger = wake_dt - timedelta(hours=PRE_COOL_WAKE_OFFSET_HOURS)
+        _LOGGER.info(
+            "Pre-cool scheduled for %s (wake_time %s - %.0fh fallback); target %.1f°F",
+            trigger.strftime("%H:%M"),
+            wake_str,
+            PRE_COOL_WAKE_OFFSET_HOURS,
+            pre_cool_target,
+        )
+        return trigger
+
+    def _maybe_schedule_pre_cool(self) -> None:
+        """Schedule the overnight pre-cool trigger if a warming trend is active and not yet scheduled."""
+        if self._pre_cool_trigger_scheduled:
+            return
+        trigger_time = self._compute_pre_cool_trigger_time()
+        if trigger_time is None:
+            return
+        now = dt_util.now()
+        if trigger_time <= now:
+            _LOGGER.info("Pre-cool trigger time %s already passed; skipping scheduling", trigger_time.strftime("%H:%M"))
+            return
+
+        # Build the pre-cool target for status display
+        from .const import CONF_SLEEP_COOL, PRE_COOL_MIN_HEADROOM_F
+
+        c = self._current_classification
+        sleep_cool = float(self.config.get(CONF_SLEEP_COOL) or self.config.get("sleep_cool", 78.0))
+        comfort_heat = float(self.config.get("comfort_heat", 70.0))
+        pre_cool_target = max(sleep_cool + c.setback_modifier, comfort_heat + PRE_COOL_MIN_HEADROOM_F)
+
+        self._pre_cool_trigger_cancel = async_track_point_in_time(self.hass, self._async_pre_cool_trigger, trigger_time)
+        self._pre_cool_trigger_scheduled = True
+        self._pre_cool_status = (
+            f"pre-cool tonight ({pre_cool_target:.0f}°F @ {trigger_time.strftime('%I:%M %p').lstrip('0')})"
+        )
+
+    async def _async_pre_cool_trigger(self, now: datetime) -> None:
+        """Handle the overnight pre-cool trigger point."""
+        nat_vent_just_closed = not self.automation_engine.natural_vent_active
+        indoor_temp = self._get_indoor_temp()
+        result = await self.automation_engine.handle_pre_cool(
+            indoor_temp=indoor_temp,
+            nat_vent_just_closed=nat_vent_just_closed,
+        )
+        _LOGGER.info("Pre-cool trigger handler completed: %s", result)
+        if "suppressed" in result:
+            self._pre_cool_status = result.replace("suppressed: ", "pre-cool suppressed — ")
+        elif "applied" in result:
+            self._pre_cool_status = result.replace("applied: ", "pre-cool active (").rstrip() + ")"
+        await self.async_refresh()
 
     async def _async_end_of_day(self, now: datetime) -> None:
         """Finalize the day's record and reset for tomorrow."""
@@ -2185,6 +2302,14 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._outdoor_temp_history.clear()
         self._indoor_temp_history.clear()
         self._hourly_forecast_temps.clear()
+
+        # Reset pre-cool state for the new day
+        if self._pre_cool_trigger_cancel is not None:
+            self._pre_cool_trigger_cancel()
+            self._pre_cool_trigger_cancel = None
+        self._pre_cool_trigger_scheduled = False
+        self._pre_cool_status = None
+
         await self._async_save_state()
 
     async def _async_door_window_changed(self, event: Event) -> None:
@@ -5074,6 +5199,22 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             except (ValueError, TypeError):
                 continue
 
+        # Compute pre-cool band parameters for chart dip visualization
+        _pc_trigger_h: float | None = None
+        _pc_target: float | None = None
+        if self._current_classification and self._current_classification.setback_modifier < 0:
+            _pc_trigger_time = self._compute_pre_cool_trigger_time()
+            if _pc_trigger_time is not None:
+                _pc_trigger_h = _pc_trigger_time.hour + _pc_trigger_time.minute / 60.0
+                from .const import CONF_SLEEP_COOL, PRE_COOL_MIN_HEADROOM_F
+
+                _pc_sleep_cool = float(self.config.get(CONF_SLEEP_COOL) or self.config.get("sleep_cool", 78.0))
+                _pc_comfort_heat = float(self.config.get("comfort_heat", 70.0))
+                _pc_target = max(
+                    _pc_sleep_cool + self._current_classification.setback_modifier,
+                    _pc_comfort_heat + PRE_COOL_MIN_HEADROOM_F,
+                )
+
         _raw_band = list(
             _compute_target_band_schedule(
                 _band_timestamps,
@@ -5087,6 +5228,8 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 ),
                 thermal_model=thermal_model,
                 classification=self._current_classification,
+                pre_cool_trigger_h=_pc_trigger_h,
+                pre_cool_target=_pc_target,
             )
         )
         _hvac_mode = getattr(self._current_classification, "hvac_mode", None) if self._current_classification else None
@@ -5745,6 +5888,8 @@ def _compute_target_band_schedule(
     setback_modifier: float = 0.0,
     thermal_model: dict | None = None,
     classification: Any | None = None,
+    pre_cool_trigger_h: float | None = None,
+    pre_cool_target: float | None = None,
 ) -> list[dict]:
     """Compute the dynamic target band (lower/upper) for each hourly timestamp.
 
@@ -5819,9 +5964,12 @@ def _compute_target_band_schedule(
             h_n = h + 24 if (night_owl and h < wake_h) else h
 
             if h_n < wake_h:
-                # Pre-wake: sleep band
+                # Pre-wake: sleep band; apply pre-cool ceiling from trigger time onward
                 lower = sleep_heat
-                upper = sleep_cool
+                if pre_cool_trigger_h is not None and pre_cool_target is not None and h_n >= pre_cool_trigger_h:
+                    upper = pre_cool_target
+                else:
+                    upper = sleep_cool
             elif h_n < wake_h + wake_ramp_h:
                 # Wake ramp: interpolate toward comfort
                 frac = (h_n - wake_h) / wake_ramp_h
@@ -5837,9 +5985,12 @@ def _compute_target_band_schedule(
                 lower = comfort_heat + frac * (sleep_heat - comfort_heat)
                 upper = comfort_cool + frac * (sleep_cool - comfort_cool)
             else:
-                # Post-sleep: sleep band
+                # Post-sleep: sleep band; apply pre-cool ceiling from trigger time onward
                 lower = sleep_heat
-                upper = sleep_cool
+                if pre_cool_trigger_h is not None and pre_cool_target is not None and h_n >= pre_cool_trigger_h:
+                    upper = pre_cool_target
+                else:
+                    upper = sleep_cool
 
         result.append({"ts": ts.isoformat(), "lower": round(lower, 1), "upper": round(upper, 1)})
 
@@ -6090,6 +6241,31 @@ def _build_predicted_indoor_future(
                 _future_timestamps_for_band.append(_lts)
         except (ValueError, TypeError):
             pass
+    # Compute pre-cool band parameters so the prediction curve tracks the pre-cool setpoint
+    _ode_pc_trigger_h: float | None = None
+    _ode_pc_target: float | None = None
+    if classification is not None and getattr(classification, "setback_modifier", 0.0) < 0:
+        from .const import (
+            CONF_SLEEP_COOL,
+            PRE_COOL_MIN_HEADROOM_F,
+            PRE_COOL_POST_NAT_VENT_DELAY_MINUTES,
+            PRE_COOL_WAKE_OFFSET_HOURS,
+        )
+
+        _wct = getattr(classification, "window_close_time", None)
+        if _wct is not None:
+            _ode_pc_trigger_h = _wct.hour + _wct.minute / 60.0 + PRE_COOL_POST_NAT_VENT_DELAY_MINUTES / 60.0
+        else:
+            _wake_str = config.get("wake_time", "06:30")
+            _wake_h_raw = int(_wake_str.split(":")[0]) + int(_wake_str.split(":")[1]) / 60.0
+            _ode_pc_trigger_h = _wake_h_raw - PRE_COOL_WAKE_OFFSET_HOURS
+        _ode_sc = float(config.get(CONF_SLEEP_COOL) or config.get("sleep_cool", 78.0))
+        _ode_ch = float(config.get("comfort_heat", 70.0))
+        _ode_pc_target = max(
+            _ode_sc + classification.setback_modifier,
+            _ode_ch + PRE_COOL_MIN_HEADROOM_F,
+        )
+
     _band_schedule = _compute_target_band_schedule(
         _future_timestamps_for_band,
         _band_config,
@@ -6097,6 +6273,8 @@ def _build_predicted_indoor_future(
         now,
         thermal_model=thermal_model,
         classification=classification,
+        pre_cool_trigger_h=_ode_pc_trigger_h,
+        pre_cool_target=_ode_pc_target,
     )
     _band_lookup: dict[str, dict] = {b["ts"]: b for b in _band_schedule}
 

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -905,7 +905,7 @@
         </div>
         <div class="status-item">
           <div class="label">Status</div>
-          <div class="value">${data.automation_status || 'unknown'}</div>
+          <div class="value">${data.automation_status || 'unknown'}${data.pre_cool_status ? `<br><span style="font-size:0.8rem;opacity:0.85">${escapeHtml(data.pre_cool_status)}</span>` : ''}</div>
         </div>
         <div class="status-item">
           <div class="label">Indoor</div>

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.18"
+  "version": "0.4.19"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -24,6 +24,7 @@ The automation logic table and all threshold constants in this document are expr
 | What temperature thresholds map to each day type? | HOT ≥ 85°F, WARM ≥ 75°F, MILD ≥ 60°F, COOL ≥ 45°F, COLD < 45°F; all thresholds are °F constants in `const.py`. | [§1. Day Classification](08-COMPUTATION-REFERENCE.md#1-day-classification) |
 | How is the setback modifier computed and what values can it take? | `avg_delta = ((tomorrow_high − today_high) + (tomorrow_low − today_low)) / 2`; modifier ranges from −3.0 (strong warming) to +3.0 (significant cold front); stable trend → 0. | [§3. Setback Modifier](08-COMPUTATION-REFERENCE.md#3-setback-modifier) |
 | What is the bedtime setpoint formula and when does the thermal model change it? | Default: `comfort_heat − 4°F` (heat) / `comfort_cool + 3°F` (cool). When thermal model confidence ≥ "low", `compute_bedtime_setback()` scales depth from `heating_rate_f_per_hour × recovery_window_hours`, clamped to `[MIN_SETBACK_DEPTH, MAX_SETBACK_DEPTH]`. | [§5a. Adaptive Bedtime Setback](08-COMPUTATION-REFERENCE.md#5a-adaptive-bedtime-setback-compute_bedtime_setback) |
+| When and how does CA pre-cool the home on warming-trend nights? | Mid-night trigger (nat-vent close + 30 min, or wake − 4 h fallback); target = `sleep_cool + setback_modifier` floored at `comfort_heat + 2°F`. AC suppressed if nat-vent already reached target. Morning guard emits `pre_cool_overshoot` if indoor < `comfort_heat` at wake-up. | [§5a-i. Overnight Pre-Cool Phase](08-COMPUTATION-REFERENCE.md#5a-i-overnight-pre-cool-phase-issue-258) |
 | How does the physics ODE predict future indoor temperature? | `T(t+dt) = T_outdoor + (T − T_outdoor) × exp(k_p × dt) + (Q/k_p) × (exp(k_p × dt) − 1)`, where Q switches between k_active_heat, k_active_cool, and 0 per schedule period. | [§5c. Predicted Temperature Graph — Physics Path](08-COMPUTATION-REFERENCE.md#5c-predicted-temperature-graph--physics-path) |
 | What is the dynamic target band and how does occupancy mode change it? | `_compute_target_band_schedule()` returns `[{ts, lower, upper}]` per forecast hour; away = setback today only, vacation = deep setback all days, home/guest = comfort with sleep/wake ramps. | [§5d. Dynamic Target Band](08-COMPUTATION-REFERENCE.md#5d-dynamic-target-band--_compute_target_band_schedule) |
 | How does comfort score accumulate and what triggers a suggestion? | `comfort_score = 1 − (total_violation_minutes / (days_recorded × 1440))`; more than 5 days with > 30 violation minutes triggers the `comfort_violations` suggestion. | [§Metric Definitions — Comfort Score](05-LEARNING-ENGINE-DESIGN.md#comfort-score-comfort_score) |
@@ -157,6 +158,51 @@ Bedtime setback depth is computed from the thermal model HVAC rates and the over
 `heating_rate_f_per_hour` and `cooling_rate_f_per_hour` are the legacy alias fields returned by `get_thermal_model()` — they equal `abs(k_active_heat)` and `abs(k_active_cool)` respectively. Both are `None` when no model data is available, which triggers the fallback.
 
 `setback_modifier` is always added to the heat setback result regardless of whether the model or the fallback was used.
+
+**Cool-mode sign convention (Issue #258):** For cool-mode nights, `setback_modifier < 0` means a warming trend — the next day will be hotter. The modifier is applied as `sleep_cool + setback_modifier`, which _lowers_ the cool ceiling (more aggressive cooling, thermal mass banking). A _positive_ modifier (cooling trend) _raises_ the ceiling (relaxed setback, AC cycles less). No sign flip is applied in cool mode.
+
+### 5a-i. Overnight Pre-Cool Phase (Issue #258)
+
+On warming-trend nights (`setback_modifier < 0`), the coordinator schedules a second setpoint change mid-night — after nat-vent has had its window — to bank cold thermal mass before the afternoon peak:
+
+**Trigger timing** (coordinator `_compute_pre_cool_trigger_time()`):
+
+| Condition | Trigger time |
+|---|---|
+| `classification.window_close_time` is set (nat-vent configured) | `window_close_time + PRE_COOL_POST_NAT_VENT_DELAY_MINUTES (30 min)` — gives nat-vent a complete window first |
+| No nat-vent config | `wake_time − PRE_COOL_WAKE_OFFSET_HOURS (4 h)` — fallback |
+| `setback_modifier >= 0` | No trigger scheduled (no warming trend) |
+
+**Target formula** (`handle_pre_cool()` in `automation.py`):
+
+```
+raw_target  = sleep_cool + setback_modifier          # modifier is negative → lower ceiling
+floor       = comfort_heat + PRE_COOL_MIN_HEADROOM_F  # default: comfort_heat + 2°F
+pre_cool_target = max(raw_target, floor)              # clamp prevents morning heating
+```
+
+The floor guard prevents the home from dropping so far below `comfort_heat` that the heat fires at wake-up (doubly wasteful: night AC + morning heat).
+
+**Nat-vent bypass condition:** If the pre-cool trigger fires with `nat_vent_just_closed=True` AND `indoor_temp ≤ pre_cool_target`, the AC service call is suppressed — free cooling via open windows already achieved the target. Event `pre_cool_suppressed_nat_vent` is emitted.
+
+**Applied path:** `_apply_comfort_band(ComfortBand(floor=sleep_heat, ceiling=pre_cool_target, active="ceiling"))` — the heat floor is preserved from the current sleep band. Event `pre_cool_applied` is emitted with `{target, modifier, sleep_cool, floor, indoor, nat_vent_suppressed}`.
+
+**Skip conditions:**
+
+| Condition | Result |
+|---|---|
+| `setback_modifier >= 0` (stable or cooling trend) | Skip silently |
+| Occupancy is `away` or `vacation` | Skip (setback already active) |
+| `_manual_override_active` | Skip (user in control) |
+| `indoor_temp is None` with `nat_vent_just_closed=True` | No bypass possible → apply setpoint |
+
+**Morning guard:** `handle_morning_wakeup(indoor_temp=...)` now accepts the current indoor temperature. If `indoor_temp < comfort_heat` at wake-up, event `pre_cool_overshoot` is emitted (diagnostic) and the heat may fire. The floor guard on `pre_cool_target` is the primary prevention; the morning guard is observability for cases where thermal drift exceeded the floor.
+
+**Status visibility:** Coordinator exposes `pre_cool_status` string in `_async_update_data()` result dict → `api.py` status response → dashboard Automation Status card (secondary line when non-null). Values: `"pre-cool tonight (75°F @ 2:30 AM)"` / `"pre-cool active (75°F ceiling)"` / `"pre-cool suppressed · nat-vent cooled to 74°F"` / `null` (no warming trend).
+
+**Chart:** `_compute_target_band_schedule()` accepts `pre_cool_trigger_h` and `pre_cool_target` params. When non-null, the band ceiling steps down from `sleep_cool` to `pre_cool_target` at the trigger hour and holds until `wake_time`.
+
+**Test coverage:** `tests/test_pre_cool.py`; golden scenarios `warming_trend_pre_cool_applied` and `warming_trend_pre_cool_nat_vent_bypass` (Issue #258).
 
 ### 5b. Adaptive Pre-heat Start Time
 

--- a/tests/test_hvac_session_detection.py
+++ b/tests/test_hvac_session_detection.py
@@ -277,6 +277,9 @@ def _make_update_data_coord(*, hvac_mode: str, hvac_action: str, ca_fan_active: 
     coord._sample_all_observations = MagicMock()
     coord._check_hvac_stabilization = AsyncMock()
 
+    coord._pre_cool_trigger_scheduled = False
+    coord._pre_cool_trigger_cancel = None
+    coord._pre_cool_status = None
     coord._event_log = []
     coord.data = None  # Required by _detect_and_emit_incidents (called from _async_update_data)
     coord._async_update_data = types.MethodType(ClimateAdvisorCoordinator._async_update_data, coord)

--- a/tests/test_pre_cool.py
+++ b/tests/test_pre_cool.py
@@ -1,0 +1,527 @@
+"""Tests for the overnight pre-cool phase (Issue #258).
+
+Covers:
+  - compute_bedtime_setback() cool-mode sign convention (warming trend = lower ceiling)
+  - handle_pre_cool() target formula, nat-vent bypass, floor clamp
+  - handle_pre_cool() skip conditions (no classification, no warming trend, away, vacation, override)
+  - handle_morning_wakeup() indoor_temp parameter passed through
+  - No crash when _emit_event_callback is None
+
+Tests are pure unit tests — no HA coordinator or real hass needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# HA stub injection (same pattern as test_bedtime_setback.py)
+# ---------------------------------------------------------------------------
+
+_STUBS = Path(__file__).parent / "stubs"
+if _STUBS.exists() and str(_STUBS) not in sys.path:
+    sys.path.insert(0, str(_STUBS))
+
+# ---------------------------------------------------------------------------
+# Imports
+# ---------------------------------------------------------------------------
+
+from custom_components.climate_advisor.automation import (  # noqa: E402
+    AutomationEngine,
+    compute_bedtime_setback,
+)
+from custom_components.climate_advisor.classifier import DayClassification  # noqa: E402
+from custom_components.climate_advisor.const import (  # noqa: E402
+    DEFAULT_SLEEP_COOL,
+    OCCUPANCY_AWAY,
+    OCCUPANCY_HOME,
+    OCCUPANCY_VACATION,
+    PRE_COOL_MIN_HEADROOM_F,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _consume_coroutine(coro):
+    """Close coroutine to prevent 'never awaited' RuntimeWarning."""
+    coro.close()
+
+
+def _make_engine(config_overrides: dict | None = None) -> AutomationEngine:
+    """Construct an AutomationEngine for pre-cool unit tests."""
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+    hass.states = MagicMock()
+
+    config = {
+        "comfort_heat": 70.0,
+        "comfort_cool": 74.0,
+        "setback_heat": 62.0,
+        "setback_cool": 79.0,
+        "notify_service": "notify.notify",
+        "temp_unit": "fahrenheit",
+        "wake_time": "06:30",
+        "sleep_time": "22:30",
+    }
+    if config_overrides:
+        config.update(config_overrides)
+
+    return AutomationEngine(
+        hass=hass,
+        climate_entity="climate.thermostat",
+        weather_entity="weather.forecast_home",
+        door_window_sensors=[],
+        notify_service=config["notify_service"],
+        config=config,
+    )
+
+
+def _make_classification(
+    hvac_mode: str = "cool",
+    setback_modifier: float = -3.0,
+    day_type: str = "warm",
+    **kwargs,
+) -> DayClassification:
+    """Build a DayClassification bypassing __post_init__ validation."""
+    obj = object.__new__(DayClassification)
+    obj.day_type = day_type
+    obj.hvac_mode = hvac_mode
+    obj.trend_direction = kwargs.get("trend_direction", "warming")
+    obj.trend_magnitude = kwargs.get("trend_magnitude", 3.0)
+    obj.today_high = kwargs.get("today_high", 88.0)
+    obj.today_low = kwargs.get("today_low", 65.0)
+    obj.tomorrow_high = kwargs.get("tomorrow_high", 96.0)
+    obj.tomorrow_low = kwargs.get("tomorrow_low", 70.0)
+    obj.pre_condition = kwargs.get("pre_condition", False)
+    obj.pre_condition_target = kwargs.get("pre_condition_target")
+    obj.windows_recommended = kwargs.get("windows_recommended", False)
+    obj.window_open_time = kwargs.get("window_open_time")
+    obj.window_close_time = kwargs.get("window_close_time")
+    obj.setback_modifier = setback_modifier
+    obj.window_opportunity_morning = kwargs.get("window_opportunity_morning", False)
+    obj.window_opportunity_evening = kwargs.get("window_opportunity_evening", False)
+    obj.window_opportunity_morning_start = None
+    obj.window_opportunity_morning_end = None
+    obj.window_opportunity_evening_start = None
+    obj.window_opportunity_evening_end = None
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Tests: compute_bedtime_setback() sign convention for cool mode
+# ---------------------------------------------------------------------------
+
+
+class TestComputeBedtimeSetbackCoolSignConvention:
+    """Warming trend (setback_modifier < 0) must LOWER the cool ceiling, not raise it.
+
+    Issue #258 root cause: the original code had `setback_modifier = -setback_modifier`
+    for cool mode, causing warming trend to produce a HIGHER ceiling (more energy setback),
+    the opposite of the thermal mass banking intent.
+    """
+
+    _BASE_CONFIG = {
+        "comfort_heat": 70.0,
+        "comfort_cool": 74.0,
+        "setback_cool": 79.0,
+        "setback_heat": 62.0,
+    }
+
+    def test_warming_trend_lowers_cool_ceiling(self):
+        """setback_modifier=-3 on a cool-mode night must produce a ceiling < baseline."""
+        c_baseline = _make_classification(hvac_mode="cool", setback_modifier=0.0)
+        c_warming = _make_classification(hvac_mode="cool", setback_modifier=-3.0)
+
+        baseline = compute_bedtime_setback(self._BASE_CONFIG, {}, c_baseline)
+        warming = compute_bedtime_setback(self._BASE_CONFIG, {}, c_warming)
+
+        assert warming < baseline, (
+            f"Warming trend should produce a LOWER cool ceiling for thermal mass banking, "
+            f"got baseline={baseline}, warming={warming} (warming should be < baseline)"
+        )
+
+    def test_warming_trend_cool_ceiling_correct_value(self):
+        """sleep_cool(78) + modifier(-3) = 75 when explicit sleep_cool is configured."""
+        config = {**self._BASE_CONFIG, "sleep_cool": 78.0}
+        c = _make_classification(hvac_mode="cool", setback_modifier=-3.0)
+
+        result = compute_bedtime_setback(config, {}, c)
+
+        assert result == pytest.approx(75.0), (
+            f"Expected 78 + (-3) = 75°F cool ceiling for thermal mass banking, got {result}"
+        )
+
+    def test_cooling_trend_raises_cool_ceiling(self):
+        """setback_modifier=+2 on a cooling-trend night must raise the cool ceiling (relaxed setback)."""
+        c_baseline = _make_classification(hvac_mode="cool", setback_modifier=0.0)
+        c_cooling = _make_classification(hvac_mode="cool", setback_modifier=2.0)
+
+        baseline = compute_bedtime_setback(self._BASE_CONFIG, {}, c_baseline)
+        cooling = compute_bedtime_setback(self._BASE_CONFIG, {}, c_cooling)
+
+        assert cooling > baseline, (
+            f"Cooling trend should produce a HIGHER cool ceiling (relaxed setback), "
+            f"got baseline={baseline}, cooling={cooling}"
+        )
+
+    def test_heat_mode_warming_trend_still_lowers_heat_floor(self):
+        """In heat mode, warming trend (modifier > 0) raises the heat floor (deeper setback allowed)."""
+        config = {**self._BASE_CONFIG, "sleep_heat": 66.0}
+        c_baseline = _make_classification(hvac_mode="heat", setback_modifier=0.0)
+        c_warming = _make_classification(hvac_mode="heat", setback_modifier=2.0)
+
+        baseline = compute_bedtime_setback(config, {}, c_baseline)
+        warming = compute_bedtime_setback(config, {}, c_warming)
+
+        # For heat mode: modifier > 0 raises the target (warmer overnight, less setback)
+        assert warming > baseline, (
+            f"Heat mode: positive modifier should raise the heat floor "
+            f"(less setback depth), got baseline={baseline}, warming={warming}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_pre_cool() — target formula
+# ---------------------------------------------------------------------------
+
+
+class TestHandlePreCoolTargetFormula:
+    """Verify the pre-cool target computation: sleep_cool + setback_modifier, floored at comfort_heat+2."""
+
+    def test_target_uses_sleep_cool_plus_modifier(self):
+        """Target = sleep_cool(78) + modifier(-3) = 75 with no clamp needed."""
+        engine = _make_engine({"sleep_cool": 78.0, "comfort_heat": 70.0})
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+
+        result = asyncio.run(engine.handle_pre_cool(indoor_temp=76.5, nat_vent_just_closed=False))
+
+        assert result.startswith("applied"), f"Expected applied result, got: {result!r}"
+        applied_events = [(e, d) for e, d in emitted if e == "pre_cool_applied"]
+        assert len(applied_events) == 1
+        _, payload = applied_events[0]
+        assert payload["target"] == pytest.approx(75.0), f"Expected target 78 + (-3) = 75°F, got {payload['target']}"
+
+    def test_target_uses_default_sleep_cool_when_not_configured(self):
+        """Without explicit sleep_cool in config, falls back to DEFAULT_SLEEP_COOL(78)."""
+        engine = _make_engine()  # no sleep_cool in config
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+
+        asyncio.run(engine.handle_pre_cool(indoor_temp=76.5, nat_vent_just_closed=False))
+
+        applied_events = [(e, d) for e, d in emitted if e == "pre_cool_applied"]
+        assert len(applied_events) == 1
+        _, payload = applied_events[0]
+        # DEFAULT_SLEEP_COOL=78 + (-3) = 75
+        assert payload["target"] == pytest.approx(DEFAULT_SLEEP_COOL + (-3.0))
+
+    def test_floor_clamp_prevents_target_below_comfort_heat_plus_headroom(self):
+        """When target < comfort_heat + PRE_COOL_MIN_HEADROOM_F, clamp to floor."""
+        # sleep_cool=72, modifier=-5 → raw=67, floor=70+2=72, clamped to 72
+        engine = _make_engine({"sleep_cool": 72.0, "comfort_heat": 70.0})
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-5.0)
+
+        asyncio.run(engine.handle_pre_cool(indoor_temp=70.0, nat_vent_just_closed=False))
+
+        applied_events = [(e, d) for e, d in emitted if e == "pre_cool_applied"]
+        assert len(applied_events) == 1
+        _, payload = applied_events[0]
+        floor = 70.0 + PRE_COOL_MIN_HEADROOM_F
+        assert payload["target"] == pytest.approx(floor), (
+            f"Expected target clamped to comfort_heat(70)+headroom(2)=72°F, got {payload['target']}"
+        )
+
+    def test_pre_cool_modifier_in_event_payload(self):
+        """Event payload must carry the modifier value for observability."""
+        engine = _make_engine({"sleep_cool": 78.0})
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-2.0)
+
+        asyncio.run(engine.handle_pre_cool(indoor_temp=76.0, nat_vent_just_closed=False))
+
+        applied_events = [(e, d) for e, d in emitted if e == "pre_cool_applied"]
+        assert len(applied_events) == 1
+        _, payload = applied_events[0]
+        assert "modifier" in payload
+        assert payload["modifier"] == pytest.approx(-2.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_pre_cool() — nat-vent bypass
+# ---------------------------------------------------------------------------
+
+
+class TestHandlePreCoolNatVentBypass:
+    """When nat-vent just closed and indoor <= target, suppress AC."""
+
+    def test_bypass_when_nat_vent_closed_and_indoor_at_target(self):
+        """Exact equality: indoor == target → suppress AC (nat-vent got it to target)."""
+        engine = _make_engine({"sleep_cool": 78.0, "comfort_heat": 70.0})
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+        # target = 75.0; indoor exactly at target
+
+        result = asyncio.run(engine.handle_pre_cool(indoor_temp=75.0, nat_vent_just_closed=True))
+
+        assert result.startswith("suppressed"), f"Expected suppressed result, got: {result!r}"
+        suppressed = [(e, d) for e, d in emitted if e == "pre_cool_suppressed_nat_vent"]
+        assert len(suppressed) == 1
+        applied = [(e, d) for e, d in emitted if e == "pre_cool_applied"]
+        assert len(applied) == 0, "Should not emit pre_cool_applied when suppressed"
+
+    def test_bypass_when_nat_vent_closed_and_indoor_below_target(self):
+        """indoor < target → suppress AC (nat-vent over-delivered)."""
+        engine = _make_engine({"sleep_cool": 78.0, "comfort_heat": 70.0})
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+        # target = 75.0; indoor 74 = below target
+
+        result = asyncio.run(engine.handle_pre_cool(indoor_temp=74.0, nat_vent_just_closed=True))
+
+        assert result.startswith("suppressed"), f"Expected suppressed result, got: {result!r}"
+
+    def test_no_bypass_when_nat_vent_closed_but_indoor_above_target(self):
+        """nat_vent_just_closed=True but indoor > target → AC still needed."""
+        engine = _make_engine({"sleep_cool": 78.0, "comfort_heat": 70.0})
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+        # target = 75.0; indoor 76 = above target → AC should run
+
+        result = asyncio.run(engine.handle_pre_cool(indoor_temp=76.0, nat_vent_just_closed=True))
+
+        assert result.startswith("applied"), f"Expected applied result, got: {result!r}"
+
+    def test_no_bypass_when_nat_vent_not_just_closed(self):
+        """nat_vent_just_closed=False: bypass check skipped even if indoor <= target."""
+        engine = _make_engine({"sleep_cool": 78.0, "comfort_heat": 70.0})
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+        # indoor at 74 (below target 75) but nat_vent_just_closed=False → fallback path, AC runs
+
+        result = asyncio.run(engine.handle_pre_cool(indoor_temp=74.0, nat_vent_just_closed=False))
+
+        assert result.startswith("applied"), f"Expected applied result, got: {result!r}"
+
+    def test_bypass_suppressed_event_carries_indoor_and_target(self):
+        """Suppression event must carry indoor and target for observability."""
+        engine = _make_engine({"sleep_cool": 78.0, "comfort_heat": 70.0})
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+
+        asyncio.run(engine.handle_pre_cool(indoor_temp=74.5, nat_vent_just_closed=True))
+
+        suppressed = [(e, d) for e, d in emitted if e == "pre_cool_suppressed_nat_vent"]
+        assert len(suppressed) == 1
+        _, payload = suppressed[0]
+        assert "indoor" in payload
+        assert "target" in payload
+        assert payload["indoor"] == pytest.approx(74.5)
+        assert payload["target"] == pytest.approx(75.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_pre_cool() — skip conditions
+# ---------------------------------------------------------------------------
+
+
+class TestHandlePreCoolSkipConditions:
+    """Pre-cool must be silently skipped in various guard conditions."""
+
+    def test_skip_when_no_classification(self):
+        """No classification → return 'skipped: no warming trend'."""
+        engine = _make_engine()
+        engine._emit_event_callback = lambda *_: None
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = None
+
+        result = asyncio.run(engine.handle_pre_cool(indoor_temp=76.0, nat_vent_just_closed=False))
+
+        assert result.startswith("skipped"), f"Expected skipped, got: {result!r}"
+
+    def test_skip_when_modifier_is_zero(self):
+        """setback_modifier=0 (stable trend) → no pre-cool."""
+        engine = _make_engine()
+        engine._emit_event_callback = lambda *_: None
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=0.0)
+
+        result = asyncio.run(engine.handle_pre_cool(indoor_temp=76.0, nat_vent_just_closed=False))
+
+        assert result.startswith("skipped"), f"Expected skipped for stable trend, got: {result!r}"
+
+    def test_skip_when_modifier_is_positive(self):
+        """setback_modifier=+2 (cooling trend) → no pre-cool (home is already cooling naturally)."""
+        engine = _make_engine()
+        engine._emit_event_callback = lambda *_: None
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=2.0)
+
+        result = asyncio.run(engine.handle_pre_cool(indoor_temp=76.0, nat_vent_just_closed=False))
+
+        assert result.startswith("skipped"), f"Expected skipped for cooling trend, got: {result!r}"
+
+    def test_skip_when_away(self):
+        """AWAY occupancy → skip (setback already active; pre-cool not needed)."""
+        engine = _make_engine()
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_AWAY)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+
+        result = asyncio.run(engine.handle_pre_cool(indoor_temp=76.0, nat_vent_just_closed=False))
+
+        assert result.startswith("skipped"), f"Expected skipped for away, got: {result!r}"
+        applied = [e for e, _ in emitted if e == "pre_cool_applied"]
+        assert len(applied) == 0
+
+    def test_skip_when_vacation(self):
+        """VACATION occupancy → skip."""
+        engine = _make_engine()
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_VACATION)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+
+        result = asyncio.run(engine.handle_pre_cool(indoor_temp=76.0, nat_vent_just_closed=False))
+
+        assert result.startswith("skipped"), f"Expected skipped for vacation, got: {result!r}"
+
+    def test_skip_when_manual_override_active(self):
+        """Manual override active → skip pre-cool (user is in control)."""
+        engine = _make_engine()
+        engine._emit_event_callback = lambda *_: None
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+        engine._manual_override_active = True
+
+        result = asyncio.run(engine.handle_pre_cool(indoor_temp=76.0, nat_vent_just_closed=False))
+
+        assert result.startswith("skipped"), f"Expected skipped for manual override, got: {result!r}"
+
+    def test_no_crash_when_emit_callback_is_none(self):
+        """No crash when _emit_event_callback is None (callback is optional)."""
+        engine = _make_engine({"sleep_cool": 78.0})
+        engine._emit_event_callback = None
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+
+        # Should not raise
+        result = asyncio.run(engine.handle_pre_cool(indoor_temp=76.0, nat_vent_just_closed=False))
+        assert result.startswith("applied")
+
+    def test_no_crash_when_emit_callback_is_none_suppressed(self):
+        """No crash when _emit_event_callback is None and nat-vent bypasses AC."""
+        engine = _make_engine({"sleep_cool": 78.0})
+        engine._emit_event_callback = None
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+
+        result = asyncio.run(engine.handle_pre_cool(indoor_temp=74.0, nat_vent_just_closed=True))
+        assert result.startswith("suppressed")
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_pre_cool() — indoor_temp is None
+# ---------------------------------------------------------------------------
+
+
+class TestHandlePreCoolIndoorTempNone:
+    """When indoor_temp is None, pre-cool must still apply setpoint (no bypass possible)."""
+
+    def test_applies_setpoint_when_indoor_unknown(self):
+        """No indoor temp → cannot evaluate nat-vent bypass → AC runs as safety measure."""
+        engine = _make_engine({"sleep_cool": 78.0, "comfort_heat": 70.0})
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+
+        result = asyncio.run(engine.handle_pre_cool(indoor_temp=None, nat_vent_just_closed=True))
+
+        # Even with nat_vent_just_closed=True, no bypass without indoor temp
+        assert result.startswith("applied"), f"Expected applied when indoor=None, got: {result!r}"
+        applied = [(e, d) for e, d in emitted if e == "pre_cool_applied"]
+        assert len(applied) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_morning_wakeup() — indoor_temp parameter
+# ---------------------------------------------------------------------------
+
+
+class TestHandleMorningWakeupIndoorTemp:
+    """handle_morning_wakeup() now accepts indoor_temp for pre-cool overshoot guard."""
+
+    def test_accepts_indoor_temp_parameter(self):
+        """handle_morning_wakeup(indoor_temp=72.0) must not raise."""
+        engine = _make_engine()
+        engine._emit_event_callback = lambda *_: None
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+
+        # Should not raise
+        asyncio.run(engine.handle_morning_wakeup(indoor_temp=72.0))
+
+    def test_accepts_indoor_temp_none(self):
+        """handle_morning_wakeup(indoor_temp=None) must not raise."""
+        engine = _make_engine()
+        engine._emit_event_callback = lambda *_: None
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+
+        asyncio.run(engine.handle_morning_wakeup(indoor_temp=None))
+
+    def test_overshoot_emits_event_when_indoor_below_comfort_heat(self):
+        """If indoor < comfort_heat at wake-up, emit pre_cool_overshoot event."""
+        engine = _make_engine({"comfort_heat": 70.0})
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+
+        asyncio.run(engine.handle_morning_wakeup(indoor_temp=68.0))  # below comfort_heat=70
+
+        overshoot = [e for e, _ in emitted if e == "pre_cool_overshoot"]
+        assert len(overshoot) == 1, "Expected pre_cool_overshoot event when indoor(68) < comfort_heat(70)"
+
+    def test_no_overshoot_when_indoor_at_or_above_comfort_heat(self):
+        """If indoor >= comfort_heat at wake-up, no pre_cool_overshoot event."""
+        engine = _make_engine({"comfort_heat": 70.0})
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+
+        asyncio.run(engine.handle_morning_wakeup(indoor_temp=70.0))  # exactly at comfort_heat
+
+        overshoot = [e for e, _ in emitted if e == "pre_cool_overshoot"]
+        assert len(overshoot) == 0, "No pre_cool_overshoot event when indoor(70) >= comfort_heat(70)"

--- a/tests/test_target_band.py
+++ b/tests/test_target_band.py
@@ -295,8 +295,9 @@ class TestComputeBedtimeSetbackIntegration:
     def test_compute_bedtime_setback_cool_used_when_model_available(self):
         """With thermal_model + cool classification, sleep upper = compute_bedtime_setback() output.
 
-        Cool path negates setback_modifier: min(sleep_cool + (-modifier), setback_cool)
-        = min(78 + (-2), 80) = 76.0 — less extreme than raw sleep_cool=78.
+        Warming trend (modifier=-2.0) lowers the cool ceiling for thermal mass banking
+        (Issue #258 sign fix): min(sleep_cool + modifier, setback_cool)
+        = min(78 + (-2), 80) = 76.0 — lower than raw sleep_cool=78.
         """
         ts_sleep = _ts(2)  # 02:00 — deep sleep window
         thermal_model = {
@@ -307,7 +308,7 @@ class TestComputeBedtimeSetbackIntegration:
             "heating_rate_f_per_hour": 4.0,
             "cooling_rate_f_per_hour": -4.0,
         }
-        classification = SimpleNamespace(hvac_mode="cool", setback_modifier=2.0)
+        classification = SimpleNamespace(hvac_mode="cool", setback_modifier=-2.0)
         result = _compute_target_band_schedule(
             [ts_sleep],
             _BASE_CONFIG,

--- a/tests/test_temperature_sensors.py
+++ b/tests/test_temperature_sensors.py
@@ -250,6 +250,9 @@ def _make_update_data_coord(
 
     coord._solar_phase_backfill = False  # Issue #310: periodic refit guard
     coord._last_solar_phase_fit_date = None  # Issue #310
+    coord._pre_cool_trigger_scheduled = False
+    coord._pre_cool_trigger_cancel = None
+    coord._pre_cool_status = None
     coord._event_log = []
     coord.data = None  # Required by _detect_and_emit_incidents (called from _async_update_data)
     coord._startup_coalesce_active = False  # Bug 1 (Issue #321)

--- a/tools/sim_harness/outcomes.py
+++ b/tools/sim_harness/outcomes.py
@@ -58,6 +58,15 @@ Mapped (production → legacy):
   override_self_resolved        → override_self_resolved
   override_cleared              → override_cleared
 
+Issue #258 — overnight pre-cool:
+  pre_cool_applied              → pre_cool_applied
+    Payload: {target, modifier, sleep_cool, floor, indoor, nat_vent_suppressed}.
+    target_temp = payload["target"] (the cool ceiling that was applied).
+  pre_cool_suppressed_nat_vent  → pre_cool_suppressed_nat_vent
+    Payload: {indoor, target, modifier}.  No setpoint was applied; nat-vent
+    already brought indoor to or below the pre-cool target.
+    target_temp = None (no service call made).
+
 Occupancy / wakeup (Issue #240 — production emits these directly now):
   occupancy_setback            → setback_applied  (away/vacation)
     P3 payload: {mode, floor, ceiling, occupancy}.  Previously had target_f;
@@ -385,6 +394,14 @@ def _map_event_to_outcome(
 
     if event_type == "override_cleared":
         return ProductionDecision(ts_str, event_type, "override_cleared")
+
+    # --- Overnight pre-cool (Issue #258) ---
+    if event_type == "pre_cool_applied":
+        target = payload.get("target")
+        return ProductionDecision(ts_str, event_type, "pre_cool_applied", float(target) if target is not None else None)
+
+    if event_type == "pre_cool_suppressed_nat_vent":
+        return ProductionDecision(ts_str, event_type, "pre_cool_suppressed_nat_vent")
 
     # --- Unmapped (FINDINGS) — documented, silently skip ---
     if event_type in UNMAPPED_PRODUCTION_EVENTS:

--- a/tools/sim_harness/run_production.py
+++ b/tools/sim_harness/run_production.py
@@ -454,6 +454,17 @@ def _dispatch_event(
         _inject_indoor_temp(fake_hass, climate_entity, indoor_temp)
         asyncio.run(engine.nat_vent_temperature_check(indoor_temp))
 
+    elif etype == "pre_cool":
+        # Issue #258: Dispatch the pre-cool trigger to the production engine.
+        # nat_vent_just_closed=True when the event marks the post-nat-vent trigger;
+        # False when using the wake_time-4h fallback path.
+        indoor_f = event.get("indoor_f")
+        indoor_temp = float(indoor_f) if indoor_f is not None else None
+        if indoor_temp is not None:
+            _inject_indoor_temp(fake_hass, climate_entity, indoor_temp)
+        nat_vent_just_closed = bool(event.get("nat_vent_just_closed", False))
+        asyncio.run(engine.handle_pre_cool(indoor_temp=indoor_temp, nat_vent_just_closed=nat_vent_just_closed))
+
     # All other unknown types are silently ignored (mirrors simulate.py's final `return None`)
 
 

--- a/tools/simulations/golden/MANIFEST.json
+++ b/tools/simulations/golden/MANIFEST.json
@@ -214,8 +214,8 @@
     "issue": 229
   },
   "strong_warming_trend_aggressive_setback": {
-    "sha256": "af4547522c7faad17f77c6a5a070d8b89712a316e89583d45b44813d2be4adf3",
-    "signed": "2026-06-13",
+    "sha256": "ee9b0fa28fd6ef91bfca8865369f7d14989995fcf56a55f38f43e9f12bfee406",
+    "signed": "2026-06-15",
     "issue": 229
   },
   "vacation_mode_full_lifecycle": {
@@ -242,5 +242,15 @@
     "sha256": "80e32b07cbb768c35901f94b3ce416e150f6b039e43319db20e295b54737650c",
     "signed": "2026-06-15",
     "issue": 321
+  },
+  "warming_trend_pre_cool_applied": {
+    "sha256": "4c74ba82269948eac207694d54aeaab7bf2a51b24abc574850dab66b40fac1f6",
+    "signed": "2026-06-15",
+    "issue": 258
+  },
+  "warming_trend_pre_cool_nat_vent_bypass": {
+    "sha256": "0ecee88989fb299e7a443f225be96cd1f85350749586e3aca833a0be2dcd6153",
+    "signed": "2026-06-15",
+    "issue": 258
   }
 }

--- a/tools/simulations/golden/strong_warming_trend_aggressive_setback.json
+++ b/tools/simulations/golden/strong_warming_trend_aggressive_setback.json
@@ -1,6 +1,6 @@
 {
   "name": "strong_warming_trend_aggressive_setback",
-  "description": "Strong warming trend: tomorrow +15F above today. setback_modifier=-3.0 passed via classification event. Bedtime fires at 22:30. Production handle_bedtime() uses select_comfort_band() with DEFAULT_SLEEP_COOL=78F — the modifier is stored in the event payload for transparency but the band uses the configured sleep setpoints, not compute_bedtime_setback(). Verifies classification and bedtime band are both applied correctly.",
+  "description": "Strong warming trend: tomorrow +15F above today. setback_modifier=-3.0 passed via classification event. Bedtime fires at 22:30. Production handle_bedtime() uses select_comfort_band() with DEFAULT_SLEEP_COOL=78F — the band ceiling is unchanged at bedtime. The pre-cool phase (Issue #258) fires separately at wake_time-4h (~02:30) and lowers the cool ceiling to 75F (sleep_cool 78 + modifier -3). This scenario covers classification + bedtime only; warming_trend_pre_cool_applied covers the pre-cool trigger.",
   "source": "synthetic",
   "issue": 229,
   "notes": [
@@ -8,13 +8,14 @@
     "Production handle_bedtime() uses select_comfort_band(in_sleep_window=True), which reads",
     "  sleep_cool = config.get(CONF_SLEEP_COOL, DEFAULT_SLEEP_COOL) = 78.0F (not in scenario config).",
     "  sleep_heat = config.get(CONF_SLEEP_HEAT, DEFAULT_SLEEP_HEAT) = 66.0F (not in scenario config).",
-    "  Sleep band = [66/78]. The setback_modifier is stored in the bedtime_setback event payload for",
-    "  transparency but does not currently change the band ceiling (adaptive wiring is a P3 follow-up).",
+    "  Sleep band = [66/78]. Bedtime applies normal sleep setpoints; the setback_modifier is carried",
+    "  in the bedtime_setback event payload for observability but does not change the bedtime ceiling.",
     "Classification at 14:00: single-setpoint cool mode, temperature=comfort_cool=74F.",
     "  production_temp_at reads the temperature field from the set_temperature action.",
     "Bedtime at 22:30: sleep band [66/78]. production_temp_at returns ceiling (78F) for cool mode",
     "  (active='ceiling' → outcomes.py reads ceiling from bedtime_setback payload).",
-    "Covers Priority 7 warming trend setback from plan abundant-mapping-clarke.md."
+    "Pre-cool phase (not in this scenario): fires at wake_time(06:30) - 4h = 02:30,",
+    "  target = sleep_cool(78) + modifier(-3) = 75F. See warming_trend_pre_cool_applied.json."
   ],
   "config": {
     "comfort_heat": 70,
@@ -42,7 +43,7 @@
     {
       "time": "2026-07-15T22:30:00",
       "type": "bedtime",
-      "note": "Bedtime: select_comfort_band(in_sleep_window=True) → [66/78]. setback_modifier stored in event payload."
+      "note": "Bedtime: select_comfort_band(in_sleep_window=True) → [66/78]. Pre-cool fires separately at 02:30."
     }
   ],
   "assertions": [
@@ -50,19 +51,19 @@
       "at": "2026-07-15T14:00:00",
       "expect": "classification_applied",
       "expect_temp": 74.0,
-      "reason": "Warm-day classification applied: cool mode single-setpoint temperature=74 (comfort_cool). setback_modifier=-3.0 stored in classification for downstream use."
+      "reason": "Warm-day classification applied: cool mode single-setpoint temperature=74 (comfort_cool). setback_modifier=-3.0 stored in classification for downstream use by handle_pre_cool at 02:30."
     },
     {
       "at": "2026-07-15T22:30:00",
       "expect": "setback_applied",
       "expect_temp": 78.0,
-      "reason": "Bedtime sleep band [66/78] applied via select_comfort_band(in_sleep_window=True). cool mode active='ceiling' so production_temp_at returns ceiling=78. setback_modifier=-3.0 is recorded in the bedtime_setback event payload; adaptive wiring to the band ceiling is a P3 follow-up."
+      "reason": "Bedtime sleep band [66/78] applied via select_comfort_band(in_sleep_window=True). cool mode active='ceiling' so production_temp_at returns ceiling=78. Bedtime setpoint is unchanged by setback_modifier — pre-cool fires separately at 02:30 via handle_pre_cool()."
     }
   ],
   "verdict": {
     "type": "positive",
-    "summary": "Warming trend classification and standard sleep band both applied correctly; setback_modifier stored in event payload",
+    "summary": "Warming trend classification and standard sleep band both applied correctly at bedtime; pre-cool thermal mass banking fires separately via handle_pre_cool at 02:30",
     "observed_behavior": "classification_applied (cool mode temperature=74) → setback_applied (sleep band ceiling=78) at bedtime",
-    "expected_behavior": "Classification arms comfort band; bedtime arms sleep band [66/78]. setback_modifier carried in payload for future adaptive wiring."
+    "expected_behavior": "Classification arms comfort band at 74F; bedtime arms sleep band [66/78] at 22:30 (unchanged). Pre-cool lowers ceiling to 75F at 02:30 — see warming_trend_pre_cool_applied.json."
   }
 }

--- a/tools/simulations/golden/warming_trend_pre_cool_applied.json
+++ b/tools/simulations/golden/warming_trend_pre_cool_applied.json
@@ -1,0 +1,77 @@
+{
+  "name": "warming_trend_pre_cool_applied",
+  "description": "Strong warming trend night: setback_modifier=-3.0. Bedtime at 22:30 sets normal sleep band [66/78]. Pre-cool trigger fires at 02:30 (wake_time 06:30 - 4h fallback, no nat-vent config). handle_pre_cool() lowers cool ceiling to 75F (sleep_cool=78 + modifier=-3.0=75F, floor=comfort_heat+2=72F so no clamp). Occupant sleeps through the quiet AC cycle that banks 3F of cold thermal mass before the hot day peaks.",
+  "source": "synthetic",
+  "issue": 258,
+  "notes": [
+    "Config: comfort_heat=70, comfort_cool=74. No explicit sleep_cool/sleep_heat → defaults used:",
+    "  DEFAULT_SLEEP_COOL=78.0, DEFAULT_SLEEP_HEAT=66.0.",
+    "No nat-vent configured (natural_vent_delta absent) → pre-cool uses wake_time-4h fallback.",
+    "  wake_time default = '06:30' → trigger at 02:30.",
+    "Pre-cool target = sleep_cool(78) + modifier(-3.0) = 75.0F.",
+    "  floor = comfort_heat(70) + PRE_COOL_MIN_HEADROOM_F(2.0) = 72.0F.",
+    "  max(75.0, 72.0) = 75.0F — no clamp needed.",
+    "Bedtime band [66/78] at 22:30 is unchanged (handle_bedtime independent of pre-cool).",
+    "Pre-cool emits pre_cool_applied event with target=75.0 and calls _apply_comfort_band([66/75]).",
+    "  action_log: set_temperature with target_temp_high=75.0 (heat_cool dual-setpoint or single cool).",
+    "Scenario effectiveness: if handle_pre_cool() is deleted, pre_cool_applied event never fires",
+    "  and the 02:30 assertion fails — regression caught."
+  ],
+  "config": {
+    "comfort_heat": 70,
+    "comfort_cool": 74,
+    "setback_heat": 62,
+    "setback_cool": 79,
+    "wake_time": "06:30",
+    "sleep_time": "22:30"
+  },
+  "events": [
+    {
+      "time": "2026-07-16T14:00:00",
+      "type": "classification",
+      "day_type": "warm",
+      "hvac_mode": "cool",
+      "setback_modifier": -3.0,
+      "note": "Strong warming trend classification. Tomorrow +15F above today. Modifier=-3.0 seeds handle_pre_cool target."
+    },
+    {
+      "time": "2026-07-16T18:00:00",
+      "type": "temp_update",
+      "indoor_f": 73.0,
+      "outdoor_f": 80.0,
+      "note": "Evening temperatures — AC holding indoor near comfort_cool."
+    },
+    {
+      "time": "2026-07-16T22:30:00",
+      "type": "bedtime",
+      "note": "Bedtime: normal sleep band [66/78] applied. Pre-cool fires separately at 02:30."
+    },
+    {
+      "time": "2026-07-17T02:30:00",
+      "type": "pre_cool",
+      "indoor_f": 76.5,
+      "nat_vent_just_closed": false,
+      "note": "Pre-cool trigger fires (wake_time 06:30 - 4h fallback). indoor=76.5F, target=75F. No nat-vent bypass. AC sets cool ceiling to 75F."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-07-16T22:30:00",
+      "expect": "setback_applied",
+      "expect_temp": 78.0,
+      "reason": "Bedtime sleep band [66/78] — ceiling=78F for cool mode. Pre-cool has not fired yet; sleep setpoints are normal."
+    },
+    {
+      "at": "2026-07-17T02:30:00",
+      "expect": "pre_cool_applied",
+      "expect_temp": 75.0,
+      "reason": "Pre-cool trigger fired: sleep_cool(78) + modifier(-3.0) = 75F. Floor = comfort_heat(70) + 2 = 72F; no clamp. AC sets cool ceiling to 75F to bank cold thermal mass before the hot day. Occupant is asleep; home quietly cools 3F below normal sleep ceiling over 4h before wake-up."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "Bedtime sets normal [66/78] sleep band; pre-cool trigger at 02:30 lowers cool ceiling to 75F for thermal mass banking on a strong warming-trend night",
+    "observed_behavior": "classification_applied (74F) → setback_applied (78F sleep ceiling) → pre_cool_applied (75F cool ceiling)",
+    "expected_behavior": "Bedtime band unchanged at 78F ceiling. 4h before wake-up, handle_pre_cool lowers the cool ceiling to 75F (sleep_cool - |modifier|). Occupant experience: home is 3F cooler at wake-up than on a non-warming-trend night, extending the coast time before afternoon AC kicks in."
+  }
+}

--- a/tools/simulations/golden/warming_trend_pre_cool_nat_vent_bypass.json
+++ b/tools/simulations/golden/warming_trend_pre_cool_nat_vent_bypass.json
@@ -1,0 +1,81 @@
+{
+  "name": "warming_trend_pre_cool_nat_vent_bypass",
+  "description": "Strong warming trend night with nat-vent success: setback_modifier=-3.0. Nat-vent window closes at ~01:30 and the home is already at 74F (below pre-cool target 75F). Pre-cool trigger fires 30min later at 02:00 with nat_vent_just_closed=True. handle_pre_cool() detects indoor(74F) <= target(75F) and suppresses AC — free cooling via open windows already banked the needed thermal mass. Occupant experience: same cool morning achieved with zero AC energy cost.",
+  "source": "synthetic",
+  "issue": 258,
+  "notes": [
+    "Config: comfort_heat=70, comfort_cool=74, natural_vent_delta=3.0.",
+    "  Natural vent configured — nat-vent close triggers the primary path (not wake_time-4h fallback).",
+    "Pre-cool target = sleep_cool(78) + modifier(-3.0) = 75.0F.",
+    "  floor = comfort_heat(70) + PRE_COOL_MIN_HEADROOM_F(2.0) = 72.0F. No clamp.",
+    "Nat-vent bypass condition: nat_vent_just_closed=True AND indoor_f(74.0) <= target(75.0).",
+    "  Both conditions met → pre_cool_suppressed_nat_vent event emitted; no set_temperature call.",
+    "Scenario effectiveness: if the nat-vent bypass is deleted from handle_pre_cool(),",
+    "  the engine emits pre_cool_applied instead of pre_cool_suppressed_nat_vent —",
+    "  the assertion fails and the regression is caught (wasted AC energy that nat-vent already handled)."
+  ],
+  "config": {
+    "comfort_heat": 70,
+    "comfort_cool": 74,
+    "setback_heat": 62,
+    "setback_cool": 79,
+    "natural_vent_delta": 3.0,
+    "wake_time": "06:30",
+    "sleep_time": "22:30"
+  },
+  "events": [
+    {
+      "time": "2026-07-16T14:00:00",
+      "type": "classification",
+      "day_type": "warm",
+      "hvac_mode": "cool",
+      "setback_modifier": -3.0,
+      "note": "Strong warming trend. Modifier=-3.0 seeds pre-cool target of 75F."
+    },
+    {
+      "time": "2026-07-16T18:00:00",
+      "type": "temp_update",
+      "indoor_f": 73.0,
+      "outdoor_f": 80.0,
+      "note": "Evening — AC holding indoor near comfort band."
+    },
+    {
+      "time": "2026-07-16T22:30:00",
+      "type": "bedtime",
+      "note": "Bedtime: sleep band [66/78] applied. Nat-vent expected to open overnight."
+    },
+    {
+      "time": "2026-07-17T01:00:00",
+      "type": "temp_update",
+      "indoor_f": 74.0,
+      "outdoor_f": 65.0,
+      "note": "Overnight: outdoor cooled to 65F, indoor 74F. Nat-vent has been cooling the home (simulated as temp_update; nat-vent open/close sequence deferred to integration track)."
+    },
+    {
+      "time": "2026-07-17T02:00:00",
+      "type": "pre_cool",
+      "indoor_f": 74.0,
+      "nat_vent_just_closed": true,
+      "note": "Pre-cool trigger fires after nat-vent close (nat_vent_close + 30min path). indoor=74F <= target=75F. Nat-vent bypass: suppress AC, free cooling achieved target."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-07-16T22:30:00",
+      "expect": "setback_applied",
+      "expect_temp": 78.0,
+      "reason": "Bedtime sleep band [66/78] — ceiling=78F for cool mode. Nat-vent and pre-cool both pending."
+    },
+    {
+      "at": "2026-07-17T02:00:00",
+      "expect": "pre_cool_suppressed_nat_vent",
+      "reason": "Pre-cool trigger fired with nat_vent_just_closed=True and indoor(74F) <= target(75F). AC suppressed: free cooling via open windows already banked the thermal mass. No energy wasted running AC when nat-vent did the job."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "Nat-vent cooled home to 74F before pre-cool trigger; AC correctly suppressed because free cooling already achieved the pre-cool target of 75F",
+    "observed_behavior": "classification_applied (74F) → setback_applied (78F sleep ceiling) → pre_cool_suppressed_nat_vent (no AC call, indoor=74F)",
+    "expected_behavior": "When nat-vent brings indoor to or below the pre-cool target before the trigger fires, handle_pre_cool() emits pre_cool_suppressed_nat_vent and skips the AC service call. Occupant experience: same cool morning as warming_trend_pre_cool_applied, but at zero AC energy cost thanks to overnight nat-vent."
+  }
+}


### PR DESCRIPTION
## Summary

- **Sign fix**: `compute_bedtime_setback()` cool mode had `setback_modifier = -setback_modifier` (flipped), causing warming trend to raise the cool ceiling (wrong direction). Removed.
- **New `handle_pre_cool()` phase**: fires mid-night after nat-vent window closes (or wake_time − 4h fallback), lowers cool ceiling to `sleep_cool + setback_modifier`, floored at `comfort_heat + 2°F` to prevent morning heating
- **Nat-vent bypass**: if nat-vent already cooled home to or below the target when the trigger fires, AC is suppressed entirely (free cooling did the job)
- **Observability**: `pre_cool_status` in coordinator data → API → dashboard Automation Status card; chart target band dips at trigger time; logging at every decision point

## Occupant experience

On a warming-trend night, the home cools 2–3°F below the normal sleep ceiling mid-night while the occupant sleeps. When afternoon heat peaks the next day, the house coasts longer before the AC needs to cycle. If nat-vent did the job overnight, no AC energy is spent.

## Test plan

- [ ] 26 unit tests in `tests/test_pre_cool.py` — sign convention, target formula, floor clamp, nat-vent bypass, skip conditions, morning guard
- [ ] 50/50 golden scenarios passing (2 new: `warming_trend_pre_cool_applied`, `warming_trend_pre_cool_nat_vent_bypass`)
- [ ] Deploy and verify `pre_cool_status` appears in status API on a warming-trend night
- [ ] Verify chart shows target band dip at ~02:30 on warming-trend nights
- [ ] Verify log lines: `Pre-cool trigger fired`, `Pre-cool setpoint applied` or `Pre-cool suppressed`