### PR TITLE
Fix #339: occupancy->away/vacation no longer arms setback while paused by open windows

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -771,6 +771,11 @@ def _render_classification_suppressed_paused(p: dict, unit: str) -> tuple[str, s
     return "Classification suppressed (windows open)", ""
 
 
+def _render_occupancy_setback_suppressed_paused(p: dict, unit: str) -> tuple[str, str]:
+    occupancy = p.get("occupancy", "away")
+    return f"Occupancy setback suppressed (windows open, {occupancy})", ""
+
+
 # Registry: event_type -> renderer
 EVENT_RENDERERS: dict[str, Callable[[dict, str], tuple[str, str]]] = {
     "comfort_band_applied": _render_comfort_band_applied,
@@ -783,6 +788,7 @@ EVENT_RENDERERS: dict[str, Callable[[dict, str], tuple[str, str]]] = {
     "ceiling_guard_fired": _render_ceiling_guard_fired,
     "classification_applied": _render_classification_applied,
     "classification_suppressed_paused": _render_classification_suppressed_paused,
+    "occupancy_setback_suppressed_paused": _render_occupancy_setback_suppressed_paused,
     "setpoint_rejected": _render_setpoint_rejected,
     "override_cleared": _render_override_cleared,
     "override_confirmed": _render_override_confirmed,

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -2719,6 +2719,17 @@ class AutomationEngine:
     async def handle_occupancy_away(self) -> None:
         """Handle everyone leaving — apply setback."""
         self._occupancy_mode = OCCUPANCY_AWAY
+        if self._paused_by_door:
+            _LOGGER.info(
+                "Occupancy away — door/window open (_paused_by_door=True), "
+                "skipping setback band; occupancy recorded, HVAC remains off"
+            )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "occupancy_setback_suppressed_paused",
+                    {"occupancy": "away", "reason": "paused_by_door"},
+                )
+            return
         if self._manual_override_active:
             _LOGGER.info(
                 "Occupancy transition to away — clearing manual override (mode=%s since %s)",
@@ -2806,6 +2817,17 @@ class AutomationEngine:
     async def handle_occupancy_vacation(self) -> None:
         """Handle vacation mode — apply deeper setback for extended away."""
         self._occupancy_mode = OCCUPANCY_VACATION
+        if self._paused_by_door:
+            _LOGGER.info(
+                "Occupancy vacation — door/window open (_paused_by_door=True), "
+                "skipping setback band; occupancy recorded, HVAC remains off"
+            )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "occupancy_setback_suppressed_paused",
+                    {"occupancy": "vacation", "reason": "paused_by_door"},
+                )
+            return
         if self._manual_override_active:
             _LOGGER.info(
                 "Occupancy transition to vacation — clearing manual override (mode=%s since %s)",

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,14 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.31"
+VERSION = "0.4.32"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.32": [
+        "Fix #339: Occupancy→away/vacation no longer arms HVAC setback while windows/doors are open. "
+        "HVAC stays off; occupancy mode is recorded for correct setback on resume. "
+        "Status now shows 'paused — away (setback deferred: windows open)' when both conditions are active.",
+    ],
     "0.4.31": [
         "Fix #338: nat-vent + AC assist — band re-armed when nat-vent activates from pause; "
         "aggressive_savings gate prevents compressor through open windows; "
@@ -475,6 +480,21 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    339: {
+        "version_fixed": "0.4.32",
+        "title": "Occupancy→away/vacation bypasses HVAC pause guard while windows open",
+        "scope_covered": (
+            "handle_occupancy_away() and handle_occupancy_vacation() — _paused_by_door guard added "
+            "after _occupancy_mode is recorded; skips _apply_comfort_band() call; emits "
+            "occupancy_setback_suppressed_paused event. _compute_automation_status() returns combined "
+            "paused+occupancy string when both conditions are active."
+        ),
+        "scope_not_covered": (
+            "handle_occupancy_home() on hot/cool days while paused — if day classification is 'cool' "
+            "or 'heat', _set_temperature_for_mode() may set comfort temps while windows open. "
+            "Separate issue tracked."
+        ),
+    },
     338: {
         "version_fixed": "0.4.31",
         "title": "Nat-vent + AC assist: band re-arm and aggressive_savings ceiling gate",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -4982,6 +4982,10 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             _nt = (_nh + _nc) / 2.0
             return f"windows open · nat-vent (target {_nt:.0f}°F)"
         if self.automation_engine.is_paused_by_door:
+            if self._occupancy_mode == OCCUPANCY_AWAY:
+                return "paused — away (setback deferred: windows open)"
+            if self._occupancy_mode == OCCUPANCY_VACATION:
+                return "paused — vacation (setback deferred: windows open)"
             return "paused — door/window open"
         if self.automation_engine._override_confirm_pending:
             return "override pending (confirming...)"

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.31"
+  "version": "0.4.32"
 }

--- a/docs/07-AUTOMATION-FLOWCHART.md
+++ b/docs/07-AUTOMATION-FLOWCHART.md
@@ -221,6 +221,18 @@ graph TD
 
 **Gate 5 detail (fix #337):** When windows or doors are open and the system is paused, the 30-minute classification cycle previously did nothing — meaning a classification scheduled while the system was already paused could restore comfort temps or change HVAC mode on the next cycle. Gate 5 closes this gap: every 30-minute poll enforces the off state while `_paused_by_door=True`, regardless of day type (hot, cold, mild, warm) and regardless of which path set the flag (direct door sensor open vs. nat-vent exit). If the thermostat is already off, no service call is made. The `classification_suppressed_paused` event is emitted so the coordinator can log and surface the suppression reason.
 
+### 4d. Occupancy Change While Paused (Fix #339)
+
+When occupancy switches to `away` or `vacation` while `_paused_by_door=True` (a door or window is open), the setback band is suppressed. The handlers behave as follows:
+
+- `_occupancy_mode` **is** updated immediately — the new occupancy state is recorded.
+- No setback band service call is made — the thermostat is left at HVAC off (the existing paused state).
+- Event `occupancy_setback_suppressed_paused` is emitted with payload `{occupancy: "away"|"vacation", reason: "paused_by_door"}`.
+- The coordinator status string reflects both states: `"paused — away (setback deferred: windows open)"` or `"paused — vacation (setback deferred: windows open)"`.
+- When sensors eventually close, the resume path calls `_set_temperature_for_mode()`, whose §6a safety net redirects to `handle_occupancy_away()` or `handle_occupancy_vacation()` as appropriate — the deferred setback is applied at that point.
+
+**Why:** Applying a setback band while HVAC is paused for open sensors would re-arm the thermostat in a mode that conflicts with the pause reason. The occupancy state is captured so the correct setback is applied the moment the sensors close and the system resumes.
+
 ---
 
 ## 5. Manual Override Protection

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -694,6 +694,8 @@ The automation engine tracks `_occupancy_mode` internally (synced by the coordin
 
 The `_set_temperature_for_mode()` safety net catches all indirect callers (door/window resume, grace expiry, economizer deactivation) so comfort temps are never applied while away/vacation.
 
+**Paused-by-door guard (Fix #339):** When `_paused_by_door=True`, `handle_occupancy_away()` and `handle_occupancy_vacation()` record `_occupancy_mode` but skip the setback band call and return early. HVAC stays off. The setback is applied when sensors close and the resume path runs `_set_temperature_for_mode()`, which the safety net above redirects to the appropriate occupancy handler. Event emitted: `occupancy_setback_suppressed_paused` with payload `{occupancy: "away"|"vacation", reason: "paused_by_door"}`.
+
 **`handle_bedtime()` skip paths — HVAC mode off (mild/warm nights):** When the current day classification has `hvac_mode = "off"` (mild or warm day, no heating/cooling required), `handle_bedtime()` logs a skip and emits a `bedtime_setback_skipped` event. No setpoint change is made — the comfort floor for the following morning is protected by the 30-min `apply_classification()` guard in §6b rather than a bedtime setpoint.
 
 **Structured skip events (Issue #151):** All skip paths emit `bedtime_setback_skipped` to the event log with a `reason` field:

--- a/tests/test_door_window.py
+++ b/tests/test_door_window.py
@@ -28,6 +28,8 @@ from custom_components.climate_advisor.const import (
     DEFAULT_AUTOMATION_GRACE_SECONDS,
     DEFAULT_MANUAL_GRACE_SECONDS,
     DEFAULT_SENSOR_DEBOUNCE_SECONDS,
+    OCCUPANCY_AWAY,
+    OCCUPANCY_VACATION,
 )
 
 # ---------------------------------------------------------------------------
@@ -879,6 +881,157 @@ class TestGracePeriodExpiry:
 
         assert engine._paused_by_door is True
         engine.hass.services.async_call.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Issue #339 — occupancy setback suppressed while paused by door/window
+# ---------------------------------------------------------------------------
+
+
+class TestOccupancyAwayWhilePaused:
+    """handle_occupancy_away() must not send setback when _paused_by_door=True."""
+
+    def test_occupancy_away_while_paused_no_thermostat_call(self):
+        """No thermostat service call is made when occupancy goes away while paused."""
+        engine = _make_automation_engine()
+        engine._paused_by_door = True
+
+        asyncio.run(engine.handle_occupancy_away())
+
+        engine.hass.services.async_call.assert_not_called()
+
+    def test_occupancy_away_while_paused_records_occupancy(self):
+        """Occupancy mode is updated to away even when setback is suppressed."""
+        engine = _make_automation_engine()
+        engine._paused_by_door = True
+
+        asyncio.run(engine.handle_occupancy_away())
+
+        assert engine._occupancy_mode == OCCUPANCY_AWAY
+
+    def test_occupancy_away_while_paused_emits_suppressed_event(self):
+        """occupancy_setback_suppressed_paused event is emitted with correct payload."""
+        engine = _make_automation_engine()
+        engine._paused_by_door = True
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_occupancy_away())
+
+        suppressed = [e for e in events if e[0] == "occupancy_setback_suppressed_paused"]
+        assert len(suppressed) == 1
+        assert suppressed[0][1] == {"occupancy": "away", "reason": "paused_by_door"}
+
+
+class TestOccupancyVacationWhilePaused:
+    """handle_occupancy_vacation() must not send setback when _paused_by_door=True."""
+
+    def test_occupancy_vacation_while_paused_no_thermostat_call(self):
+        """No thermostat service call is made when occupancy goes vacation while paused."""
+        engine = _make_automation_engine()
+        engine._paused_by_door = True
+
+        asyncio.run(engine.handle_occupancy_vacation())
+
+        engine.hass.services.async_call.assert_not_called()
+
+    def test_occupancy_vacation_while_paused_records_occupancy(self):
+        """Occupancy mode is updated to vacation even when setback is suppressed."""
+        engine = _make_automation_engine()
+        engine._paused_by_door = True
+
+        asyncio.run(engine.handle_occupancy_vacation())
+
+        assert engine._occupancy_mode == OCCUPANCY_VACATION
+
+    def test_occupancy_vacation_while_paused_emits_suppressed_event(self):
+        """occupancy_setback_suppressed_paused event is emitted with correct payload."""
+        engine = _make_automation_engine()
+        engine._paused_by_door = True
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
+
+        asyncio.run(engine.handle_occupancy_vacation())
+
+        suppressed = [e for e in events if e[0] == "occupancy_setback_suppressed_paused"]
+        assert len(suppressed) == 1
+        assert suppressed[0][1] == {"occupancy": "vacation", "reason": "paused_by_door"}
+
+
+class TestAutomationStatusPausedWithOccupancy:
+    """_compute_automation_status() returns occupancy-aware strings when paused."""
+
+    def _compute_automation_status(
+        self,
+        is_paused_by_door: bool,
+        occupancy_mode: str = "home",
+        automation_enabled: bool = True,
+        natural_vent_active: bool = False,
+        startup_coalesce_active: bool = False,
+        within_planned_window: bool = False,
+        any_sensor_open: bool = False,
+        override_confirm_pending: bool = False,
+        grace_active: bool = False,
+        resumed_from_pause: bool = False,
+        last_resume_source: str | None = None,
+    ) -> str:
+        """Inline replication of ClimateAdvisorCoordinator._compute_automation_status()
+        including the Issue #339 occupancy-aware paused strings.
+        """
+        if not automation_enabled:
+            return "disabled"
+        if startup_coalesce_active:
+            return "starting — initializing"
+        if within_planned_window and any_sensor_open:
+            return "windows open (as planned)"
+        if natural_vent_active:
+            return "windows open · nat-vent (target 73°F)"
+        if is_paused_by_door:
+            if occupancy_mode == OCCUPANCY_AWAY:
+                return "paused — away (setback deferred: windows open)"
+            if occupancy_mode == OCCUPANCY_VACATION:
+                return "paused — vacation (setback deferred: windows open)"
+            return "paused — door/window open"
+        if override_confirm_pending:
+            return "override pending (confirming...)"
+        if grace_active:
+            if resumed_from_pause:
+                return "resumed — door/window override"
+            source = last_resume_source or "automation"
+            return f"grace period ({source})"
+        if occupancy_mode == "vacation":
+            return "active (vacation)"
+        if occupancy_mode == "away":
+            return "active (away)"
+        if occupancy_mode == "guest":
+            return "active (guest)"
+        return "active"
+
+    def test_status_paused_away(self):
+        """When paused and occupancy=away, status shows deferred setback message."""
+        status = self._compute_automation_status(
+            is_paused_by_door=True,
+            occupancy_mode=OCCUPANCY_AWAY,
+        )
+        assert status == "paused — away (setback deferred: windows open)"
+
+    def test_status_paused_vacation(self):
+        """When paused and occupancy=vacation, status shows deferred setback message."""
+        status = self._compute_automation_status(
+            is_paused_by_door=True,
+            occupancy_mode=OCCUPANCY_VACATION,
+        )
+        assert status == "paused — vacation (setback deferred: windows open)"
+
+    def test_status_paused_home_still_shows_generic(self):
+        """When paused and occupancy=home, status is the original generic string."""
+        status = self._compute_automation_status(
+            is_paused_by_door=True,
+            occupancy_mode="home",
+        )
+        assert status == "paused — door/window open"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `handle_occupancy_away()` and `handle_occupancy_vacation()` now skip the setback band when `_paused_by_door=True` — occupancy mode is still recorded, HVAC stays off, and `occupancy_setback_suppressed_paused` event is emitted
- `_compute_automation_status()` returns a richer combined string when paused + away/vacation: `"paused — away (setback deferred: windows open)"`
- `ai_skills_activity.py` renderer added for the new event type

## Root cause

In `apply_classification()`, Gate 4 (away/vacation, line 946) calls the occupancy handler and returns before Gate 5 (`_paused_by_door`, line 952) is ever reached. The handlers themselves had no pause check, so direct calls from occupancy change events also bypassed the guard entirely.

## Occupant experience fixed

Before: leaving home with windows open caused CA to arm the thermostat to a setback cooling setpoint in an empty house with open windows.

After: HVAC stays off. Occupancy is recorded. When windows eventually close, the resume path applies the correct setback via the existing `_set_temperature_for_mode()` safety net.

## Test plan

- [ ] `pytest tests/test_door_window.py` — 3 new test classes (9 methods) covering both handlers + status string
- [ ] Full suite: 2781 passed, 0 failed, 0 warnings
- [ ] 50/50 golden simulation scenarios pass
- [ ] `test_version_sync.py` passes (v0.4.31 -> v0.4.32)

## Known gap (not in scope)

`handle_occupancy_home()` on cool/heat days while paused may still set comfort temps with windows open — documented in `KNOWN_FIXES[339].scope_not_covered`. Tracked as a separate issue.