### PR TITLE
Fix #343: remove stale since dates and obs_count from Prediction Engines panel

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,14 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.33"
+VERSION = "0.4.34"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.34": [
+        "Fix #343: Prediction Engines debug panel now shows only confidence level per parameter — "
+        "stale 'since' dates (which were frozen at first observation and never updated on EWMA changes) "
+        "and redundant observation counts have been removed.",
+    ],
     "0.4.33": [
         "Fix #341: nat-vent active during sleep window no longer sets two conflicting thermostat "
         "setpoints every 30 minutes all night — one write per cycle (sleep band) instead of two.",
@@ -489,6 +494,28 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    343: {
+        "version_fixed": "0.4.34",
+        "title": "Remove stale 'since' dates and obs_count from Prediction Engines debug panel",
+        "scope_covered": (
+            "learning.py get_engine_status(): removed _PRE_TRACKING sentinel, _since() helper, "
+            "'since' key from all parameter dicts, 'obs_count' key from parameter dicts; "
+            "_update_thermal_model_cache() and _update_solar_phase_offset(): removed all "
+            "first_active_date_* write blocks and cache default-init keys; "
+            "get_thermal_model(): removed first_active_date_* from return dict; "
+            "index.html: removed obs and since from engineRow() and hvacRow() rendering; "
+            "tools/engine_status.py: removed date_key param from _engine(), removed since column; "
+            "tools/learning_db.py: removed first_active_date display from --model output; "
+            "tests/test_solar_phase.py: removed test_first_active_date_set_on_first_update, "
+            "removed since assertions from test_inactive_before_observations, "
+            "test_active_after_first_observation, and test_engine_status_response_shape."
+        ),
+        "scope_not_covered": (
+            "Existing first_active_date_* values in persisted learning DB JSON files are left in "
+            "place — they become orphaned fields that are no longer read or written. No migration "
+            "removes them; they harmlessly persist until the cache is reset."
+        ),
+    },
     341: {
         "version_fixed": "0.4.33",
         "title": "Dual setpoint thrash + 'Grace started' missing context in activity report",

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -2222,10 +2222,7 @@
         }
         const value = info.value != null ? Number(info.value).toFixed(4) + (unit || '') : '—';
         const conf = info.confidence ? escapeHtml(info.confidence) + ' confidence' : '';
-        const obs = info.obs_count != null ? escapeHtml(String(info.obs_count)) + ' obs' : '';
-        const since = info.since ? 'since ' + escapeHtml(info.since) : '';
-        const detail = [conf, obs, since].filter(Boolean).join(' · ');
-        return `<tr><td>${escapeHtml(label)}</td><td>${escapeHtml(value)}${detail ? '<span class="kv-desc">' + detail + '</span>' : ''}</td></tr>`;
+        return `<tr><td>${escapeHtml(label)}</td><td>${escapeHtml(value)}${conf ? '<span class="kv-desc">' + conf + '</span>' : ''}</td></tr>`;
       }
 
       function hvacRow() {
@@ -2235,8 +2232,7 @@
         }
         const heat = info.value?.heat != null ? Number(info.value.heat).toFixed(4) : '—';
         const cool = info.value?.cool != null ? Number(info.value.cool).toFixed(4) : '—';
-        const since = info.since ? 'since ' + escapeHtml(info.since) : '';
-        return `<tr><td>k_active_hvac</td><td>heat=${escapeHtml(heat)} cool=${escapeHtml(cool)} ${unitSym}/hr${since ? '<span class="kv-desc">' + since + '</span>' : ''}</td></tr>`;
+        return `<tr><td>k_active_hvac</td><td>heat=${escapeHtml(heat)} cool=${escapeHtml(cool)} ${unitSym}/hr</td></tr>`;
       }
 
       const odeVer = escapeHtml(data.ode_version || 'unknown');

--- a/custom_components/climate_advisor/learning.py
+++ b/custom_components/climate_advisor/learning.py
@@ -839,11 +839,6 @@ class LearningEngine:
                 "avg_r_squared_passive": None,
                 "confidence_k_passive": "none",
                 "confidence_k_hvac": "none",
-                "first_active_date_passive": None,
-                "first_active_date_solar": None,
-                "first_active_date_phase_offset": None,
-                "first_active_date_vent_window": None,
-                "first_active_date_hvac": None,
             }
 
         k_p = obs.get("k_passive")
@@ -857,10 +852,6 @@ class LearningEngine:
         if k_p is not None and _envelope_modes:
             if cache["k_passive"] is None:
                 cache["k_passive"] = k_p
-                if cache.get("first_active_date_passive") is None:
-                    from datetime import date as _date
-
-                    cache["first_active_date_passive"] = _date.today().isoformat()
             else:
                 cache["k_passive"] = (1.0 - alpha) * cache["k_passive"] + alpha * k_p
 
@@ -877,20 +868,12 @@ class LearningEngine:
         if mode == "heat" and k_a is not None:
             if cache["k_active_heat"] is None:
                 cache["k_active_heat"] = k_a
-                if cache.get("first_active_date_hvac") is None:
-                    from datetime import date as _date
-
-                    cache["first_active_date_hvac"] = _date.today().isoformat()
             else:
                 cache["k_active_heat"] = (1.0 - alpha) * cache["k_active_heat"] + alpha * k_a
             cache["observation_count_heat"] = cache.get("observation_count_heat", 0) + 1
         elif mode == "cool" and k_a is not None:
             if cache["k_active_cool"] is None:
                 cache["k_active_cool"] = k_a
-                if cache.get("first_active_date_hvac") is None:
-                    from datetime import date as _date
-
-                    cache["first_active_date_hvac"] = _date.today().isoformat()
             else:
                 cache["k_active_cool"] = (1.0 - alpha) * cache["k_active_cool"] + alpha * k_a
             cache["observation_count_cool"] = cache.get("observation_count_cool", 0) + 1
@@ -907,10 +890,6 @@ class LearningEngine:
             if k_p is not None:
                 if cache.get("k_vent_window") is None:
                     cache["k_vent_window"] = k_p
-                    if cache.get("first_active_date_vent_window") is None:
-                        from datetime import date as _date
-
-                        cache["first_active_date_vent_window"] = _date.today().isoformat()
                 else:
                     cache["k_vent_window"] = (1.0 - alpha) * cache["k_vent_window"] + alpha * k_p
             # If this was a 2-param commit, also update k_solar from the separated solar term.
@@ -919,10 +898,6 @@ class LearningEngine:
                 alpha_sol = {"high": 0.3, "medium": 0.15, "low": 0.05}.get(grade, 0.05)
                 if cache["k_solar"] is None:
                     cache["k_solar"] = k_sol
-                    if cache.get("first_active_date_solar") is None:
-                        from datetime import date as _date
-
-                        cache["first_active_date_solar"] = _date.today().isoformat()
                 else:
                     cache["k_solar"] = (1.0 - alpha_sol) * cache["k_solar"] + alpha_sol * k_sol
             cache["observation_count_vent"] = cache.get("observation_count_vent", 0) + 1
@@ -931,10 +906,6 @@ class LearningEngine:
             if k_solar is not None:
                 if cache.get("k_solar") is None:
                     cache["k_solar"] = k_solar
-                    if cache.get("first_active_date_solar") is None:
-                        from datetime import date as _date
-
-                        cache["first_active_date_solar"] = _date.today().isoformat()
                 else:
                     cache["k_solar"] = (1.0 - alpha) * cache["k_solar"] + alpha * k_solar
             cache["observation_count_solar"] = cache.get("observation_count_solar", 0) + 1
@@ -1001,11 +972,6 @@ class LearningEngine:
                 "avg_r_squared_passive": None,
                 "confidence_k_passive": "none",
                 "confidence_k_hvac": "none",
-                "first_active_date_passive": None,
-                "first_active_date_solar": None,
-                "first_active_date_phase_offset": None,
-                "first_active_date_vent_window": None,
-                "first_active_date_hvac": None,
             }
 
         current = cache.get("solar_phase_offset_h")
@@ -1013,10 +979,6 @@ class LearningEngine:
 
         cache["solar_phase_offset_h"] = new_val
         cache["solar_phase_offset_last_obs_date"] = _date.today().isoformat()
-
-        if cache.get("first_active_date_phase_offset") is None:
-            cache["first_active_date_phase_offset"] = _date.today().isoformat()
-
         self._state.thermal_model_cache = cache
 
     def update_ac_duty_solar_phase_offset(self, observed_offset_h: float, today_str: str) -> None:
@@ -1047,7 +1009,7 @@ class LearningEngine:
         """Return structured engine status for each thermal parameter.
 
         Returns a dict with one entry per learnable parameter plus meta keys.
-        Each parameter entry has at minimum: active (bool), since (str|None).
+        Each parameter entry has at minimum: active (bool), confidence (str|None).
         """
         cache = self._state.thermal_model_cache or {}
 
@@ -1059,54 +1021,28 @@ class LearningEngine:
         phase_offset_val = cache.get("solar_phase_offset_h")
         conf_k_passive = _grade_passive_confidence(cache)
 
-        _PRE_TRACKING = "pre-v0.3.46"
-
-        def _since(date_key: str, value) -> str | None:
-            """Return the first_active date, or a retroactive label for pre-existing values."""
-            d = cache.get(date_key)
-            if d is not None:
-                return d
-            if value is not None:
-                # Value exists but date was never recorded — predates first_active tracking.
-                # Retroactively write the date so future calls have it persisted.
-                cache[date_key] = _PRE_TRACKING
-                return _PRE_TRACKING
-            return None
-
         status: dict = {
             "k_passive": {
                 "active": k_passive_val is not None,
                 "value": k_passive_val,
-                "since": _since("first_active_date_passive", k_passive_val),
                 "confidence": conf_k_passive,
-                "obs_count": (
-                    cache.get("observation_count_passive", 0)
-                    + cache.get("observation_count_fan_only", 0)
-                    + cache.get("observation_count_heat", 0)
-                    + cache.get("observation_count_cool", 0)
-                ),
             },
             "k_solar": {
                 "active": k_solar_val is not None,
                 "value": k_solar_val,
-                "since": _since("first_active_date_solar", k_solar_val),
                 "confidence": "none",
-                "obs_count": cache.get("observation_count_solar", 0),
             },
             "solar_phase_offset_h": {
                 "active": phase_offset_val is not None,
                 "value": phase_offset_val,
-                "since": _since("first_active_date_phase_offset", phase_offset_val),
             },
             "k_vent_window": {
                 "active": k_vent_window_val is not None,
                 "value": k_vent_window_val,
-                "since": _since("first_active_date_vent_window", k_vent_window_val),
             },
             "k_active_hvac": {
                 "active": k_active_heat is not None or k_active_cool is not None,
                 "value": {"heat": k_active_heat, "cool": k_active_cool},
-                "since": _since("first_active_date_hvac", k_active_heat or k_active_cool),
             },
         }
 
@@ -1229,11 +1165,6 @@ class LearningEngine:
             "observation_count_swing_cool": cache.get("observation_count_swing_cool", 0),
             "confidence_swing_heat": _grade_swing_confidence(cache.get("observation_count_swing_heat", 0)),
             "confidence_swing_cool": _grade_swing_confidence(cache.get("observation_count_swing_cool", 0)),
-            "first_active_date_passive": cache.get("first_active_date_passive"),
-            "first_active_date_solar": cache.get("first_active_date_solar"),
-            "first_active_date_phase_offset": cache.get("first_active_date_phase_offset"),
-            "first_active_date_vent_window": cache.get("first_active_date_vent_window"),
-            "first_active_date_hvac": cache.get("first_active_date_hvac"),
             "learning_health": learning_health or {},
         }
 

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.33"
+  "version": "0.4.34"
 }

--- a/docs/thermal-model-v3-spec.md
+++ b/docs/thermal-model-v3-spec.md
@@ -16,7 +16,7 @@
 | How does the dual-estimator framework select between endpoint and block-averaged OLS per overnight window? | Both estimators always run; an 8-row decision table selects based on R²_B and 30% relative agreement. On disagreement, Estimator A (endpoint) wins. On R²_B ≥ 0.50 and agreement, B wins with medium grade (α=0.15). | [§Dual Estimator Framework](#dual-estimator-framework) |
 | Where is the solar factor formula defined and what does `phase_offset_h` do? | `_solar_factor(local_hour, phase_offset_h)` shifts the sinusoidal solar input peak by `phase_offset_h` hours. With the default offset=2 the peak falls at local hour 15 (3pm) instead of 13 (1pm). | [§Solar Factor](#solar-factor) |
 | How is `solar_phase_offset_h` learned from chart_log? | Daytime passive windows (HVAC off, fan off, windows closed) are scanned for the indoor temperature peak hour. `phase_obs = peak_hour − 13` is accumulated via EWMA (α=0.10), clamped to [0, 4]. | [§Solar Phase Offset Learning](#solar-phase-offset-learning) |
-| What is engine visibility and where is it exposed? | `get_engine_status()` returns per-engine `active`, `value`, and `since` fields; `k_passive` and `k_solar` additionally include `confidence` and `obs_count`. Exposed at REST `/api/climate_advisor/engines`, dashboard Debug tab, AI investigator context, and `tools/engine_status.py`. | [§Engine Visibility](#engine-visibility) |
+| What is engine visibility and where is it exposed? | `get_engine_status()` returns per-engine `active`, `value`, and (for `k_passive`/`k_solar`) `confidence` fields. Exposed at REST `/api/climate_advisor/engines`, dashboard Debug tab, AI investigator context, and `tools/engine_status.py`. | [§Engine Visibility](#engine-visibility) |
 | Why does `k_active_cool` stay `None` despite AC cycling normally? | Two v0.3.50 bugs can cause this: (1) the `"samples": []` key shadow — `_start_hvac_observation` created a `"samples"` key that was always returned instead of `"active_samples"`; (2) startup recovery discarded all HVAC pending obs by reading the wrong key. Both fixed in v0.3.50. Check `--rejections --type hvac_cool` for `n=0` entries with elapsed > 0. | [§Observation Pipeline Failure Modes](#observation-pipeline-failure-modes) |
 | What rejection codes indicate normal operation vs. pipeline failure for HVAC obs types? | `new_session_started` (short-cycling), `plateau_guard` (insufficient post-heat decay), and `n=0 delta_t=0.00°F` (sensor quantization) are expected on some homes. `n=0` with elapsed > 0 in pre-v0.3.50 coordinators indicates the key-shadow bug. | [§Known Rejection Patterns](#known-rejection-patterns) |
 
@@ -647,7 +647,6 @@ A chart_log window is eligible for a phase observation only when all six conditi
 
 - Applies EWMA update to `thermal_model_cache["solar_phase_offset_h"]`
 - On first call (value is `None`), initialises directly: `solar_phase_offset_h = clamp(observed_h, MIN, MAX)`
-- Sets `first_active_date_phase_offset` to today's ISO date string on the first call
 - Thread-safe: called only from the coordinator's async context
 
 ### `_build_learning_health` update
@@ -658,21 +657,7 @@ A chart_log window is eligible for a phase observation only when all six conditi
 
 ## Engine Visibility
 
-**Scope:** `get_engine_status()` in `learning.py`; `first_active_date_*` fields in `thermal_model_cache`; REST endpoint in `api.py`; dashboard card in `index.html`; AI context in `ai_skills_activity.py`; CLI tool `tools/engine_status.py`.
-
-### Per-Parameter Activation Tracking
-
-When `_update_thermal_model_cache` writes a parameter for the first time (transition from `None` → first real value), it also sets the corresponding `first_active_date_*` field to today's ISO date string (e.g., `"2026-04-01"`). The field is never overwritten on subsequent updates.
-
-| Cache field | Tracks first activation of |
-|---|---|
-| `first_active_date_passive` | `k_passive` |
-| `first_active_date_solar` | `k_solar` |
-| `first_active_date_phase_offset` | `solar_phase_offset_h` |
-| `first_active_date_vent_window` | `k_vent_window` |
-| `first_active_date_hvac` | `k_active_heat` or `k_active_cool` (whichever is first) |
-
-All five fields are initialised to `None` in `thermal_model_cache` and included in the learning JSON on every persist cycle.
+**Scope:** `get_engine_status()` in `learning.py`; REST endpoint in `api.py`; dashboard card in `index.html`; AI context in `ai_skills_activity.py`; CLI tool `tools/engine_status.py`.
 
 ### `get_engine_status()` Return Shape
 
@@ -684,30 +669,23 @@ All five fields are initialised to `None` in `thermal_model_cache` and included 
     "active": bool,          # True when k_passive is not None
     "value": float | None,   # current thermal_model_cache["k_passive"]
     "confidence": str,       # "none" | "low" | "medium" | "high"
-    "obs_count": int,        # observation_count_passive + observation_count_fan_only + observation_count_heat + observation_count_cool
-    "since": str | None,     # first_active_date_passive (ISO date) or None
   },
   "k_solar": {
     "active": bool,
     "value": float | None,
     "confidence": str,       # derived from observation_count_solar (same grade thresholds as k_passive)
-    "obs_count": int,        # observation_count_solar
-    "since": str | None,     # first_active_date_solar
   },
   "solar_phase_offset_h": {
     "active": bool,          # True when solar_phase_offset_h is not None
     "value": float | None,
-    "since": str | None,     # first_active_date_phase_offset
   },
   "k_vent_window": {
     "active": bool,
     "value": float | None,
-    "since": str | None,     # first_active_date_vent_window
   },
   "k_active_hvac": {
     "active": bool,                                  # True when k_active_heat or k_active_cool is not None
     "value": {"heat": float | None, "cool": float | None},  # k_active_heat and k_active_cool
-    "since": str | None,                             # first_active_date_hvac
   },
   "ode_version": str,        # "v3" when k_solar or k_vent present; "basic" otherwise
   "physics_eligible": bool,  # True when the ODE prediction path is currently active
@@ -729,13 +707,13 @@ All five fields are initialised to `None` in `thermal_model_cache` and included 
 | Consumer | Mechanism |
 |---|---|
 | REST API | `GET /api/climate_advisor/engines` returns `get_engine_status()` JSON directly |
-| Dashboard Debug tab | "Prediction Engines" card in `index.html`; table: engine \| active \| value \| confidence \| since; auto-refreshes with status panel |
+| Dashboard Debug tab | "Prediction Engines" card in `index.html`; table: engine \| active \| value \| confidence; auto-refreshes with status panel |
 | AI investigator | `ACTIVE_PREDICTION_ENGINES` section prepended to activity context in `ai_skills_activity.py`; plain-text table for LLM consumption |
 | CLI tool | `tools/engine_status.py` reads learning DB via SSH (same pattern as `tools/learning_db.py`), prints formatted table; `--history` flag also tails `ha_logs.py --thermal` and greps for engine activation events |
 
 ### `get_thermal_model()` additions
 
-`solar_phase_offset_h` and all five `first_active_date_*` fields are included in the `get_thermal_model()` return dict. Downstream consumers (`coordinator.py`, `api.py`, `ai_skills_activity.py`) read from this output, not from `thermal_model_cache` directly.
+`solar_phase_offset_h` is included in the `get_thermal_model()` return dict. Downstream consumers (`coordinator.py`, `api.py`, `ai_skills_activity.py`) read from this output, not from `thermal_model_cache` directly.
 
 ---
 

--- a/tests/test_solar_phase.py
+++ b/tests/test_solar_phase.py
@@ -546,24 +546,6 @@ class TestLearningConvergence:
             "Negative observations must be clamped before EWMA."
         )
 
-    def test_first_active_date_set_on_first_update(self):
-        """first_active_date_phase_offset is set after first update_solar_phase_offset() call."""
-        learning = _make_learning()
-        model_before = learning.get_thermal_model()
-        assert model_before.get("first_active_date_phase_offset") is None, (
-            "first_active_date_phase_offset should be None before any observation"
-        )
-        self._update(learning, 2.0)
-        model_after = learning.get_thermal_model()
-        date_after = model_after.get("first_active_date_phase_offset")
-        assert date_after is not None, (
-            "first_active_date_phase_offset should be set after first update_solar_phase_offset() call"
-        )
-        # Should be an ISO date string (YYYY-MM-DD)
-        assert isinstance(date_after, str) and len(date_after) == 10, (
-            f"Expected ISO date string (YYYY-MM-DD), got {date_after!r}"
-        )
-
 
 # ── TestEngineStatus ─────────────────────────────────────────────────────────
 
@@ -579,7 +561,7 @@ class TestEngineStatus:
         return learning.get_engine_status()
 
     def test_inactive_before_observations(self):
-        """Fresh learning state → all engines inactive, all first_active_date_* = None."""
+        """Fresh learning state → all engines inactive."""
         learning = _make_learning()
         status = self._call_engine_status(learning)
 
@@ -589,8 +571,6 @@ class TestEngineStatus:
             assert not engine.get("active", True), (
                 f"Engine {engine_key!r} should be inactive on fresh learning, got active={engine.get('active')}"
             )
-            since = engine.get("since")
-            assert since is None, f"Engine {engine_key!r} since should be None on fresh learning, got {since!r}"
 
     def test_active_after_first_observation(self):
         """After one k_passive obs via update_solar_phase_offset, phase_offset engine is active.
@@ -607,9 +587,6 @@ class TestEngineStatus:
         phase_engine = status.get("solar_phase_offset_h", {})
         assert phase_engine.get("active") is True, (
             f"solar_phase_offset_h engine should be active after first update, got active={phase_engine.get('active')}"
-        )
-        assert phase_engine.get("since") is not None, (
-            "solar_phase_offset_h engine 'since' should be set after first update"
         )
 
     def test_engine_status_response_shape(self):
@@ -634,7 +611,6 @@ class TestEngineStatus:
             assert key in status, f"Missing engine key {key!r} in get_engine_status() response"
             engine = status[key]
             assert "active" in engine, f"Engine {key!r} missing 'active' field"
-            assert "since" in engine, f"Engine {key!r} missing 'since' field"
 
         for key in required_meta_keys:
             assert key in status, f"Missing meta key {key!r} in get_engine_status() response"

--- a/tools/engine_status.py
+++ b/tools/engine_status.py
@@ -59,46 +59,22 @@ def build_engine_status(cache: dict) -> dict:
     tool falls back to inferring 'active' from whether the value is non-None.
     """
 
-    def _engine(key: str, date_key: str, conf_key: str | None, obs_key: str | None) -> dict:
+    def _engine(key: str, conf_key: str | None) -> dict:
         value = cache.get(key)
         active = value is not None
-        since = cache.get(date_key)
         confidence = cache.get(conf_key) if conf_key else None
-        obs_count = cache.get(obs_key) if obs_key else None
         return {
             "active": active,
             "value": value,
             "confidence": confidence,
-            "obs_count": obs_count,
-            "since": since,
         }
 
-    k_passive = _engine(
-        "k_passive",
-        "first_active_date_passive",
-        "confidence_k_passive",
-        "n_passive",
-    )
-    k_solar = _engine(
-        "k_solar",
-        "first_active_date_solar",
-        None,
-        "n_solar",
-    )
-    solar_phase = _engine(
-        "solar_phase_offset_h",
-        "first_active_date_phase_offset",
-        None,
-        "n_solar_phase",
-    )
-    k_vent_window = _engine(
-        "k_vent_window",
-        "first_active_date_vent_window",
-        None,
-        "n_vent_window",
-    )
+    k_passive = _engine("k_passive", "confidence_k_passive")
+    k_solar = _engine("k_solar", None)
+    solar_phase = _engine("solar_phase_offset_h", None)
+    k_vent_window = _engine("k_vent_window", None)
 
-    # HVAC engines (heat + cool share one activation date)
+    # HVAC engines (heat + cool)
     k_heat = cache.get("k_active_heat")
     k_cool = cache.get("k_active_cool")
     hvac_active = k_heat is not None or k_cool is not None
@@ -107,9 +83,6 @@ def build_engine_status(cache: dict) -> dict:
         "k_active_heat": k_heat,
         "k_active_cool": k_cool,
         "confidence": cache.get("confidence_k_hvac"),
-        "obs_count_heat": cache.get("n_hvac_heat"),
-        "obs_count_cool": cache.get("n_hvac_cool"),
-        "since": cache.get("first_active_date_hvac"),
     }
 
     # ODE version: v3 if any extended params are present
@@ -145,7 +118,6 @@ def build_engine_status(cache: dict) -> dict:
 COL_NAME = 22
 COL_VALUE = 16
 COL_CONF = 12
-COL_OBS = 8
 
 
 def print_engine_status(status: dict) -> None:
@@ -159,13 +131,9 @@ def print_engine_status(status: dict) -> None:
             return
         val = value_override if value_override is not None else _fmt_value(info.get("value"), unit)
         conf = _conf_str(info.get("confidence"))
-        obs = str(info.get("obs_count") or "")
-        since = info.get("since") or "?"
         conf_col = f"{conf} confidence" if conf and conf != "none" else ""
-        obs_col = f"{obs} obs" if obs else ""
-        parts = " | ".join(p for p in [conf_col, obs_col] if p)
-        detail = f" | {parts}" if parts else ""
-        print(f"{_pad(label + ':', COL_NAME)} {_pad(val, COL_VALUE)}{detail} | active since {since}")
+        detail = f" | {conf_col}" if conf_col else ""
+        print(f"{_pad(label + ':', COL_NAME)} {_pad(val, COL_VALUE)}{detail}")
 
     _row("k_passive", status["k_passive"], " hr⁻¹")
     _row("k_solar", status["k_solar"], " °F/hr")
@@ -176,8 +144,7 @@ def print_engine_status(status: dict) -> None:
     if hvac.get("active"):
         heat = _fmt_value(hvac.get("k_active_heat"), " °F/hr")
         cool = _fmt_value(hvac.get("k_active_cool"), " °F/hr")
-        since = hvac.get("since") or "?"
-        print(f"{'k_active (HVAC):':{COL_NAME}} heat={heat} cool={cool} | active since {since}")
+        print(f"{'k_active (HVAC):':{COL_NAME}} heat={heat} cool={cool}")
     else:
         print(f"{'k_active (HVAC):':{COL_NAME}} (not active)")
 

--- a/tools/learning_db.py
+++ b/tools/learning_db.py
@@ -220,17 +220,13 @@ def _print_solar_model_section(db: dict) -> None:
 
     # --- Phase offset ---
     phase_offset = cache.get("solar_phase_offset_h")
-    first_offset_date = cache.get("first_active_date_phase_offset")
     if phase_offset is None:
         print("solar_phase_offset_h:    None  (no phase observations yet)")
     else:
-        since_str = f"  (since {first_offset_date})" if first_offset_date else ""
-        print(f"solar_phase_offset_h:    {phase_offset:.3f} h{since_str}")
+        print(f"solar_phase_offset_h:    {phase_offset:.3f} h")
 
     # --- Committed solar observations + confidence ---
     n_solar = cache.get("observation_count_solar", 0)
-    first_solar_date = cache.get("first_active_date_solar")
-    since_solar = f"  (since {first_solar_date})" if first_solar_date else ""
 
     # Derive confidence_k_solar directly (mirrors learning.py logic)
     if n_solar >= 100:
@@ -242,7 +238,7 @@ def _print_solar_model_section(db: dict) -> None:
     else:
         conf_solar = "none"
 
-    print(f"observation_count_solar: {n_solar}{since_solar}")
+    print(f"observation_count_solar: {n_solar}")
     print(f"confidence_k_solar:      {conf_solar}")
 
     # --- Solar rejection summary ---


### PR DESCRIPTION
## Summary

- **Problem**: Prediction Engines debug panel showed confusing `since pre-v0.3.46` sentinel labels and stale ISO dates. The `first_active_date_*` fields were only set on the very first EWMA write — they were never updated when values changed. `solar_phase_offset_h` changes frequently but its date was frozen from the first observation. The `obs_count` subtext was also redundant with the "Why some measurements were skipped" section already on the Status page.
- **Fix**: Eliminated the `first_active_date_*` feature entirely (no longer written to cache, not returned from API). Parameter rows now show only `confidence` level — the only current, reliable epistemic signal. `obs_count` removed from frontend row rendering.
- **Scope**: `learning.py`, `index.html`, `tools/engine_status.py`, `tools/learning_db.py`, `tests/test_solar_phase.py`, `docs/thermal-model-v3-spec.md`, `const.py`, `manifest.json`.

## User outcome

Before: debug panel shows `since pre-v0.3.46` or stale dates that haven't been updated since first observation, and redundant obs counts.

After: parameter rows show only `confidence` level (e.g. "high confidence") — current, meaningful, programmatic.

## Test plan

- [x] `pytest tests/test_solar_phase.py tests/test_version_sync.py` — 31 passed
- [x] `pytest tests/ -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning` — 2793 passed
- [x] Ruff check + format — clean
- [ ] Reload dashboard Prediction Engines section — confirm only confidence subtext visible, no obs count, no since date