### PR TITLE
Fix #354: Activity Record shows indoor/outdoor temp at thermostat decision events

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -38,6 +38,15 @@ _LOGGER = logging.getLogger(__name__)
 _SKILL_NAME = "activity_report"
 
 
+def _first_temp(entry: dict, *keys: str) -> Any:
+    """Return first non-None temp value from the given keys in an event dict."""
+    for k in keys:
+        v = entry.get(k)
+        if v is not None:
+            return v
+    return None
+
+
 def _fmt_temp_cell(val: Any, unit: str) -> str:
     """Format a temperature value for a timeline table cell; em-dash when unavailable."""
     try:
@@ -1007,8 +1016,8 @@ def build_event_timeline_table(
             settings_text = ""
 
         source = _event_source_label(event_type, payload) or "sensor"
-        indoor_cell = _fmt_temp_cell(entry.get("indoor_f"), unit)
-        outdoor_cell = _fmt_temp_cell(entry.get("outdoor_f"), unit)
+        indoor_cell = _fmt_temp_cell(_first_temp(entry, "indoor_f", "indoor_temp", "indoor"), unit)
+        outdoor_cell = _fmt_temp_cell(_first_temp(entry, "outdoor_f", "outdoor_temp", "outdoor"), unit)
 
         # Flush run when type changes or type is not deduplicated
         if event_type in _NO_DEDUP or event_type != run_type:

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -838,6 +838,7 @@ class AutomationEngine:
                         "classification_mode": classification_mode,
                         "old_setpoint_f": old_setpoint_f,
                         "new_setpoint_f": new_setpoint_f,
+                        "indoor_f": self._indoor_f_for_event(),
                     },
                 )
         else:
@@ -1031,6 +1032,7 @@ class AutomationEngine:
                         "hvac_mode": classification.hvac_mode,
                         "trend": classification.trend_direction,
                         "old_hvac_mode": _old_mode_cls,
+                        "indoor_f": indoor_temp,
                     },
                 )
         else:
@@ -1301,6 +1303,7 @@ class AutomationEngine:
                     "active": band.active,
                     "mode": _cmd_shape,
                     "reason": band.reason,
+                    "indoor_f": self._indoor_f_for_event(),
                 },
             )
 
@@ -2773,6 +2776,7 @@ class AutomationEngine:
                     "floor": _away_band.floor,
                     "ceiling": _away_band.ceiling,
                     "occupancy": "away",
+                    "indoor_f": self._indoor_f_for_event(),
                 },
             )
         await self._apply_comfort_band(_away_band, reason="occupancy away — setback band")
@@ -2790,7 +2794,7 @@ class AutomationEngine:
             if self._emit_event_callback:
                 self._emit_event_callback(
                     "occupancy_comfort_restored",
-                    {"mode": c.hvac_mode, "target_f": comfort},
+                    {"mode": c.hvac_mode, "target_f": comfort, "indoor_f": self._indoor_f_for_event()},
                 )
 
         # Check 1: Temperature proximity — skip notification if house already near comfort.
@@ -2870,6 +2874,7 @@ class AutomationEngine:
                     "floor": _vac_band.floor,
                     "ceiling": _vac_band.ceiling,
                     "occupancy": "vacation",
+                    "indoor_f": self._indoor_f_for_event(),
                 },
             )
         await self._apply_comfort_band(_vac_band, reason="vacation mode — deep setback band")
@@ -3629,6 +3634,16 @@ class AutomationEngine:
         if climate_state:
             temp = climate_state.attributes.get("current_temperature")
             return to_fahrenheit(float(temp), unit) if temp is not None else None
+        return None
+
+    def _indoor_f_for_event(self) -> float | None:
+        """Read current indoor temp from climate entity for event enrichment."""
+        try:
+            state = self.hass.states.get(self.climate_entity)
+            if state is not None:
+                return float(state.attributes["current_temperature"])
+        except (TypeError, ValueError, KeyError, AttributeError):
+            pass
         return None
 
     def _get_thermostat_capabilities(self) -> ThermostatCapabilities:

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,12 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.38"
+VERSION = "0.4.39"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.39": [
+        "Fix #354: Activity Record now shows indoor/outdoor temp at thermostat decision events.",
+    ],
     "0.4.38": [
         "Feat #352: Analysis tab — single dropdown card replaces three-section layout; "
         "report type selector (Activity Record / AI Activity Report / AI Investigative Analysis) "
@@ -518,6 +521,32 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    354: {
+        "version_fixed": "0.4.39",
+        "title": "Activity Record temp columns — alt-key fallback + explicit injection at 5 call sites",
+        "scope_covered": (
+            "ai_skills_activity.py: added _first_temp() helper that resolves indoor_f/outdoor_f from "
+            "alt key names (indoor_temp, indoor, outdoor_temp, outdoor); build_event_timeline_table "
+            "now calls _first_temp() instead of entry.get('indoor_f') for both columns. "
+            "coordinator.py _emit_event: normalizes indoor_temp/indoor -> indoor_f and "
+            "outdoor_temp/outdoor -> outdoor_f before the setdefault block so any event carrying "
+            "alt-named temps gets canonical indoor_f/outdoor_f keys. "
+            "automation.py: added _indoor_f_for_event() helper reading current_temperature from the "
+            "climate entity; injected indoor_f into 6 emit call sites: classification_applied, "
+            "occupancy_comfort_restored, comfort_band_applied, occupancy_setback (away), "
+            "occupancy_setback (vacation), override_detected. "
+            "tests/test_activity_renderers.py: TestAltKeyTempFallback (3 tests)."
+        ),
+        "scope_not_covered": (
+            "Events emitted by coordinator.py directly (e.g. startup_coalesced, fan_running_untracked) "
+            "already receive indoor_f/outdoor_f from the setdefault block in _emit_event — no change needed. "
+            "Events emitted by automation.py that do not have a meaningful indoor temp "
+            "(e.g. grace_started, nat_vent_fan_off) rely on coordinator's setdefault enrichment. "
+            "_indoor_f_for_event() reads climate entity attributes only (not the configured "
+            "indoor_temp_entity sensor) — temperature may differ slightly from what _get_indoor_temp_f() "
+            "would return if a dedicated sensor is configured."
+        ),
+    },
     352: {
         "version_fixed": "0.4.37",
         "title": "Activity Report: temp columns, Activity Record endpoint, Analysis tab restructure",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -4865,6 +4865,15 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
     def _emit_event(self, event_type: str, data: dict) -> None:
         """Append a timestamped event to the in-memory event log ring buffer (Issue #76)."""
         entry: dict[str, Any] = {"time": dt_util.now().isoformat(), "type": event_type, **data}
+        # Normalize alternate temp field names used by automation events
+        for _src in ("indoor_temp", "indoor"):
+            if _src in entry:
+                entry.setdefault("indoor_f", entry[_src])
+                break
+        for _src in ("outdoor_temp", "outdoor"):
+            if _src in entry:
+                entry.setdefault("outdoor_f", entry[_src])
+                break
         if getattr(self, "config", None):
             entry.setdefault("indoor_f", self._get_indoor_temp())
             entry.setdefault("outdoor_f", getattr(self, "_last_outdoor_temp", None))

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.38"
+  "version": "0.4.39"
 }

--- a/tests/test_activity_renderers.py
+++ b/tests/test_activity_renderers.py
@@ -675,3 +675,55 @@ class TestTempColumns:
         assert "x3" in table
         assert "75" in table
         assert "70" in table
+
+
+# ---------------------------------------------------------------------------
+# TestAltKeyTempFallback
+# ---------------------------------------------------------------------------
+
+
+class TestAltKeyTempFallback:
+    """Verify _first_temp fallback reads alt key names from existing ring buffer events."""
+
+    def test_indoor_temp_key_populates_column(self):
+        """nat_vent_fan_on stores indoor_temp — table must show it."""
+        events = [
+            _make_event(
+                "nat_vent_fan_on",
+                hours_ago=1.0,
+                indoor_temp=71.0,
+                on_threshold=68.0,
+                target=72.0,
+            )
+        ]
+        table = _build_table(events)
+        assert "71" in table  # 71.0°F formatted
+
+    def test_indoor_outdoor_keys_populate_columns(self):
+        """nat_vent_ceiling_escalation stores indoor/outdoor — both columns must show."""
+        events = [
+            _make_event(
+                "nat_vent_ceiling_escalation",
+                hours_ago=1.0,
+                indoor=78.0,
+                outdoor=62.0,
+                comfort_cool=75.0,
+            )
+        ]
+        table = _build_table(events)
+        assert "78" in table
+        assert "62" in table
+
+    def test_indoor_f_takes_priority_over_alt_keys(self):
+        """If indoor_f is already present, it wins over indoor_temp."""
+        events = [
+            _make_event(
+                "some_event",
+                hours_ago=1.0,
+                indoor_f=75.0,
+                indoor_temp=99.0,  # should be ignored
+            )
+        ]
+        table = _build_table(events)
+        assert "75" in table
+        assert "99" not in table


### PR DESCRIPTION
## Summary

The Activity Record timeline table was showing "—" for Indoor/Outdoor on most rows due to two bugs:

1. **Key name mismatch** — events like `nat_vent_fan_on` stored `indoor_temp`, `nat_vent_ceiling_escalation` stored `indoor`/`outdoor`, but the table read `indoor_f`/`outdoor_f`. Events had the data; the table couldn't find it (affected existing ring buffer)
2. **No-temp at call site** — decision events like `classification_applied`, `comfort_band_applied`, `occupancy_setback`, `override_detected` carried no temp fields at all

### Changes

- **`ai_skills_activity.py`**: Added `_first_temp()` helper; `build_event_timeline_table` now falls back to `indoor_temp`/`indoor` and `outdoor_temp`/`outdoor` key names — fixes existing ring buffer entries immediately
- **`coordinator.py`**: `_emit_event` normalizes alt key names to `indoor_f`/`outdoor_f` before storage — canonical keys on all future events
- **`automation.py`**: Added `_indoor_f_for_event()` helper (reads `current_temperature` from climate entity); injected `indoor_f` at 6 call sites: `classification_applied` (from `indoor_temp` param), `comfort_band_applied`, `occupancy_setback` (away + vacation), `occupancy_comfort_restored`, `override_detected`

## Events now showing Indoor temperature

| Event | Source |
|---|---|
| Nat-vent on/off | `indoor_temp` key (alt-key fallback) |
| Nat-vent ceiling escalation | `indoor`/`outdoor` keys (alt-key fallback) |
| Pre-cool applied | `indoor` key (alt-key fallback) |
| Classification applied (daily HVAC mode) | explicit `indoor_f` injection |
| Comfort band applied (setpoint change) | explicit `indoor_f` injection |
| Occupancy setback/restore | explicit `indoor_f` injection |
| Override detected (user thermostat change) | explicit `indoor_f` injection |

## Test plan

- [ ] Activity Record: nat-vent on/off rows show Indoor temp
- [ ] Activity Record: classification applied rows show Indoor temp
- [ ] Activity Record: override detected rows show Indoor temp
- [ ] Outdoor column populated for nat-vent escalation/outdoor-rise-exit events
- [ ] `TestAltKeyTempFallback` — 3 new tests pass (alt key fallback, indoor/outdoor keys, priority)
- [ ] 2803 tests pass: `python -m pytest tests/ -q`