### PR TITLE
Feat #352: Analysis tab — Activity Record, temp columns, unified report dropdown

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -37,6 +37,15 @@ _LOGGER = logging.getLogger(__name__)
 
 _SKILL_NAME = "activity_report"
 
+
+def _fmt_temp_cell(val: Any, unit: str) -> str:
+    """Format a temperature value for a timeline table cell; em-dash when unavailable."""
+    try:
+        return format_temp(float(val), unit)
+    except (TypeError, ValueError):
+        return "—"
+
+
 _SYSTEM_PROMPT = """You are an HVAC automation diagnostic assistant for Climate Advisor, a Home Assistant integration.
 Analyze the provided system state and sensor data.
 Return your analysis with these exact section headers (use ## for headers):
@@ -951,10 +960,12 @@ def build_event_timeline_table(
         filtered.append(entry)
 
     if not filtered:
-        return "| Time | Event | Settings | Source |\n|---|---|---|---|\n| -- | (no events in window) | | |"
+        return "| Time | Event | Settings | Source | Indoor | Outdoor |\n|---|---|---|---|---|---|\n| -- | (no events in window) | | | | |"
 
     # ---- render & deduplicate ----
-    rows: list[tuple[str, str, str, str]] = []  # (time_str, event_text, settings_text, source)
+    rows: list[
+        tuple[str, str, str, str, str, str]
+    ] = []  # (time_str, event_text, settings_text, source, indoor, outdoor)
 
     # Dedup state
     run_type: str | None = None
@@ -963,17 +974,19 @@ def build_event_timeline_table(
     run_last_time: str = ""
     run_settings: str = ""
     run_source: str = ""
+    run_indoor: str = ""
+    run_outdoor: str = ""
 
     def _flush_run() -> None:
-        nonlocal run_type, run_count, run_first_time, run_last_time, run_settings, run_source
+        nonlocal run_type, run_count, run_first_time, run_last_time, run_settings, run_source, run_indoor, run_outdoor
         if run_type is None or run_count == 0:
             return
         if run_count == 1:
-            rows.append((run_first_time, _humanize_type(run_type), run_settings, run_source))
+            rows.append((run_first_time, _humanize_type(run_type), run_settings, run_source, run_indoor, run_outdoor))
         else:
             time_range = f"{run_first_time}-{run_last_time}" if run_first_time != run_last_time else run_first_time
             event_text = f"{_humanize_type(run_type)} x{run_count} ({time_range})"
-            rows.append((run_first_time, event_text, run_settings, run_source))
+            rows.append((run_first_time, event_text, run_settings, run_source, run_indoor, run_outdoor))
         run_type = None
         run_count = 0
 
@@ -994,22 +1007,26 @@ def build_event_timeline_table(
             settings_text = ""
 
         source = _event_source_label(event_type, payload) or "sensor"
+        indoor_cell = _fmt_temp_cell(entry.get("indoor_f"), unit)
+        outdoor_cell = _fmt_temp_cell(entry.get("outdoor_f"), unit)
 
         # Flush run when type changes or type is not deduplicated
         if event_type in _NO_DEDUP or event_type != run_type:
             _flush_run()
             if event_type in _NO_DEDUP:
-                rows.append((time_str, ev_text, settings_text, source))
+                rows.append((time_str, ev_text, settings_text, source, indoor_cell, outdoor_cell))
             else:
-                # Start a new run
+                # Start a new run; temps are from the first event in the run
                 run_type = event_type
                 run_count = 1
                 run_first_time = time_str
                 run_last_time = time_str
                 run_settings = settings_text
                 run_source = source
+                run_indoor = indoor_cell
+                run_outdoor = outdoor_cell
         else:
-            # Continue run -- update last time and settings (last setpoint wins)
+            # Continue run -- update last time and settings (last setpoint wins); temps stay from first event
             run_count += 1
             run_last_time = time_str
             if settings_text:
@@ -1018,12 +1035,12 @@ def build_event_timeline_table(
     _flush_run()
 
     if not rows:
-        return "| Time | Event | Settings | Source |\n|---|---|---|---|\n| -- | (no events in window) | | |"
+        return "| Time | Event | Settings | Source | Indoor | Outdoor |\n|---|---|---|---|---|---|\n| -- | (no events in window) | | | | |"
 
     # ---- format as markdown ----
-    header = "| Time | Event | Settings | Source |"
-    sep = "|---|---|---|---|"
-    row_lines = [f"| {t} | {ev} | {st} | {src} |" for t, ev, st, src in rows]
+    header = "| Time | Event | Settings | Source | Indoor | Outdoor |"
+    sep = "|---|---|---|---|---|---|"
+    row_lines = [f"| {t} | {ev} | {st} | {src} | {ind} | {out} |" for t, ev, st, src, ind, out in rows]
     return "\n".join([header, sep, *row_lines])
 
 

--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -10,6 +10,7 @@ from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant
 
+from .ai_skills_activity import build_event_timeline_table
 from .const import (
     API_AI_ACTIVITY,
     API_AI_INVESTIGATE,
@@ -627,6 +628,42 @@ class ClimateAdvisorAIActivityView(HomeAssistantView):
         return self.json(result)
 
 
+class ClimateAdvisorActivityRecordView(HomeAssistantView):
+    """Deterministic activity record endpoint — no AI required."""
+
+    url = "/api/climate_advisor/activity_record"
+    name = "api:climate_advisor:activity_record"
+    requires_auth = True
+
+    async def get(self, request: web.Request) -> web.Response:
+        hass = request.app["hass"]
+        coordinator = _get_coordinator(hass)
+        if not coordinator:
+            return self.json({"error": "Climate Advisor not loaded"}, status_code=503)
+
+        try:
+            hours = float(request.query.get("hours", 24))
+        except (TypeError, ValueError):
+            hours = 24.0
+        hours = max(1.0, min(hours, 168.0))
+
+        from homeassistant.util import dt as dt_util
+
+        table = build_event_timeline_table(
+            list(getattr(coordinator, "_event_log", []) or []),
+            coordinator.config or {},
+            hours,
+            dt_util.now(),
+        )
+        return self.json(
+            {
+                "table": table,
+                "hours": hours,
+                "generated_at": dt_util.now().isoformat(),
+            }
+        )
+
+
 class ClimateAdvisorAIReportsView(HomeAssistantView):
     """API endpoint for persisted AI report history."""
 
@@ -894,6 +931,7 @@ API_VIEWS = [
     ClimateAdvisorToggleAutomationView,
     ClimateAdvisorAIStatusView,
     ClimateAdvisorAIActivityView,
+    ClimateAdvisorActivityRecordView,
     ClimateAdvisorAIReportsView,
     ClimateAdvisorInvestigateView,
     ClimateAdvisorInvestigationReportsView,

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,15 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.37"
+VERSION = "0.4.38"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.38": [
+        "Feat #352: Analysis tab — single dropdown card replaces three-section layout; "
+        "report type selector (Activity Record / AI Activity Report / AI Investigative Analysis) "
+        "with adaptive time window and controls. Download .md and Submit GitHub Issue available "
+        "for all three types. Debug and Analysis tabs swapped in tab bar order.",
+    ],
     "0.4.37": [
         "Feat #352: Activity Record — new deterministic event timeline (no AI required) "
         "with indoor/outdoor temperature columns. Available on the Analysis tab with "

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.36"
+VERSION = "0.4.37"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.37": [
+        "Feat #352: Activity Record — new deterministic event timeline (no AI required) "
+        "with indoor/outdoor temperature columns. Available on the Analysis tab with "
+        "Copy, Download .md, and Submit GitHub Issue actions. AI Activity Report and "
+        "AI Investigative Analysis now have their own dedicated sections with separate "
+        "generate buttons; AI sections show a disabled notice when AI is not configured. "
+        "Tab renamed from 'AI' to 'Analysis'.",
+    ],
     "0.4.36": [
         "Fix #347: Fan no longer stays running (untracked) indefinitely after thermostat "
         "starts it autonomously between AC cycles. CA now reconciles on every hvac_action "
@@ -504,6 +512,25 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    352: {
+        "version_fixed": "0.4.37",
+        "title": "Activity Report: temp columns, Activity Record endpoint, Analysis tab restructure",
+        "scope_covered": (
+            "coordinator.py _emit_event: enriches every event with indoor_f/outdoor_f at emit time "
+            "using setdefault(); ai_skills_activity.py build_event_timeline_table: adds Indoor/Outdoor "
+            "columns, _fmt_temp_cell() helper; api.py ClimateAdvisorActivityRecordView: new GET endpoint "
+            "/api/climate_advisor/activity_record?hours=N; frontend/index.html: 'AI' tab renamed to "
+            "'Analysis', three-section layout (Activity Record / AI Activity Report / AI Investigative "
+            "Analysis), Download .md buttons on all sections, Full/Brief stub removed, AI disabled state "
+            "wired to loadAIStatus(); tests/test_activity_renderers.py: TestTempColumns (3 tests)."
+        ),
+        "scope_not_covered": (
+            "Activity Record has no server-side pagination — all events in the window are returned. "
+            "Download .md uses Blob/URL.createObjectURL which is unavailable in some non-browser contexts. "
+            "The AI disabled state only reflects the ai_status endpoint response — it does not prevent "
+            "the API call if a user manipulates the DOM directly."
+        ),
+    },
     347: {
         "version_fixed": "0.4.36",
         "title": "Post-startup thermostat-autonomous fan stays running (untracked) indefinitely",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -4865,6 +4865,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
     def _emit_event(self, event_type: str, data: dict) -> None:
         """Append a timestamped event to the in-memory event log ring buffer (Issue #76)."""
         entry: dict[str, Any] = {"time": dt_util.now().isoformat(), "type": event_type, **data}
+        if getattr(self, "config", None):
+            entry.setdefault("indoor_f", self._get_indoor_temp())
+            entry.setdefault("outdoor_f", getattr(self, "_last_outdoor_temp", None))
         self._event_log.append(entry)
         if len(self._event_log) > EVENT_LOG_CAP:
             self._event_log.pop(0)

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -502,7 +502,7 @@
   <button class="tab-btn active" data-tab="status">Status</button>
   <button class="tab-btn" data-tab="debug">Debug</button>
   <button class="tab-btn" data-tab="settings">Settings</button>
-  <button class="tab-btn" data-tab="ai">AI</button>
+  <button class="tab-btn" data-tab="ai">Analysis</button>
 </div>
 
 <div id="tab-status" class="tab-content active">
@@ -654,62 +654,94 @@
     </div>
   </div>
 
-  <!-- Panel A — Controls -->
+  <!-- Section 1 — Activity Record (no AI required) -->
   <div class="card">
-    <h2>Generate Report</h2>
-    <div style="display:flex;gap:12px;align-items:center;margin-bottom:10px;flex-wrap:wrap;">
-      <label style="font-size:0.85rem;color:var(--text-secondary);">Report type:</label>
-      <select id="report-type" onchange="updateReportTypeUI()" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
-        <option value="activity">Activity Report</option>
-        <option value="investigation">Investigative Analysis</option>
-      </select>
-    </div>
+    <h2>Activity Record</h2>
     <div style="display:flex;gap:12px;align-items:center;margin-bottom:10px;flex-wrap:wrap;">
       <label style="font-size:0.85rem;color:var(--text-secondary);">Time window:</label>
-      <select id="report-time-window" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
+      <select id="activity-record-hours" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
         <option value="6">Last 6 hours</option>
         <option value="12">Last 12 hours</option>
         <option value="24" selected>Last 24 hours</option>
         <option value="48">Last 48 hours</option>
         <option value="168">Last 7 days</option>
       </select>
-      <span id="activity-detail-controls" style="display:flex;gap:8px;align-items:center;">
-        <label style="font-size:0.85rem;color:var(--text-secondary);">Detail:</label>
-        <select id="ai-detail" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
-          <option value="full" selected>Full</option>
-          <option value="brief">Brief</option>
-        </select>
-      </span>
+      <button class="btn" onclick="_runActivityRecord()" id="activity-record-btn">Generate</button>
+      <span id="activity-record-status" style="font-size:0.8rem;color:var(--text-secondary);"></span>
     </div>
-    <div id="investigation-focus-controls" style="display:none;margin-bottom:10px;">
+    <div id="activity-record-loading" class="loading" style="display:none;">Building event table&#x2026;</div>
+    <div id="activity-record-content" style="overflow-x:auto;">
+      <p style="color:var(--text-secondary);font-size:0.85rem;">Click Generate to build the event timeline.</p>
+    </div>
+    <div id="activity-record-actions" style="display:none;margin-top:12px;display:flex;gap:8px;flex-wrap:wrap;">
+      <button class="btn secondary" onclick="_copyActivityRecord()" style="font-size:0.8rem;">Copy</button>
+      <button class="btn secondary" onclick="_downloadActivityRecord()" style="font-size:0.8rem;">&#x2B07; Download .md</button>
+      <button class="btn secondary" onclick="downloadFullLogs()" style="font-size:0.8rem;">Download Full Logs</button>
+      <button class="btn secondary" onclick="_githubActivityRecord()" style="font-size:0.8rem;">&#x1F41B; Submit GitHub Issue</button>
+    </div>
+  </div>
+
+  <!-- Section 2 — AI Activity Report -->
+  <div class="card">
+    <h2>AI Activity Report <span style="background:var(--primary);color:#fff;font-size:0.65rem;padding:1px 7px;border-radius:10px;vertical-align:middle;margin-left:4px;">AI</span></h2>
+    <div id="ai-activity-disabled-notice" style="display:none;color:var(--text-secondary);font-size:0.85rem;margin-bottom:10px;padding:8px;background:var(--bg);border-radius:4px;">
+      AI features are not configured. Enable in Settings &#x2192; AI Configuration.
+    </div>
+    <div style="display:flex;gap:12px;align-items:center;margin-bottom:10px;flex-wrap:wrap;">
+      <label style="font-size:0.85rem;color:var(--text-secondary);">Time window:</label>
+      <select id="ai-activity-hours" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
+        <option value="6">Last 6 hours</option>
+        <option value="12">Last 12 hours</option>
+        <option value="24" selected>Last 24 hours</option>
+        <option value="48">Last 48 hours</option>
+      </select>
+      <button class="btn" id="ai-activity-btn" onclick="_runAIActivityReport()">Generate with AI</button>
+      <span id="ai-activity-status" style="font-size:0.8rem;color:var(--text-secondary);"></span>
+    </div>
+    <div id="ai-activity-loading" class="loading" style="display:none;">Generating report&#x2026; this may take 15&#x2013;30 seconds.</div>
+    <div id="ai-activity-content">
+      <p style="color:var(--text-secondary);font-size:0.85rem;">Click Generate with AI to produce a narrative report.</p>
+    </div>
+    <div id="ai-activity-actions" style="display:none;margin-top:12px;gap:8px;flex-wrap:wrap;">
+      <button class="btn secondary" onclick="_copyAIActivity()" style="font-size:0.8rem;">Copy</button>
+      <button class="btn secondary" onclick="_downloadAIActivity()" style="font-size:0.8rem;">&#x2B07; Download .md</button>
+      <button class="btn secondary" onclick="_githubAIActivity()" style="font-size:0.8rem;">&#x1F41B; Submit GitHub Issue</button>
+    </div>
+  </div>
+
+  <!-- Section 3 — AI Investigative Analysis -->
+  <div class="card">
+    <h2>AI Investigative Analysis <span style="background:var(--primary);color:#fff;font-size:0.65rem;padding:1px 7px;border-radius:10px;vertical-align:middle;margin-left:4px;">AI</span></h2>
+    <div id="ai-invest-disabled-notice" style="display:none;color:var(--text-secondary);font-size:0.85rem;margin-bottom:10px;padding:8px;background:var(--bg);border-radius:4px;">
+      AI features are not configured. Enable in Settings &#x2192; AI Configuration.
+    </div>
+    <div style="margin-bottom:10px;">
       <textarea id="investigation-focus"
         placeholder="Optional: describe what you'd like investigated (e.g. 'why is window compliance 0%')..."
         style="width:100%;min-height:60px;padding:0.5rem;border-radius:6px;border:1px solid var(--border);background:var(--bg);color:var(--text);font-size:0.85rem;resize:vertical;box-sizing:border-box;"></textarea>
     </div>
-    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
-      <button class="btn" id="run-report-btn" onclick="runReport()">Run Report</button>
-      <span id="report-run-status" style="font-size:0.8rem;color:var(--text-secondary);"></span>
+    <div style="display:flex;gap:12px;align-items:center;margin-bottom:10px;flex-wrap:wrap;">
+      <label style="font-size:0.85rem;color:var(--text-secondary);">Time window:</label>
+      <select id="ai-invest-hours" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
+        <option value="24">Last 1 day</option>
+        <option value="168" selected>Last 7 days</option>
+        <option value="720">Last 30 days</option>
+      </select>
+      <button class="btn" id="ai-invest-btn" onclick="_runAIInvestigation()">Investigate</button>
+      <span id="ai-invest-status" style="font-size:0.8rem;color:var(--text-secondary);"></span>
     </div>
-    <div id="report-run-loading" class="loading" style="display:none;">Generating report&#x2026; this may take 15&#x2013;30 seconds.</div>
-  </div>
-
-  <!-- Panel B — Preview Pane -->
-  <div class="card" id="report-preview-card">
-    <div id="report-preview-header" style="display:flex;align-items:center;gap:8px;margin-bottom:10px;flex-wrap:wrap;">
-      <h2 style="margin:0;">Report Preview</h2>
+    <div id="ai-invest-loading" class="loading" style="display:none;">Investigating&#x2026; this may take up to a minute.</div>
+    <div id="ai-invest-content">
+      <p style="color:var(--text-secondary);font-size:0.85rem;">Click Investigate to run a deep AI analysis.</p>
     </div>
-    <div id="report-preview-content">
-      <p style="color:var(--text-secondary);font-size:0.85rem;">No report loaded. Select a type above and click Run Report.</p>
-    </div>
-    <div id="report-preview-actions" style="display:none;margin-top:12px;gap:8px;flex-wrap:wrap;">
-      <button class="btn secondary" onclick="copyCurrentReport()" style="font-size:0.8rem;">Copy for Bug Report</button>
-      <button class="btn secondary" onclick="downloadCurrentReport()" style="font-size:0.8rem;">&#x2B07; Download Report</button>
-      <button class="btn secondary" onclick="downloadFullLogs()" style="font-size:0.8rem;">Download Full Logs</button>
-      <button class="btn secondary" id="github-issue-btn" onclick="window.openGithubIssueModal()" style="font-size:0.8rem;">&#x1F41B; Submit GitHub Issue</button>
+    <div id="ai-invest-actions" style="display:none;margin-top:12px;gap:8px;flex-wrap:wrap;">
+      <button class="btn secondary" onclick="_copyAIInvestigation()" style="font-size:0.8rem;">Copy</button>
+      <button class="btn secondary" onclick="_downloadAIInvestigation()" style="font-size:0.8rem;">&#x2B07; Download .md</button>
+      <button class="btn secondary" onclick="_githubAIInvestigation()" style="font-size:0.8rem;">&#x1F41B; Submit GitHub Issue</button>
     </div>
   </div>
 
-  <!-- GitHub Issue Modal -->
+  <!-- GitHub Issue Modal (shared) -->
   <div id="github-issue-modal" style="display:none;position:fixed;inset:0;z-index:10000;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;">
     <div style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:20px;width:min(560px,90vw);max-height:80vh;overflow-y:auto;box-shadow:0 4px 20px rgba(0,0,0,0.4);">
       <h3 style="margin:0 0 12px;">Submit GitHub Issue</h3>
@@ -730,9 +762,9 @@
     </div>
   </div>
 
-  <!-- Panel C — History -->
+  <!-- Report History (AI reports only) -->
   <div class="card">
-    <h2>Report History</h2>
+    <h2>AI Report History</h2>
     <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;margin-bottom:10px;">
       <button class="btn secondary" id="hist-filter-all" onclick="setHistoryFilter('all')" style="font-size:0.8rem;">All</button>
       <button class="btn secondary" id="hist-filter-activity" onclick="setHistoryFilter('activity')" style="font-size:0.8rem;opacity:0.55;">Activity</button>
@@ -2487,54 +2519,82 @@
         <div class="status-item"><div class="label">Auto Today</div><div class="value">${s.auto_requests_today || 0}</div></div>
         <div class="status-item"><div class="label">Manual Today</div><div class="value">${s.manual_requests_today || 0}</div></div>
       `;
+      const aiDisabled = s.status === 'disabled' || !s.status;
+      ['ai-activity-disabled-notice', 'ai-invest-disabled-notice'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.style.display = aiDisabled ? 'block' : 'none';
+      });
+      ['ai-activity-btn', 'ai-invest-btn'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) { el.disabled = aiDisabled; el.style.opacity = aiDisabled ? '0.45' : ''; }
+      });
     } catch (e) {
       document.getElementById('ai-status-loading').textContent = 'Failed to load AI status: ' + e.message;
     }
   }
 
-  function updateReportTypeUI() {
-    const type = document.getElementById('report-type').value;
-    const twSelect = document.getElementById('report-time-window');
-    const detailControls = document.getElementById('activity-detail-controls');
-    const focusControls = document.getElementById('investigation-focus-controls');
-    if (type === 'activity') {
-      twSelect.innerHTML = '<option value="6">Last 6 hours</option>'
-        + '<option value="12">Last 12 hours</option>'
-        + '<option value="24" selected>Last 24 hours</option>'
-        + '<option value="48">Last 48 hours</option>'
-        + '<option value="168">Last 7 days</option>';
-      detailControls.style.display = 'flex';
-      focusControls.style.display = 'none';
-    } else {
-      twSelect.innerHTML = '<option value="24">Last 1 day</option>'
-        + '<option value="168" selected>Last 7 days</option>'
-        + '<option value="720">Last 30 days</option>';
-      detailControls.style.display = 'none';
-      focusControls.style.display = 'block';
+  // ---- Activity Record (deterministic, no AI) ----
+
+  let _activityRecordTable = null;
+
+  async function _runActivityRecord() {
+    const hours = parseInt(document.getElementById('activity-record-hours').value, 10) || 24;
+    const btn = document.getElementById('activity-record-btn');
+    const loading = document.getElementById('activity-record-loading');
+    const status = document.getElementById('activity-record-status');
+    const content = document.getElementById('activity-record-content');
+    const actions = document.getElementById('activity-record-actions');
+    btn.disabled = true;
+    btn.textContent = 'Generating\u2026';
+    loading.style.display = 'block';
+    status.textContent = '';
+    try {
+      const resp = await apiFetch('activity_record?hours=' + hours, { method: 'GET' });
+      _activityRecordTable = resp.table || '';
+      content.innerHTML = _activityRecordTable
+        ? '<div class="report-section" style="overflow-x:auto;">' + renderMarkdown(_activityRecordTable) + '</div>'
+        : '<p style="color:var(--text-secondary);font-size:0.85rem;">No events in the selected window.</p>';
+      actions.style.display = 'flex';
+    } catch (e) {
+      status.textContent = 'Error: ' + e.message;
+    } finally {
+      btn.disabled = false;
+      btn.textContent = 'Generate';
+      loading.style.display = 'none';
     }
   }
 
-  async function runReport() {
-    const type = document.getElementById('report-type').value;
-    if (type === 'activity') {
-      await _runActivityReport();
-    } else {
-      await _runInvestigation();
-    }
+  function _copyActivityRecord() {
+    if (!_activityRecordTable) return;
+    _copyText(_activityRecordTable);
   }
 
-  async function _runActivityReport() {
-    const hours = parseInt(document.getElementById('report-time-window').value, 10) || 24;
-    const detail = document.getElementById('ai-detail').value;
-    const btn = document.getElementById('run-report-btn');
-    const loading = document.getElementById('report-run-loading');
-    const status = document.getElementById('report-run-status');
+  function _downloadActivityRecord() {
+    if (!_activityRecordTable) return;
+    const date = new Date().toISOString().slice(0, 10);
+    downloadMarkdown(_activityRecordTable, 'climate-advisor-activity-record-' + date + '.md');
+  }
+
+  function _githubActivityRecord() {
+    if (!_activityRecordTable) return;
+    document.getElementById('github-issue-title').value = 'Activity Record \u2014 ' + new Date().toLocaleDateString();
+    document.getElementById('github-issue-body').value = '## Activity Record\n\n' + _activityRecordTable + '\n\n---\n*Generated by Climate Advisor*';
+    window.openGithubIssueModal({ skipCurrentReport: true });
+  }
+
+  // ---- AI Activity Report ----
+
+  async function _runAIActivityReport() {
+    const hours = parseInt(document.getElementById('ai-activity-hours').value, 10) || 24;
+    const btn = document.getElementById('ai-activity-btn');
+    const loading = document.getElementById('ai-activity-loading');
+    const status = document.getElementById('ai-activity-status');
     btn.disabled = true;
     btn.textContent = 'Running\u2026';
     loading.style.display = 'block';
     status.textContent = '';
     try {
-      const result = await apiPost('ai_activity', { hours, detail_level: detail });
+      const result = await apiPost('ai_activity', { hours });
       _currentReport = { reportType: 'activity', timestamp: new Date().toISOString(), result };
       renderReportInPreview(_currentReport);
       loadUnifiedHistory();
@@ -2542,17 +2602,35 @@
       status.textContent = 'Error: ' + e.message;
     } finally {
       btn.disabled = false;
-      btn.textContent = 'Run Report';
+      btn.textContent = 'Generate with AI';
       loading.style.display = 'none';
     }
   }
 
-  async function _runInvestigation() {
-    const btn = document.getElementById('run-report-btn');
-    const loading = document.getElementById('report-run-loading');
-    const status = document.getElementById('report-run-status');
+  function _copyAIActivity() {
+    if (!_currentReport || _currentReport.reportType !== 'activity') return;
+    _copyText(_formatCurrentReport());
+  }
+
+  function _downloadAIActivity() {
+    if (!_currentReport || _currentReport.reportType !== 'activity') return;
+    const date = new Date(_currentReport.timestamp).toISOString().slice(0, 10);
+    downloadMarkdown(_formatCurrentReport(), 'climate-advisor-ai-report-' + date + '.md');
+  }
+
+  function _githubAIActivity() {
+    if (!_currentReport || _currentReport.reportType !== 'activity') return;
+    window.openGithubIssueModal();
+  }
+
+  // ---- AI Investigative Analysis ----
+
+  async function _runAIInvestigation() {
+    const btn = document.getElementById('ai-invest-btn');
+    const loading = document.getElementById('ai-invest-loading');
+    const status = document.getElementById('ai-invest-status');
     const focus = document.getElementById('investigation-focus').value.trim();
-    const hours = parseInt(document.getElementById('report-time-window').value, 10) || 168;
+    const hours = parseInt(document.getElementById('ai-invest-hours').value, 10) || 168;
     btn.disabled = true;
     btn.textContent = 'Running\u2026';
     loading.style.display = 'block';
@@ -2593,37 +2671,80 @@
     } finally {
       clearInterval(_stageTimer);
       btn.disabled = false;
-      btn.textContent = 'Run Report';
+      btn.textContent = 'Investigate';
       loading.style.display = 'none';
     }
   }
 
+  function _copyAIInvestigation() {
+    if (!_currentReport || _currentReport.reportType !== 'investigation') return;
+    _copyText(_formatCurrentReport());
+  }
+
+  function _downloadAIInvestigation() {
+    if (!_currentReport || _currentReport.reportType !== 'investigation') return;
+    const date = new Date(_currentReport.timestamp).toISOString().slice(0, 10);
+    downloadMarkdown(_formatCurrentReport(), 'climate-advisor-investigation-' + date + '.md');
+  }
+
+  function _githubAIInvestigation() {
+    if (!_currentReport || _currentReport.reportType !== 'investigation') return;
+    window.openGithubIssueModal();
+  }
+
+  // ---- Shared helpers ----
+
+  function downloadMarkdown(content, filename) {
+    const blob = new Blob([content], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function _copyText(text) {
+    try {
+      navigator.clipboard.writeText(text);
+    } catch (_e) {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+  }
+
   function renderReportInPreview(entry) {
-    const header = document.getElementById('report-preview-header');
-    const content = document.getElementById('report-preview-content');
-    const actions = document.getElementById('report-preview-actions');
-    const typeLabel = entry.reportType === 'investigation' ? '\ud83d\udd2c Investigative Analysis' : 'Activity Report';
+    const isInvestigation = entry.reportType === 'investigation';
+    const contentId = isInvestigation ? 'ai-invest-content' : 'ai-activity-content';
+    const actionsId = isInvestigation ? 'ai-invest-actions' : 'ai-activity-actions';
+    const content = document.getElementById(contentId);
+    const actions = document.getElementById(actionsId);
+    if (!content) return;
     const ts = entry.timestamp ? new Date(entry.timestamp).toLocaleString() : '';
-    const isRefined = entry.result && entry.result.is_refined;
-    const refinedBadge = isRefined
-      ? ' <span style="background:var(--primary);color:#fff;font-size:0.7rem;padding:1px 6px;border-radius:10px;vertical-align:middle;">refined</span>'
-      : '';
-    header.innerHTML = '<h2 style="margin:0;">' + escapeHtml(typeLabel) + '</h2>'
-      + (ts ? '<span style="color:var(--text-secondary);font-size:0.85rem;">' + escapeHtml(ts) + '</span>' : '')
-      + refinedBadge;
     const result = entry.result || {};
     if (!result.success) {
       const err = result.error || 'Unknown error';
       const src = result.source || 'error';
       content.innerHTML = '<p style="color:var(--danger)">Report failed (' + escapeHtml(src) + '): ' + escapeHtml(err) + '</p>';
-      actions.style.display = 'none';
+      if (actions) actions.style.display = 'none';
       return;
     }
+    const isRefined = result.is_refined;
+    const refinedBadge = isRefined
+      ? ' <span style="background:var(--primary);color:#fff;font-size:0.7rem;padding:1px 6px;border-radius:10px;vertical-align:middle;">refined</span>'
+      : '';
+    const tsSpan = ts ? '<div style="color:var(--text-secondary);font-size:0.82rem;margin-bottom:8px;">' + escapeHtml(ts) + refinedBadge + '</div>' : '';
     const data = result.data || {};
     const sourceLabel = result.source === 'fallback'
       ? '<span style="color:var(--warning);font-size:0.8rem">(fallback \u2014 AI unavailable)</span>'
       : '<span style="color:var(--success);font-size:0.8rem">(AI-generated)</span>';
-    let html = '<div style="margin-bottom:8px">' + sourceLabel + '</div>';
+    let html = tsSpan + '<div style="margin-bottom:8px">' + sourceLabel + '</div>';
     if (entry.reportType === 'activity') {
       const sections = ['summary', 'timeline', 'decisions', 'anomalies', 'diagnostics'];
       const sectionLabels = { summary: 'Summary', timeline: 'Timeline', decisions: 'Decisions', anomalies: 'Anomalies', diagnostics: 'Diagnostics' };
@@ -2659,7 +2780,7 @@
       }
     }
     content.innerHTML = html;
-    actions.style.display = 'flex';
+    if (actions) actions.style.display = 'flex';
   }
 
   function escapeHtml(text) {
@@ -2713,18 +2834,7 @@
 
   function copyCurrentReport() {
     if (!_currentReport) return;
-    const text = _formatCurrentReport();
-    const btn = document.querySelector('#report-preview-actions .btn');
-    const orig = btn ? btn.textContent : 'Copy for Bug Report';
-    function showCopied() {
-      if (btn) { btn.textContent = 'Copied!'; setTimeout(() => { btn.textContent = orig; }, 2000); }
-    }
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(text).then(showCopied).catch(() => { fallbackCopy(text); showCopied(); });
-    } else {
-      fallbackCopy(text);
-      showCopied();
-    }
+    _copyText(_formatCurrentReport());
   }
 
   function fallbackCopy(text) {
@@ -2739,11 +2849,8 @@
   }
 
   async function downloadFullLogs() {
-    const hoursEl = document.getElementById('report-time-window');
+    const hoursEl = document.getElementById('activity-record-hours');
     const hours = hoursEl ? parseInt(hoursEl.value, 10) || 24 : 24;
-    const btn = document.querySelector('#report-preview-actions .btn:last-child');
-    const orig = btn ? btn.textContent : '';
-    if (btn) { btn.textContent = 'Downloading...'; btn.disabled = true; }
     try {
       const [logData, investigationData] = await Promise.allSettled([
         apiFetch('event_log?hours=' + hours),
@@ -2767,8 +2874,6 @@
     } catch (e) {
       console.error('Failed to download full logs:', e);
       alert('Failed to download logs: ' + e.message);
-    } finally {
-      if (btn) { btn.textContent = orig; btn.disabled = false; }
     }
   }
 
@@ -2912,8 +3017,10 @@
     };
     renderReportInPreview(_currentReport);
     renderHistory();
-    const card = document.getElementById('report-preview-card');
-    if (card) card.scrollIntoView({ behavior: 'smooth' });
+    const isInvestigation = _currentReport.reportType === 'investigation';
+    const targetId = isInvestigation ? 'ai-invest-content' : 'ai-activity-content';
+    const target = document.getElementById(targetId);
+    if (target) target.scrollIntoView({ behavior: 'smooth' });
   }
 
   function _formatInvestigationReport(entry) {
@@ -2973,9 +3080,14 @@
       // If the deleted report is currently displayed, clear the preview
       if (_currentReport && _currentReport.timestamp === entry.timestamp) {
         _currentReport = null;
-        document.getElementById('report-preview-header').innerHTML = '<h2 style="margin:0;">Report Preview</h2>';
-        document.getElementById('report-preview-content').innerHTML = '<p style="color:var(--text-secondary);font-size:0.85rem;">No report loaded. Select a type above and click Run Report.</p>';
-        document.getElementById('report-preview-actions').style.display = 'none';
+        ['ai-activity-content', 'ai-invest-content'].forEach(id => {
+          const el = document.getElementById(id);
+          if (el) el.innerHTML = '<p style="color:var(--text-secondary);font-size:0.85rem;">Report deleted.</p>';
+        });
+        ['ai-activity-actions', 'ai-invest-actions'].forEach(id => {
+          const el = document.getElementById(id);
+          if (el) el.style.display = 'none';
+        });
       }
       await loadUnifiedHistory();
     } catch (e) {
@@ -2988,7 +3100,7 @@
     const date = new Date(_currentReport.timestamp).toISOString().slice(0, 10);
     const rType = _currentReport.reportType;
     const filename = 'climate-advisor-' + (rType === 'investigation' ? 'investigation' : 'activity') + '-' + date + '.md';
-    _triggerTextDownload(_formatCurrentReport(), filename);
+    downloadMarkdown(_formatCurrentReport(), filename);
   }
 
   function _formatCurrentReport() {
@@ -3020,19 +3132,21 @@
 
   // ---- GitHub Issue Modal ----
 
-  function openGithubIssueModal() {
-    if (!_currentReport) return;
+  function openGithubIssueModal(opts) {
     const modal = document.getElementById('github-issue-modal');
-    const result = _currentReport.result || {};
-    const data = result.data || {};
-    const rType = _currentReport.reportType === 'investigation' ? 'Investigative Analysis' : 'Activity Report';
-    const ts = _currentReport.timestamp ? new Date(_currentReport.timestamp).toLocaleString() : '';
-    const summary = (data.summary || '').replace(/\s+/g, ' ').trim().substring(0, 120);
-    document.getElementById('github-issue-title').value = summary
-      ? summary.substring(0, 100)
-      : rType + ' — ' + ts;
-    document.getElementById('github-issue-body').value = _formatCurrentReport();
-    document.getElementById('github-issue-labels').value = 'bug';
+    if (!opts || !opts.skipCurrentReport) {
+      if (!_currentReport) return;
+      const result = _currentReport.result || {};
+      const data = result.data || {};
+      const rType = _currentReport.reportType === 'investigation' ? 'Investigative Analysis' : 'Activity Report';
+      const ts = _currentReport.timestamp ? new Date(_currentReport.timestamp).toLocaleString() : '';
+      const summary = (data.summary || '').replace(/\s+/g, ' ').trim().substring(0, 120);
+      document.getElementById('github-issue-title').value = summary
+        ? summary.substring(0, 100)
+        : rType + ' — ' + ts;
+      document.getElementById('github-issue-body').value = _formatCurrentReport();
+      document.getElementById('github-issue-labels').value = 'bug';
+    }
     document.getElementById('github-issue-status').textContent = '';
     document.getElementById('github-modal-not-configured').style.display = 'none';
     document.getElementById('github-submit-btn').disabled = false;
@@ -3100,9 +3214,7 @@
     if (evt.target === this) closeGithubIssueModal();
   });
 
-  // Expose AI tab functions to window for onclick handlers
-  window.runReport = runReport;
-  window.updateReportTypeUI = updateReportTypeUI;
+  // Expose Analysis tab functions to window for onclick handlers
   window.renderHistory = renderHistory;
   window.setHistoryFilter = setHistoryFilter;
   window.showMoreHistory = showMoreHistory;

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -500,9 +500,9 @@
 
 <div class="tabs">
   <button class="tab-btn active" data-tab="status">Status</button>
-  <button class="tab-btn" data-tab="debug">Debug</button>
-  <button class="tab-btn" data-tab="settings">Settings</button>
   <button class="tab-btn" data-tab="ai">Analysis</button>
+  <button class="tab-btn" data-tab="settings">Settings</button>
+  <button class="tab-btn" data-tab="debug">Debug</button>
 </div>
 
 <div id="tab-status" class="tab-content active">
@@ -654,90 +654,48 @@
     </div>
   </div>
 
-  <!-- Section 1 — Activity Record (no AI required) -->
+  <!-- Generate Report -->
   <div class="card">
-    <h2>Activity Record</h2>
+    <h2>Generate Report</h2>
+    <div style="display:flex;gap:12px;align-items:center;margin-bottom:10px;flex-wrap:wrap;">
+      <label style="font-size:0.85rem;color:var(--text-secondary);">Report type:</label>
+      <select id="report-type" onchange="updateReportTypeUI()" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
+        <option value="activity_record">Activity Record</option>
+        <option value="activity">AI Activity Report</option>
+        <option value="investigation">AI Investigative Analysis</option>
+      </select>
+    </div>
     <div style="display:flex;gap:12px;align-items:center;margin-bottom:10px;flex-wrap:wrap;">
       <label style="font-size:0.85rem;color:var(--text-secondary);">Time window:</label>
-      <select id="activity-record-hours" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
+      <select id="report-time-window" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
         <option value="6">Last 6 hours</option>
         <option value="12">Last 12 hours</option>
         <option value="24" selected>Last 24 hours</option>
         <option value="48">Last 48 hours</option>
         <option value="168">Last 7 days</option>
       </select>
-      <button class="btn" onclick="_runActivityRecord()" id="activity-record-btn">Generate</button>
-      <span id="activity-record-status" style="font-size:0.8rem;color:var(--text-secondary);"></span>
     </div>
-    <div id="activity-record-loading" class="loading" style="display:none;">Building event table&#x2026;</div>
-    <div id="activity-record-content" style="overflow-x:auto;">
-      <p style="color:var(--text-secondary);font-size:0.85rem;">Click Generate to build the event timeline.</p>
-    </div>
-    <div id="activity-record-actions" style="display:none;margin-top:12px;display:flex;gap:8px;flex-wrap:wrap;">
-      <button class="btn secondary" onclick="_copyActivityRecord()" style="font-size:0.8rem;">Copy</button>
-      <button class="btn secondary" onclick="_downloadActivityRecord()" style="font-size:0.8rem;">&#x2B07; Download .md</button>
-      <button class="btn secondary" onclick="downloadFullLogs()" style="font-size:0.8rem;">Download Full Logs</button>
-      <button class="btn secondary" onclick="_githubActivityRecord()" style="font-size:0.8rem;">&#x1F41B; Submit GitHub Issue</button>
-    </div>
-  </div>
-
-  <!-- Section 2 — AI Activity Report -->
-  <div class="card">
-    <h2>AI Activity Report <span style="background:var(--primary);color:#fff;font-size:0.65rem;padding:1px 7px;border-radius:10px;vertical-align:middle;margin-left:4px;">AI</span></h2>
-    <div id="ai-activity-disabled-notice" style="display:none;color:var(--text-secondary);font-size:0.85rem;margin-bottom:10px;padding:8px;background:var(--bg);border-radius:4px;">
-      AI features are not configured. Enable in Settings &#x2192; AI Configuration.
-    </div>
-    <div style="display:flex;gap:12px;align-items:center;margin-bottom:10px;flex-wrap:wrap;">
-      <label style="font-size:0.85rem;color:var(--text-secondary);">Time window:</label>
-      <select id="ai-activity-hours" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
-        <option value="6">Last 6 hours</option>
-        <option value="12">Last 12 hours</option>
-        <option value="24" selected>Last 24 hours</option>
-        <option value="48">Last 48 hours</option>
-      </select>
-      <button class="btn" id="ai-activity-btn" onclick="_runAIActivityReport()">Generate with AI</button>
-      <span id="ai-activity-status" style="font-size:0.8rem;color:var(--text-secondary);"></span>
-    </div>
-    <div id="ai-activity-loading" class="loading" style="display:none;">Generating report&#x2026; this may take 15&#x2013;30 seconds.</div>
-    <div id="ai-activity-content">
-      <p style="color:var(--text-secondary);font-size:0.85rem;">Click Generate with AI to produce a narrative report.</p>
-    </div>
-    <div id="ai-activity-actions" style="display:none;margin-top:12px;gap:8px;flex-wrap:wrap;">
-      <button class="btn secondary" onclick="_copyAIActivity()" style="font-size:0.8rem;">Copy</button>
-      <button class="btn secondary" onclick="_downloadAIActivity()" style="font-size:0.8rem;">&#x2B07; Download .md</button>
-      <button class="btn secondary" onclick="_githubAIActivity()" style="font-size:0.8rem;">&#x1F41B; Submit GitHub Issue</button>
-    </div>
-  </div>
-
-  <!-- Section 3 — AI Investigative Analysis -->
-  <div class="card">
-    <h2>AI Investigative Analysis <span style="background:var(--primary);color:#fff;font-size:0.65rem;padding:1px 7px;border-radius:10px;vertical-align:middle;margin-left:4px;">AI</span></h2>
-    <div id="ai-invest-disabled-notice" style="display:none;color:var(--text-secondary);font-size:0.85rem;margin-bottom:10px;padding:8px;background:var(--bg);border-radius:4px;">
-      AI features are not configured. Enable in Settings &#x2192; AI Configuration.
-    </div>
-    <div style="margin-bottom:10px;">
+    <div id="investigation-focus-controls" style="display:none;margin-bottom:10px;">
       <textarea id="investigation-focus"
         placeholder="Optional: describe what you'd like investigated (e.g. 'why is window compliance 0%')..."
         style="width:100%;min-height:60px;padding:0.5rem;border-radius:6px;border:1px solid var(--border);background:var(--bg);color:var(--text);font-size:0.85rem;resize:vertical;box-sizing:border-box;"></textarea>
     </div>
-    <div style="display:flex;gap:12px;align-items:center;margin-bottom:10px;flex-wrap:wrap;">
-      <label style="font-size:0.85rem;color:var(--text-secondary);">Time window:</label>
-      <select id="ai-invest-hours" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
-        <option value="24">Last 1 day</option>
-        <option value="168" selected>Last 7 days</option>
-        <option value="720">Last 30 days</option>
-      </select>
-      <button class="btn" id="ai-invest-btn" onclick="_runAIInvestigation()">Investigate</button>
-      <span id="ai-invest-status" style="font-size:0.8rem;color:var(--text-secondary);"></span>
+    <div id="ai-disabled-notice" style="display:none;color:var(--text-secondary);font-size:0.85rem;margin-bottom:10px;padding:8px;background:var(--bg);border-radius:4px;">
+      AI features are not configured. Enable in Settings &#x2192; AI Configuration.
     </div>
-    <div id="ai-invest-loading" class="loading" style="display:none;">Investigating&#x2026; this may take up to a minute.</div>
-    <div id="ai-invest-content">
-      <p style="color:var(--text-secondary);font-size:0.85rem;">Click Investigate to run a deep AI analysis.</p>
+    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+      <button class="btn" id="run-report-btn" onclick="runReport()">Generate</button>
+      <span id="report-status" style="font-size:0.8rem;color:var(--text-secondary);"></span>
     </div>
-    <div id="ai-invest-actions" style="display:none;margin-top:12px;gap:8px;flex-wrap:wrap;">
-      <button class="btn secondary" onclick="_copyAIInvestigation()" style="font-size:0.8rem;">Copy</button>
-      <button class="btn secondary" onclick="_downloadAIInvestigation()" style="font-size:0.8rem;">&#x2B07; Download .md</button>
-      <button class="btn secondary" onclick="_githubAIInvestigation()" style="font-size:0.8rem;">&#x1F41B; Submit GitHub Issue</button>
+    <div id="report-loading" class="loading" style="display:none;">Generating&#x2026;</div>
+    <div id="report-content" style="margin-top:10px;overflow-x:auto;">
+      <p style="color:var(--text-secondary);font-size:0.85rem;">Select a report type and click Generate.</p>
+    </div>
+    <div id="report-actions" style="display:none;margin-top:12px;gap:8px;flex-wrap:wrap;">
+      <button class="btn secondary" onclick="copyReport()" style="font-size:0.8rem;">Copy</button>
+      <button class="btn secondary" onclick="downloadReport()" style="font-size:0.8rem;">&#x2B07; Download .md</button>
+      <button class="btn secondary" onclick="downloadFullLogs()" style="font-size:0.8rem;">Download Full Logs</button>
+      <button class="btn secondary" onclick="githubReport()" style="font-size:0.8rem;">&#x1F41B; Submit GitHub Issue</button>
     </div>
   </div>
 
@@ -2519,37 +2477,79 @@
         <div class="status-item"><div class="label">Auto Today</div><div class="value">${s.auto_requests_today || 0}</div></div>
         <div class="status-item"><div class="label">Manual Today</div><div class="value">${s.manual_requests_today || 0}</div></div>
       `;
-      const aiDisabled = s.status === 'disabled' || !s.status;
-      ['ai-activity-disabled-notice', 'ai-invest-disabled-notice'].forEach(id => {
-        const el = document.getElementById(id);
-        if (el) el.style.display = aiDisabled ? 'block' : 'none';
-      });
-      ['ai-activity-btn', 'ai-invest-btn'].forEach(id => {
-        const el = document.getElementById(id);
-        if (el) { el.disabled = aiDisabled; el.style.opacity = aiDisabled ? '0.45' : ''; }
-      });
+      _aiDisabled = s.status === 'disabled' || !s.status;
+      _applyAIDisabledState();
     } catch (e) {
       document.getElementById('ai-status-loading').textContent = 'Failed to load AI status: ' + e.message;
     }
   }
 
-  // ---- Activity Record (deterministic, no AI) ----
+  // ---- Report type UI ----
 
+  let _aiDisabled = false;
   let _activityRecordTable = null;
 
+  function _applyAIDisabledState() {
+    const type = (document.getElementById('report-type') || {}).value || 'activity_record';
+    const isAiType = type !== 'activity_record';
+    const notice = document.getElementById('ai-disabled-notice');
+    const btn = document.getElementById('run-report-btn');
+    if (notice) notice.style.display = (isAiType && _aiDisabled) ? 'block' : 'none';
+    if (btn) { btn.disabled = isAiType && _aiDisabled; btn.style.opacity = (isAiType && _aiDisabled) ? '0.45' : ''; }
+  }
+
+  function updateReportTypeUI() {
+    const type = document.getElementById('report-type').value;
+    const twSelect = document.getElementById('report-time-window');
+    const focusControls = document.getElementById('investigation-focus-controls');
+    const btn = document.getElementById('run-report-btn');
+    if (type === 'activity_record') {
+      twSelect.innerHTML = '<option value="6">Last 6 hours</option>'
+        + '<option value="12">Last 12 hours</option>'
+        + '<option value="24" selected>Last 24 hours</option>'
+        + '<option value="48">Last 48 hours</option>'
+        + '<option value="168">Last 7 days</option>';
+      focusControls.style.display = 'none';
+      btn.textContent = 'Generate';
+    } else if (type === 'activity') {
+      twSelect.innerHTML = '<option value="6">Last 6 hours</option>'
+        + '<option value="12">Last 12 hours</option>'
+        + '<option value="24" selected>Last 24 hours</option>'
+        + '<option value="48">Last 48 hours</option>';
+      focusControls.style.display = 'none';
+      btn.textContent = 'Generate with AI';
+    } else {
+      twSelect.innerHTML = '<option value="24">Last 1 day</option>'
+        + '<option value="168" selected>Last 7 days</option>'
+        + '<option value="720">Last 30 days</option>';
+      focusControls.style.display = 'block';
+      btn.textContent = 'Investigate';
+    }
+    _applyAIDisabledState();
+  }
+
+  async function runReport() {
+    const type = document.getElementById('report-type').value;
+    if (type === 'activity_record') await _runActivityRecord();
+    else if (type === 'activity') await _runAIActivityReport();
+    else await _runAIInvestigation();
+  }
+
+  // ---- Activity Record (deterministic, no AI) ----
+
   async function _runActivityRecord() {
-    const hours = parseInt(document.getElementById('activity-record-hours').value, 10) || 24;
-    const btn = document.getElementById('activity-record-btn');
-    const loading = document.getElementById('activity-record-loading');
-    const status = document.getElementById('activity-record-status');
-    const content = document.getElementById('activity-record-content');
-    const actions = document.getElementById('activity-record-actions');
+    const hours = parseInt(document.getElementById('report-time-window').value, 10) || 24;
+    const btn = document.getElementById('run-report-btn');
+    const loading = document.getElementById('report-loading');
+    const status = document.getElementById('report-status');
+    const content = document.getElementById('report-content');
+    const actions = document.getElementById('report-actions');
     btn.disabled = true;
     btn.textContent = 'Generating\u2026';
     loading.style.display = 'block';
     status.textContent = '';
     try {
-      const resp = await apiFetch('activity_record?hours=' + hours, { method: 'GET' });
+      const resp = await apiFetch('activity_record?hours=' + hours);
       _activityRecordTable = resp.table || '';
       content.innerHTML = _activityRecordTable
         ? '<div class="report-section" style="overflow-x:auto;">' + renderMarkdown(_activityRecordTable) + '</div>'
@@ -2564,31 +2564,13 @@
     }
   }
 
-  function _copyActivityRecord() {
-    if (!_activityRecordTable) return;
-    _copyText(_activityRecordTable);
-  }
-
-  function _downloadActivityRecord() {
-    if (!_activityRecordTable) return;
-    const date = new Date().toISOString().slice(0, 10);
-    downloadMarkdown(_activityRecordTable, 'climate-advisor-activity-record-' + date + '.md');
-  }
-
-  function _githubActivityRecord() {
-    if (!_activityRecordTable) return;
-    document.getElementById('github-issue-title').value = 'Activity Record \u2014 ' + new Date().toLocaleDateString();
-    document.getElementById('github-issue-body').value = '## Activity Record\n\n' + _activityRecordTable + '\n\n---\n*Generated by Climate Advisor*';
-    window.openGithubIssueModal({ skipCurrentReport: true });
-  }
-
   // ---- AI Activity Report ----
 
   async function _runAIActivityReport() {
-    const hours = parseInt(document.getElementById('ai-activity-hours').value, 10) || 24;
-    const btn = document.getElementById('ai-activity-btn');
-    const loading = document.getElementById('ai-activity-loading');
-    const status = document.getElementById('ai-activity-status');
+    const hours = parseInt(document.getElementById('report-time-window').value, 10) || 24;
+    const btn = document.getElementById('run-report-btn');
+    const loading = document.getElementById('report-loading');
+    const status = document.getElementById('report-status');
     btn.disabled = true;
     btn.textContent = 'Running\u2026';
     loading.style.display = 'block';
@@ -2607,30 +2589,14 @@
     }
   }
 
-  function _copyAIActivity() {
-    if (!_currentReport || _currentReport.reportType !== 'activity') return;
-    _copyText(_formatCurrentReport());
-  }
-
-  function _downloadAIActivity() {
-    if (!_currentReport || _currentReport.reportType !== 'activity') return;
-    const date = new Date(_currentReport.timestamp).toISOString().slice(0, 10);
-    downloadMarkdown(_formatCurrentReport(), 'climate-advisor-ai-report-' + date + '.md');
-  }
-
-  function _githubAIActivity() {
-    if (!_currentReport || _currentReport.reportType !== 'activity') return;
-    window.openGithubIssueModal();
-  }
-
   // ---- AI Investigative Analysis ----
 
   async function _runAIInvestigation() {
-    const btn = document.getElementById('ai-invest-btn');
-    const loading = document.getElementById('ai-invest-loading');
-    const status = document.getElementById('ai-invest-status');
+    const btn = document.getElementById('run-report-btn');
+    const loading = document.getElementById('report-loading');
+    const status = document.getElementById('report-status');
     const focus = document.getElementById('investigation-focus').value.trim();
-    const hours = parseInt(document.getElementById('ai-invest-hours').value, 10) || 168;
+    const hours = parseInt(document.getElementById('report-time-window').value, 10) || 168;
     btn.disabled = true;
     btn.textContent = 'Running\u2026';
     loading.style.display = 'block';
@@ -2676,20 +2642,42 @@
     }
   }
 
-  function _copyAIInvestigation() {
-    if (!_currentReport || _currentReport.reportType !== 'investigation') return;
-    _copyText(_formatCurrentReport());
+  // ---- Unified action buttons ----
+
+  function copyReport() {
+    const type = document.getElementById('report-type').value;
+    if (type === 'activity_record') {
+      if (_activityRecordTable) _copyText(_activityRecordTable);
+    } else {
+      if (_currentReport) _copyText(_formatCurrentReport());
+    }
   }
 
-  function _downloadAIInvestigation() {
-    if (!_currentReport || _currentReport.reportType !== 'investigation') return;
-    const date = new Date(_currentReport.timestamp).toISOString().slice(0, 10);
-    downloadMarkdown(_formatCurrentReport(), 'climate-advisor-investigation-' + date + '.md');
+  function downloadReport() {
+    const type = document.getElementById('report-type').value;
+    if (type === 'activity_record') {
+      if (!_activityRecordTable) return;
+      const date = new Date().toISOString().slice(0, 10);
+      downloadMarkdown(_activityRecordTable, 'climate-advisor-activity-record-' + date + '.md');
+    } else {
+      if (!_currentReport) return;
+      const date = new Date(_currentReport.timestamp).toISOString().slice(0, 10);
+      const prefix = _currentReport.reportType === 'investigation' ? 'investigation' : 'ai-report';
+      downloadMarkdown(_formatCurrentReport(), 'climate-advisor-' + prefix + '-' + date + '.md');
+    }
   }
 
-  function _githubAIInvestigation() {
-    if (!_currentReport || _currentReport.reportType !== 'investigation') return;
-    window.openGithubIssueModal();
+  function githubReport() {
+    const type = document.getElementById('report-type').value;
+    if (type === 'activity_record') {
+      if (!_activityRecordTable) return;
+      document.getElementById('github-issue-title').value = 'Activity Record \u2014 ' + new Date().toLocaleDateString();
+      document.getElementById('github-issue-body').value = '## Activity Record\n\n' + _activityRecordTable + '\n\n---\n*Generated by Climate Advisor*';
+      window.openGithubIssueModal({ skipCurrentReport: true });
+    } else {
+      if (!_currentReport) return;
+      window.openGithubIssueModal();
+    }
   }
 
   // ---- Shared helpers ----
@@ -2720,11 +2708,8 @@
   }
 
   function renderReportInPreview(entry) {
-    const isInvestigation = entry.reportType === 'investigation';
-    const contentId = isInvestigation ? 'ai-invest-content' : 'ai-activity-content';
-    const actionsId = isInvestigation ? 'ai-invest-actions' : 'ai-activity-actions';
-    const content = document.getElementById(contentId);
-    const actions = document.getElementById(actionsId);
+    const content = document.getElementById('report-content');
+    const actions = document.getElementById('report-actions');
     if (!content) return;
     const ts = entry.timestamp ? new Date(entry.timestamp).toLocaleString() : '';
     const result = entry.result || {};
@@ -2849,7 +2834,7 @@
   }
 
   async function downloadFullLogs() {
-    const hoursEl = document.getElementById('activity-record-hours');
+    const hoursEl = document.getElementById('report-time-window');
     const hours = hoursEl ? parseInt(hoursEl.value, 10) || 24 : 24;
     try {
       const [logData, investigationData] = await Promise.allSettled([
@@ -3017,9 +3002,7 @@
     };
     renderReportInPreview(_currentReport);
     renderHistory();
-    const isInvestigation = _currentReport.reportType === 'investigation';
-    const targetId = isInvestigation ? 'ai-invest-content' : 'ai-activity-content';
-    const target = document.getElementById(targetId);
+    const target = document.getElementById('report-content');
     if (target) target.scrollIntoView({ behavior: 'smooth' });
   }
 
@@ -3080,14 +3063,10 @@
       // If the deleted report is currently displayed, clear the preview
       if (_currentReport && _currentReport.timestamp === entry.timestamp) {
         _currentReport = null;
-        ['ai-activity-content', 'ai-invest-content'].forEach(id => {
-          const el = document.getElementById(id);
-          if (el) el.innerHTML = '<p style="color:var(--text-secondary);font-size:0.85rem;">Report deleted.</p>';
-        });
-        ['ai-activity-actions', 'ai-invest-actions'].forEach(id => {
-          const el = document.getElementById(id);
-          if (el) el.style.display = 'none';
-        });
+        const delContent = document.getElementById('report-content');
+        if (delContent) delContent.innerHTML = '<p style="color:var(--text-secondary);font-size:0.85rem;">Report deleted.</p>';
+        const delActions = document.getElementById('report-actions');
+        if (delActions) delActions.style.display = 'none';
       }
       await loadUnifiedHistory();
     } catch (e) {

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -3194,6 +3194,11 @@
   });
 
   // Expose Analysis tab functions to window for onclick handlers
+  window.updateReportTypeUI = updateReportTypeUI;
+  window.runReport = runReport;
+  window.copyReport = copyReport;
+  window.downloadReport = downloadReport;
+  window.githubReport = githubReport;
   window.renderHistory = renderHistory;
   window.setHistoryFilter = setHistoryFilter;
   window.showMoreHistory = showMoreHistory;

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.36"
+  "version": "0.4.37"
 }

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.37"
+  "version": "0.4.38"
 }

--- a/docs/activity-report-table.md
+++ b/docs/activity-report-table.md
@@ -9,7 +9,7 @@ _Introduced: Issue #330 (deterministic table) · Chart Vent bar: Issue #331_
 | Question | Short answer | → Full answer |
 |---|---|---|
 | How is the per-event table built — LLM or Python? | Deterministically in Python by `build_event_timeline_table()` in `ai_skills_activity.py`. Not LLM-generated. The AI still writes the summary, decisions, and anomalies sections. | [Overview](#overview) |
-| What do the Event and Settings columns mean? | Event = what happened (trigger or action label). Settings = the concrete HVAC action performed (setpoint, mode, fan state). | [Overview](#overview) |
+| What do the Event, Settings, Indoor, and Outdoor columns mean? | Event = what happened. Settings = the concrete HVAC action (setpoint, mode, fan state). Indoor/Outdoor = ambient temperatures at event emit time, sourced from coordinator.data; `—` for events recorded before Issue #352. | [Overview](#overview) |
 | How does `_format_band_setpoint` render a setpoint? | Active edge first (the live thermostat setpoint), other edge in parens as the monitored bound: `setpoint: 72°F Cool (64°F Heat)`. | [Setpoint Convention](#setpoint-convention) |
 | What is the full set of event types the table must handle? | 38 registered types across 6 groups: band/setpoint-program, setpoint/mode delta, override lifecycle, nat-vent/fan, skip/advisory, system/diagnostic. | [Event Catalog](#event-catalog) |
 | What happens when an unrecognised event type appears? | `_default_renderer` fires: humanized type name + `reason` field as Event; generic field extraction as Settings. Never blank, never crashes. | [Default Renderer](#default-renderer) |
@@ -40,9 +40,13 @@ rendering applies even when Claude is unavailable.
 | **Time** | Local HH:MM of the event |
 | **Event** | What happened — a human-readable label for the trigger or action type |
 | **Settings** | The concrete HVAC action performed — setpoint, mode change, fan state, or skip reason |
+| **Indoor** | Indoor temperature at the moment the event was emitted, from `coordinator._get_indoor_temp()`. Displays `—` for events recorded before Issue #352 enrichment. |
+| **Outdoor** | Outdoor temperature at the moment the event was emitted, from `coordinator._last_outdoor_temp`. Same availability caveat. |
 
 The split between Event and Settings lets users scan the Settings column to understand
-_what the thermostat was told to do_ independently from the event labels.
+_what the thermostat was told to do_ independently from the event labels. Indoor and
+Outdoor make the ambient conditions visible alongside each decision, eliminating the
+need to cross-reference chart data to understand why a setpoint was applied.
 
 ---
 
@@ -194,6 +198,9 @@ Consecutive rows with the **same event type** are collapsed into a single row:
 **The Settings cell is preserved** — all collapsed rows share the same band parameters
 (they represent the same comfort state being re-armed), so the Settings text from the
 first (or last) instance is used verbatim.
+
+**Indoor and Outdoor cells use the first event in the collapsed run.** Temperature
+conditions at the start of a repeated band cycle are more informative than the last.
 
 This fixes the historical defect where `Sleep comfort band applied ×18` showed an empty
 Settings column (Issue #330): the collapse preserves the `_format_band_setpoint` output

--- a/tests/test_activity_renderers.py
+++ b/tests/test_activity_renderers.py
@@ -300,7 +300,7 @@ class TestBuildEventTimelineTable:
         """Empty event log → table has header + '(no events in window)' sentinel row."""
         table = _build_table([])
 
-        assert "| Time | Event | Settings | Source |" in table
+        assert "| Time | Event | Settings | Source | Indoor | Outdoor |" in table
         assert "no events in window" in table
 
     def test_table_always_starts_with_header(self):
@@ -309,7 +309,7 @@ class TestBuildEventTimelineTable:
         table = _build_table([event])
 
         first_line = table.splitlines()[0]
-        assert first_line == "| Time | Event | Settings | Source |", (
+        assert first_line == "| Time | Event | Settings | Source | Indoor | Outdoor |", (
             f"Table must start with header row. Got: {first_line!r}"
         )
 
@@ -615,3 +615,63 @@ class TestFanManualOverrideRenderer:
         """fan_manual_override source resolves to 'manual' for timeline Source column."""
         source = _act_mod._event_source_label("fan_manual_override", {"source": ""})
         assert source == "manual"
+
+
+# ---------------------------------------------------------------------------
+# TestTempColumns (Issue #352)
+# ---------------------------------------------------------------------------
+
+
+class TestTempColumns:
+    """Indoor/Outdoor temperature columns in the timeline table (Issue #352)."""
+
+    def test_temp_columns_populated_from_event(self):
+        """Events carrying indoor_f/outdoor_f render temperatures in the table."""
+        events = [
+            _make_event(
+                "comfort_band_applied",
+                hours_ago=1.0,
+                floor=68.0,
+                ceiling=74.0,
+                active="ceiling",
+                mode="cool",
+                reason="day",
+                indoor_f=73.5,
+                outdoor_f=68.0,
+            )
+        ]
+        table = _build_table(events)
+        assert "Indoor" in table
+        assert "Outdoor" in table
+        # 73.5°F rounds to 74°F in format_temp; 68°F is both setpoint floor and outdoor temp
+        assert "74" in table
+
+    def test_temp_columns_absent_renders_emdash(self):
+        """Events without indoor_f/outdoor_f render em-dash; no crash."""
+        events = [
+            _make_event(
+                "comfort_band_applied",
+                hours_ago=1.0,
+                floor=68.0,
+                ceiling=74.0,
+                active="ceiling",
+                mode="cool",
+                reason="day",
+            )
+        ]
+        table = _build_table(events)
+        assert "Indoor" in table
+        assert "Outdoor" in table
+        assert "—" in table  # em-dash
+
+    def test_dedup_row_preserves_first_event_temps(self):
+        """Consecutive same-type events collapsed to one row keep the first event's temps."""
+        events = [
+            _make_event("nat_vent_ac_assist_armed", hours_ago=3.0, indoor_f=75.0, outdoor_f=70.0),
+            _make_event("nat_vent_ac_assist_armed", hours_ago=2.5, indoor_f=76.0, outdoor_f=71.0),
+            _make_event("nat_vent_ac_assist_armed", hours_ago=2.0, indoor_f=77.0, outdoor_f=72.0),
+        ]
+        table = _build_table(events)
+        assert "x3" in table
+        assert "75" in table
+        assert "70" in table

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -105,7 +105,7 @@ class TestAPIViewList:
     """Test the API_VIEWS registry."""
 
     def test_correct_count(self):
-        assert len(API_VIEWS) == 22
+        assert len(API_VIEWS) == 23
 
     def test_all_are_callable(self):
         for view_cls in API_VIEWS:


### PR DESCRIPTION
## Summary

- **New Analysis tab** — renamed from \"AI\" tab, moved to second position (Status → Analysis → Settings → Debug)
- **Activity Record** — new deterministic event timeline (no AI required) via \`GET /api/climate_advisor/activity_record?hours=N\`; always available regardless of AI config
- **Temperature columns** — every emitted event enriched with \`indoor_f\`/\`outdoor_f\` at emit time; timeline table gains Indoor and Outdoor columns (em-dash for pre-enrichment events)
- **Unified Generate Report card** — single card with report-type dropdown replacing three separate section cards:
  - Activity Record (no AI)
  - AI Activity Report
  - AI Investigative Analysis
- **Adaptive controls** — switching type updates time window options, button label, and shows/hides investigation focus textarea
- **AI disabled state** — AI types show notice and greyed button when \`ai_status\` returns disabled; Activity Record always works
- **Download .md** — all three types share Copy, Download .md, Download Full Logs, Submit GitHub Issue action buttons
- **Window export fix** — \`runReport\`, \`updateReportTypeUI\`, \`copyReport\`, \`downloadReport\`, \`githubReport\` exported to \`window\` so onclick handlers resolve correctly

## Test plan

- [x] Activity Record: Generate → table renders with Indoor/Outdoor columns
- [x] Activity Record: Download .md → saves \`.md\` file; Submit GitHub Issue → modal pre-populated
- [x] AI Activity Report: Generate with AI → report renders
- [x] AI Investigative Analysis: focus textarea appears; Investigate → report renders
- [x] Switching types: time window options and button label adapt
- [x] History: clicking entry loads report into the content area
- [x] AI disabled: AI types show notice/greyed button; Activity Record still works
- [x] 2803 tests pass: \`python -m pytest tests/ -q\`