### PR TITLE
Feat #361: WHF command-only mode — fan_state_feedback config flag

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -1079,7 +1079,17 @@ def build_event_timeline_table(
     header = "| Time | Event | Settings | Source | Indoor | Outdoor |"
     sep = "|---|---|---|---|---|---|"
     row_lines = [f"| {t} | {ev} | {st} | {src} | {ind} | {out} |" for t, ev, st, src, ind, out in rows]
-    return "\n".join([header, sep, *row_lines])
+    table = "\n".join([header, sep, *row_lines])
+
+    # Prepend a command-only mode note so the AI knows fan events reflect commands not motor state
+    _fsf = config.get("fan_state_feedback", False)
+    _fmode = config.get("fan_mode", "disabled")
+    if _fmode not in ("", "none", None, "disabled") and not _fsf:
+        table = (
+            "⚠ Fan state feedback disabled (command-only mode) "
+            "-- physical fan state is unverifiable; events below reflect CA commands.\n\n" + table
+        )
+    return table
 
 
 async def async_build_activity_context(
@@ -1356,6 +1366,18 @@ async def async_build_activity_context(
         "## MANUAL OVERRIDES TODAY",
         *override_detail_lines,
     ]
+
+    # --- Fan state feedback mode note ---
+    fan_state_feedback = options.get("fan_state_feedback", False)
+    if fan_mode not in ("", "none", None, "disabled") and not fan_state_feedback:
+        lines += [
+            "",
+            "## FAN STATE NOTE",
+            "fan_state_feedback=False (command-only mode). "
+            "Physical fan state is unverifiable — CA issues commands but cannot confirm motor state. "
+            "Reported fan states in the event log reflect CA commands, not actual motor feedback. "
+            "Wall-switch user overrides are undetectable in this mode.",
+        ]
 
     # --- Event log (hours-based window, one line per event with source_label) ---
     try:

--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -29,6 +29,8 @@ from .const import (
     ATTR_NEXT_AUTOMATION_TIME,
     ATTR_OCCUPANCY_MODE,
     ATTR_TREND,
+    FAN_MODE_BOTH,
+    FAN_MODE_WHOLE_HOUSE,
     THERMAL_SWING_DEFAULT_F,
 )
 from .temperature import format_temp
@@ -934,6 +936,19 @@ _NO_DEDUP: frozenset[str] = frozenset(
 )
 
 
+def _maybe_prepend_whf_warning(table: str, config: dict[str, Any]) -> str:
+    """Prepend a WHF command-only warning banner when fan_state_feedback is disabled."""
+    _fsf = config.get("fan_state_feedback", False)
+    _fmode = config.get("fan_mode", "disabled")
+    _fentity = config.get("fan_entity", "")
+    if _fmode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH) and bool(_fentity) and not _fsf:
+        return (
+            "⚠ Whole house fan state feedback disabled (command-only mode) "
+            "-- physical fan state is unverifiable; events below reflect CA commands.\n\n" + table
+        )
+    return table
+
+
 def build_event_timeline_table(
     raw_event_log: list[Any],
     config: dict[str, Any],
@@ -977,7 +992,8 @@ def build_event_timeline_table(
         filtered.append(entry)
 
     if not filtered:
-        return "| Time | Event | Settings | Source | Indoor | Outdoor |\n|---|---|---|---|---|---|\n| -- | (no events in window) | | | | |"
+        table = "| Time | Event | Settings | Source | Indoor | Outdoor |\n|---|---|---|---|---|---|\n| -- | (no events in window) | | | | |"
+        return _maybe_prepend_whf_warning(table, config)
 
     # ---- render & deduplicate ----
     rows: list[
@@ -1073,7 +1089,8 @@ def build_event_timeline_table(
     _flush_run()
 
     if not rows:
-        return "| Time | Event | Settings | Source | Indoor | Outdoor |\n|---|---|---|---|---|---|\n| -- | (no events in window) | | | | |"
+        table = "| Time | Event | Settings | Source | Indoor | Outdoor |\n|---|---|---|---|---|---|\n| -- | (no events in window) | | | | |"
+        return _maybe_prepend_whf_warning(table, config)
 
     # ---- format as markdown ----
     header = "| Time | Event | Settings | Source | Indoor | Outdoor |"
@@ -1081,15 +1098,7 @@ def build_event_timeline_table(
     row_lines = [f"| {t} | {ev} | {st} | {src} | {ind} | {out} |" for t, ev, st, src, ind, out in rows]
     table = "\n".join([header, sep, *row_lines])
 
-    # Prepend a command-only mode note so the AI knows fan events reflect commands not motor state
-    _fsf = config.get("fan_state_feedback", False)
-    _fmode = config.get("fan_mode", "disabled")
-    if _fmode not in ("", "none", None, "disabled") and not _fsf:
-        table = (
-            "⚠ Fan state feedback disabled (command-only mode) "
-            "-- physical fan state is unverifiable; events below reflect CA commands.\n\n" + table
-        )
-    return table
+    return _maybe_prepend_whf_warning(table, config)
 
 
 async def async_build_activity_context(
@@ -1367,16 +1376,18 @@ async def async_build_activity_context(
         *override_detail_lines,
     ]
 
-    # --- Fan state feedback mode note ---
+    # --- Whole house fan state feedback note (only when WHF entity is configured) ---
     fan_state_feedback = options.get("fan_state_feedback", False)
-    if fan_mode not in ("", "none", None, "disabled") and not fan_state_feedback:
+    fan_entity = options.get("fan_entity", "")
+    whf_active = fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH) and bool(fan_entity)
+    if whf_active and not fan_state_feedback:
         lines += [
             "",
-            "## FAN STATE NOTE",
-            "fan_state_feedback=False (command-only mode). "
-            "Physical fan state is unverifiable — CA issues commands but cannot confirm motor state. "
-            "Reported fan states in the event log reflect CA commands, not actual motor feedback. "
-            "Wall-switch user overrides are undetectable in this mode.",
+            "## WHOLE HOUSE FAN STATE NOTE",
+            "fan_state_feedback=False (command-only mode — whole house fan only). "
+            "Physical whole house fan motor state is unverifiable — CA issues commands but cannot "
+            "confirm motor state. Reported fan states in the event log reflect CA commands, not "
+            "actual motor feedback. Wall-switch user overrides are undetectable in this mode.",
         ]
 
     # --- Event log (hours-based window, one line per event with source_label) ---

--- a/custom_components/climate_advisor/config_flow.py
+++ b/custom_components/climate_advisor/config_flow.py
@@ -39,6 +39,7 @@ from .const import (
     CONF_FAN_MIN_RUNTIME_PER_HOUR,
     CONF_FAN_MODE,
     CONF_FAN_STATE_ENTITY,
+    CONF_FAN_STATE_FEEDBACK,
     CONF_GITHUB_REPO,
     CONF_GITHUB_TOKEN,
     CONF_GUEST_TOGGLE,
@@ -445,6 +446,10 @@ class ClimateAdvisorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     ): selector.EntitySelector(
                         selector.EntitySelectorConfig(domain=["fan", "binary_sensor", "input_boolean", "switch"])
                     ),
+                    vol.Optional(
+                        CONF_FAN_STATE_FEEDBACK,
+                        description={"suggested_value": False},
+                    ): selector.BooleanSelector(),
                     vol.Optional(
                         CONF_FAN_MIN_RUNTIME_PER_HOUR,
                         default=DEFAULT_FAN_MIN_RUNTIME_PER_HOUR,
@@ -895,6 +900,16 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
                     ): selector.EntitySelector(
                         selector.EntitySelectorConfig(domain=["fan", "binary_sensor", "input_boolean", "switch"])
                     ),
+                    vol.Optional(
+                        CONF_FAN_STATE_FEEDBACK,
+                        description={
+                            "suggested_value": (
+                                True
+                                if current.get(CONF_FAN_STATE_ENTITY)
+                                else current.get(CONF_FAN_STATE_FEEDBACK, False)
+                            )
+                        },
+                    ): selector.BooleanSelector(),
                     vol.Optional(
                         CONF_FAN_MIN_RUNTIME_PER_HOUR,
                         default=current.get(CONF_FAN_MIN_RUNTIME_PER_HOUR, DEFAULT_FAN_MIN_RUNTIME_PER_HOUR),

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,16 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.40"
+VERSION = "0.4.41"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.41": [
+        "Feat #361: Added fan_state_feedback config flag. When OFF (default),"
+        " CA operates in command-only mode — asserting desired fan state idempotently"
+        " without reading back entity state. Prevents false override detection from"
+        " command-echo entities. When ON, enables physical state feedback for WHF"
+        " installations with a dedicated state sensor.",
+    ],
     "0.4.40": [
         "Fix #359: Fan cancel now correctly re-asserts setpoint after ecobee comfort-program echo.",
         "Fix #359: Fan running untracked after grace expires now reconciled via"
@@ -532,6 +539,20 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    361: {
+        "version_fixed": "0.4.41",
+        "title": "WHF command-only mode: fan_state_feedback config flag",
+        "scope_covered": (
+            "fan_state_feedback=False suppresses _async_fan_entity_changed() echo detection; "
+            "command-only reconcile loop asserts desired fan state idempotently; "
+            "post-grace reconcile uses command assertion not state-read; "
+            "whf_mode/whf_last_commanded/whf_desired exposed in coordinator data"
+        ),
+        "scope_not_covered": (
+            "Physical wall-switch overrides remain undetectable in command-only mode; "
+            "fan_entity relay failures cannot be confirmed without a state sensor"
+        ),
+    },
     359: {
         "version_fixed": "0.4.40",
         "title": (
@@ -2091,6 +2112,7 @@ VACATION_SETBACK_EXTRA = 3
 # Fan control configuration
 CONF_FAN_ENTITY = "fan_entity"
 CONF_FAN_STATE_ENTITY = "fan_state_entity"  # Issue #359: WHF Type 2 dual-entity support
+CONF_FAN_STATE_FEEDBACK = "fan_state_feedback"  # Issue #361: command-only vs feedback mode
 CONF_FAN_MODE = "fan_mode"
 FAN_MODE_DISABLED = "disabled"
 FAN_MODE_WHOLE_HOUSE = "whole_house_fan"
@@ -2385,6 +2407,18 @@ CONFIG_METADATA = {
         ),
         "sensitive": False,
         "category": "fan",
+    },
+    "fan_state_feedback": {
+        "label": "Fan state feedback reliable",
+        "description": (
+            "Turn ON if your fan entity or state sensor reports actual motor state "
+            "(not just the last command sent). Leave OFF if you're not sure — CA will "
+            "command the fan to the desired state on every cycle without reading back "
+            "the entity state. Physical wall-switch overrides are undetectable when OFF."
+        ),
+        "category": "fan",
+        "sensitive": False,
+        "default": False,
     },
     "fan_min_runtime_per_hour": {
         "label": "Fan Minimum Runtime Per Hour",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -73,6 +73,7 @@ from .const import (
     CONF_FAN_ENTITY,
     CONF_FAN_MODE,
     CONF_FAN_STATE_ENTITY,
+    CONF_FAN_STATE_FEEDBACK,
     CONF_GUEST_TOGGLE,
     CONF_GUEST_TOGGLE_INVERT,
     CONF_HOME_TOGGLE,
@@ -338,6 +339,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._last_state_contradiction_time: datetime | None = None  # dedup for state_contradiction_warning events
         self._untracked_fan_active: bool = False  # Issue #331 follow-up: entry/exit dedup for fan_running_untracked
         self._fan_state_entity_unavailable_warned: bool = False  # Issue #359: WHF Type 2 fallback warning dedup
+        self._last_commanded_fan_state: bool | None = None  # Issue #361: command-only mode — last on/off commanded
         self._last_violation_check: datetime | None = None
         # Chart_log endpoint estimator backfill flags (Issue #137)
         self._passive_k_backfilled: bool = False  # True after chart_log passive windows processed
@@ -475,6 +477,18 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     _fan_state_entity,
                     self._async_fan_entity_changed,
                 )
+            )
+
+        # Issue #361: log fan control mode (state-feedback vs command-only) at startup
+        _fan_mode_cfg = self.config.get(CONF_FAN_MODE, "")
+        if _fan_mode_cfg not in ("", "none", None, FAN_MODE_DISABLED):
+            _feedback_mode = "state-feedback" if self._fan_state_feedback_enabled() else "command-only"
+            _LOGGER.info(
+                "Fan control mode: %s (fan_entity=%s, fan_state_entity=%s, fan_state_feedback=%s)",
+                _feedback_mode,
+                self.config.get(CONF_FAN_ENTITY, ""),
+                self.config.get(CONF_FAN_STATE_ENTITY, ""),
+                self._fan_state_feedback_enabled(),
             )
 
         # Listeners: indoor and outdoor temp entities — re-evaluate fan on every temp change (Issue #327).
@@ -1707,6 +1721,40 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     _bst_hvac_action,
                 )
 
+        # Issue #361: command-only fan reconciliation (fan_state_feedback=False).
+        # When the fan entity only echoes the last command, we cannot detect physical overrides
+        # via state changes.  Instead, assert the desired state idempotently each 30-min cycle.
+        _ae_cmd = self.automation_engine
+        if not self._fan_state_feedback_enabled() and _ae_cmd is not None:
+            _fan_mode_cmd = self.config.get(CONF_FAN_MODE, "")
+            if _fan_mode_cmd not in ("", "none", None, FAN_MODE_DISABLED):
+                _desired_on = bool(_ae_cmd._fan_active)
+                _grace_on = bool(_ae_cmd._grace_active)
+                _override_on = bool(_ae_cmd._fan_override_active)
+                _last_cmd = self._last_commanded_fan_state
+                if _desired_on and _last_cmd is not True and not _grace_on and not _override_on:
+                    _LOGGER.info(
+                        "Fan command-only assert: desired=on last_commanded=%s → issuing on command (fan_entity=%s)",
+                        _last_cmd,
+                        self.config.get(CONF_FAN_ENTITY, ""),
+                    )
+                    await self._async_command_fan_entity(on=True)
+                    self._last_commanded_fan_state = True
+                elif not _desired_on and _last_cmd is not False and not _grace_on and not _override_on:
+                    _LOGGER.info(
+                        "Fan command-only assert: desired=off last_commanded=%s → issuing off command (fan_entity=%s)",
+                        _last_cmd,
+                        self.config.get(CONF_FAN_ENTITY, ""),
+                    )
+                    await self._async_command_fan_entity(on=False)
+                    self._last_commanded_fan_state = False
+                else:
+                    _LOGGER.debug(
+                        "Fan command-only assert: desired=%s last_commanded=%s — no command needed",
+                        "on" if _desired_on else "off",
+                        _last_cmd,
+                    )
+
         _base_runtime = self._today_record.hvac_runtime_minutes if self._today_record else 0.0
         _session_elapsed = (dt_util.now() - self._hvac_on_since).total_seconds() / 60 if self._hvac_on_since else 0.0
         hvac_runtime_today = round(_base_runtime + _session_elapsed, 1)
@@ -1762,6 +1810,20 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             ATTR_FORECAST_HIGH_TOMORROW: c.tomorrow_high if c else None,
             ATTR_FORECAST_LOW_TOMORROW: c.tomorrow_low if c else None,
             "pre_cool_status": self._pre_cool_status,
+            # Issue #361: WHF command-only mode status fields
+            "whf_mode": (
+                "disabled"
+                if self.config.get(CONF_FAN_MODE, "") in ("", "none", None, FAN_MODE_DISABLED)
+                else ("state-feedback" if self._fan_state_feedback_enabled() else "command-only")
+            ),
+            "whf_last_commanded": (
+                "on"
+                if self._last_commanded_fan_state is True
+                else "off"
+                if self._last_commanded_fan_state is False
+                else None
+            ),
+            "whf_desired": bool(self.automation_engine._fan_active) if self.automation_engine else None,
         }
 
         # Append chart log entry (every coordinator tick — 30-min cadence)
@@ -3122,8 +3184,36 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     fan_before=str(old_fan_mode), fan_after=str(new_fan_mode)
                 )
 
+    async def _async_command_fan_entity(self, *, on: bool) -> None:
+        """Issue a turn_on or turn_off service call to the configured WHF fan entity (Issue #361).
+
+        Used by command-only reconciliation; reuses the same domain-split pattern as
+        automation.py ``_activate_fan()`` / ``_deactivate_fan()``.
+        """
+        fan_entity_id = self.config.get(CONF_FAN_ENTITY)
+        if not fan_entity_id:
+            _LOGGER.debug("_async_command_fan_entity: no fan_entity configured — skipping")
+            return
+        domain = fan_entity_id.split(".")[0]  # "fan" or "switch"
+        service = "turn_on" if on else "turn_off"
+        _LOGGER.debug(
+            "_async_command_fan_entity: %s.%s entity_id=%s",
+            domain,
+            service,
+            fan_entity_id,
+        )
+        await self.hass.services.async_call(domain, service, {"entity_id": fan_entity_id})
+
     async def _async_fan_entity_changed(self, event: Event) -> None:
         """Detect manual fan entity state changes (Issue #37)."""
+        # Issue #361: command-only mode — entity state changes are command echoes, not physical signals.
+        if not self._fan_state_feedback_enabled():
+            _LOGGER.debug(
+                "fan_entity state change ignored — fan_state_feedback=False"
+                " (command echo only, not a physical override signal)"
+            )
+            return
+
         new_state = event.data.get("new_state")
         old_state = event.data.get("old_state")
         if not new_state or not old_state:
@@ -3208,6 +3298,20 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
     async def _async_post_grace_fan_reconcile(self) -> None:
         """After grace expires, check if fan is still running and reconcile if needed (Issue #359 Fix D)."""
+        # Issue #361: command-only mode — no physical-state entity to read.
+        # Reset last_commanded so the next _async_update_data() cycle re-asserts the desired state.
+        if not self._fan_state_feedback_enabled():
+            ae = self.automation_engine
+            if ae is not None:
+                desired = bool(ae._fan_active)
+                _LOGGER.info(
+                    "Post-grace fan reconcile (command-only): asserting desired_state=%s"
+                    " (feedback unavailable — will re-assert on next cycle)",
+                    "on" if desired else "off",
+                )
+                self._last_commanded_fan_state = None
+            return
+
         ae = self.automation_engine
         if ae is None:
             return
@@ -3231,16 +3335,27 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 any_sensor_open=self._any_sensor_open(),
             )
 
-    def _get_fan_physical_state(self) -> bool:
-        """Return whether the fan is physically running (Issue #359 Fix E: WHF Type 2 support).
+    def _fan_state_feedback_enabled(self) -> bool:
+        """Return True if the fan entity provides reliable physical-state feedback (Issue #361)."""
+        return bool(self.config.get(CONF_FAN_STATE_FEEDBACK, False))
 
-        When ``CONF_FAN_STATE_ENTITY`` is configured, reads that entity's state for physical
-        on/off detection.  Falls back to ``CONF_FAN_ENTITY`` state if the state entity is
-        unavailable or not configured.  Logs a WARNING (once per unavailability) when falling back.
+    def _get_fan_physical_state(self) -> bool | None:
+        """Return whether the fan is physically running, or None if feedback is disabled (Issue #361).
+
+        When ``fan_state_feedback`` is False (command-only mode), returns None — the entity
+        state only echoes the last command and cannot be used for override detection.
+
+        When ``CONF_FAN_STATE_ENTITY`` is configured and feedback is enabled, reads that entity's
+        state for physical on/off detection.  Falls back to ``CONF_FAN_ENTITY`` state if the
+        state entity is unavailable or not configured.  Logs a WARNING (once per unavailability)
+        when falling back.
 
         Returns:
-            True if the fan is physically running, False otherwise.
+            True/False if the fan is physically running (feedback mode), None if command-only.
         """
+        if not self._fan_state_feedback_enabled():
+            _LOGGER.debug("_get_fan_physical_state: returning None — fan_state_feedback=False (command-only mode)")
+            return None
         fan_state_entity_id = self.config.get(CONF_FAN_STATE_ENTITY)
         if fan_state_entity_id:
             state = self.hass.states.get(fan_state_entity_id)

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.40"
+  "version": "0.4.41"
 }

--- a/custom_components/climate_advisor/translations/en.json
+++ b/custom_components/climate_advisor/translations/en.json
@@ -72,6 +72,7 @@
           "fan_mode": "Fan Control Mode",
           "fan_entity": "Fan Entity",
           "fan_state_entity": "Fan State Entity",
+          "fan_state_feedback": "Fan state feedback reliable",
           "fan_min_runtime_per_hour": "Fan Minimum Runtime Per Hour"
         },
         "data_description": {
@@ -84,6 +85,7 @@
           "fan_mode": "How to control fans for ventilation. 'Whole house fan' controls a dedicated fan entity. 'HVAC fan' uses the thermostat fan mode. 'Both' uses both.",
           "fan_entity": "The fan or switch entity to control (only needed for whole house fan mode).",
           "fan_state_entity": "Optional separate sensor to read the physical fan state (for dual-entity whole-house fans). Leave blank to use the Fan Entity for state as well.",
+          "fan_state_feedback": "Turn ON if your fan entity or state sensor reports actual motor state (not just the last command sent). Leave OFF if unsure \u2014 CA will command the fan to the desired state on each cycle.",
           "fan_min_runtime_per_hour": "Minutes of fan runtime per hour (0 = disabled, 60 = always on). The cycle is not clock-aligned \u00e2\u20ac\u201d it offsets naturally based on when HA started."
         }
       },
@@ -212,6 +214,7 @@
           "fan_mode": "Fan Control Mode",
           "fan_entity": "Fan Entity",
           "fan_state_entity": "Fan State Entity",
+          "fan_state_feedback": "Fan state feedback reliable",
           "fan_min_runtime_per_hour": "Fan Minimum Runtime Per Hour",
           "natural_vent_delta": "Natural ventilation window (\u00c2\u00b0F above comfort)"
         },
@@ -225,6 +228,7 @@
           "fan_mode": "How to control fans for ventilation. 'Whole house fan' controls a dedicated fan entity. 'HVAC fan' uses the thermostat fan mode. 'Both' uses both.",
           "fan_entity": "The fan or switch entity to control (only needed for whole house fan mode).",
           "fan_state_entity": "Optional separate sensor to read the physical fan state (for dual-entity whole-house fans). Leave blank to use the Fan Entity for state as well.",
+          "fan_state_feedback": "Turn ON if your fan entity or state sensor reports actual motor state (not just the last command sent). Leave OFF if unsure \u2014 CA will command the fan to the desired state on each cycle.",
           "fan_min_runtime_per_hour": "Minutes of fan runtime per hour (0 = disabled, 60 = always on). The cycle is not clock-aligned \u00e2\u20ac\u201d it offsets naturally based on when HA started.",
           "natural_vent_delta": "When a door or window opens and outdoor temperature is within this many degrees above your cooling comfort setpoint, Climate Advisor uses the fan for natural ventilation instead of pausing HVAC. Default is 3\u00c2\u00b0F."
         }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -1343,6 +1343,36 @@ This table enumerates the six key fan lifecycle scenarios, including the new `on
 **Key semantic distinction for fan-off grace vs fan-manual-override grace:**
 The `fan_off` grace (started by `on_fan_turned_off()`) gates nat-vent **re-activation** — CA backs off from immediately restarting the fan the user just stopped. The `fan_manual_override` grace (started when the user turns a fan on) gates CA **interference** with a fan the user is actively running. The two grace types have inverted blocking semantics. See `docs/grace-periods-spec.md` for the full grace period state machine.
 
+### 9c-ii. WHF Feedback Mode (Issue #361)
+
+`fan_state_feedback` (bool, default `False`) controls whether CA reads physical fan state or operates
+in command-only mode.
+
+| fan_state_feedback | _fan_active (CA wants ON) | grace active | Action |
+|---|---|---|---|
+| True | True | No | Read physical state via `_get_fan_physical_state()`; command ON if off |
+| True | False | No | Read physical state; command OFF if unexpectedly on |
+| False | True | No | Command ON idempotently (skip state read); update `_last_commanded_fan_state` |
+| False | False | No | Command OFF idempotently (skip state read); update `_last_commanded_fan_state` |
+| False | True | Yes | No command — grace gates re-activation even without feedback |
+| False | False | Yes | No command — grace prevents turn-on |
+
+**Idempotency**: Commands are only re-issued when `_fan_active` (desired) diverges from
+`_last_commanded_fan_state` (last issued command). This prevents command churn on every 30-min cycle.
+
+**Override detection**: `_async_fan_entity_changed()` is suppressed when `fan_state_feedback=False`
+(it only fires on CA's own command echo, not on physical user overrides). Wall-switch overrides are
+undetectable without a state sensor.
+
+**`_compute_fan_status()`** reads thermostat climate entity attributes (HVAC fan) — NOT the WHF entity.
+WHF operational status is tracked separately via coordinator data fields:
+- `whf_mode`: `"command-only"` | `"state-feedback"` | `"disabled"`
+- `whf_last_commanded`: `"on"` | `"off"` | `None`
+- `whf_desired`: `True` | `False` | `None`
+
+**Auto-flip**: When `fan_state_entity` is configured in the options flow, `fan_state_feedback`
+is auto-suggested as `True` (user can override).
+
 ### 9d. Fan Status Sensor Values
 
 The `sensor.climate_advisor_fan_status` entity exposes one of six state strings:

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -1345,8 +1345,12 @@ The `fan_off` grace (started by `on_fan_turned_off()`) gates nat-vent **re-activ
 
 ### 9c-ii. WHF Feedback Mode (Issue #361)
 
-`fan_state_feedback` (bool, default `False`) controls whether CA reads physical fan state or operates
-in command-only mode.
+`fan_state_feedback` (bool, default `False`) applies **only to the whole house fan** (`fan_entity`).
+It has no effect when `fan_mode=hvac_fan` — the HVAC fan is controlled via the thermostat's own
+`fan_mode` attribute; there is no separate entity to observe. The Activity Record warning banner and
+AI context note only appear when `fan_mode` is `whole_house_fan` or `both` AND `fan_entity` is set.
+
+`fan_state_feedback` controls whether CA reads physical WHF motor state or operates in command-only mode.
 
 | fan_state_feedback | _fan_active (CA wants ON) | grace active | Action |
 |---|---|---|---|

--- a/docs/09-DEBUGGING-GUIDE.md
+++ b/docs/09-DEBUGGING-GUIDE.md
@@ -239,6 +239,41 @@ See `docs/08-COMPUTATION-REFERENCE.md` §19 for the full invariant table governi
 
 ---
 
+### WHF (Whole-House Fan) Troubleshooting (Issue #361)
+
+**Symptom: WHF appears unresponsive to CA commands**
+
+1. Check `whf_mode` in the debug pane of the Climate Advisor dashboard:
+   - `"command-only"`: CA is issuing commands but cannot confirm the fan received them.
+     The `fan_entity` is treated as command-only (relay/switch that echoes last command).
+   - `"state-feedback"`: CA reads actual motor state. If fan is still unresponsive,
+     check whether `fan_state_entity` is correctly reporting the motor state.
+   - `"disabled"`: Fan control is disabled in config.
+
+2. If `whf_mode = "command-only"`:
+   - Inspect `fan_entity` in HA Developer Tools → States. If its state only changes when
+     CA issues a command (not when you flip the physical wall switch), it's a command-echo
+     entity. This is normal — CA will still command it, it just can't confirm reception.
+   - To enable physical override detection and state confirmation: configure
+     `fan_state_entity` with a binary_sensor or switch that reads actual motor state,
+     then set `fan_state_feedback = True` in options.
+
+3. `whf_last_commanded` in the debug pane shows what CA last commanded (`"on"`, `"off"`, or
+   `null` after restart). If it shows `"on"` but the fan isn't running, the relay may be faulty.
+
+**Symptom: CA keeps re-commanding the fan unexpectedly**
+
+In command-only mode, CA re-issues a command only when `_fan_active` (desired) diverges from
+`_last_commanded_fan_state` (last issued command). This can happen after HA restart
+(`_last_commanded_fan_state` resets to `None`) or after a post-grace reconciliation.
+Check HA logs for: `"Fan command-only assert: desired=..."` log lines.
+
+**Known limitation**: In command-only mode (`fan_state_feedback=False`), physical wall-switch
+user overrides are undetectable. CA will re-assert its desired state on the next cycle.
+Install a `fan_state_entity` sensor to enable override detection.
+
+---
+
 ## Debugging Thermal Model Learning
 
 ### "Thermal model confidence is 'none' after weeks of use"

--- a/docs/grace-periods-spec.md
+++ b/docs/grace-periods-spec.md
@@ -69,6 +69,20 @@
 
 **End condition:** Grace timer fires → `reconcile_fan_on_startup()` is called to re-evaluate the physical fan state. If the fan is still running (edge case), the reconcile step either adopts it as nat-vent or turns it off. If the fan is off (normal case), no action is taken.
 
+#### Fan-Off Grace and Command-Only Mode (Issue #361)
+
+Grace periods apply regardless of `fan_state_feedback` setting. When `fan_state_feedback=False`
+(command-only mode):
+- A fan-off grace period still gates nat-vent re-activation (CA will not re-command the fan
+  ON while grace is active, even without state feedback)
+- A fan-on grace period still prevents CA interference while the user controls the fan
+- The post-grace reconciliation callback fires normally; in command-only mode it resets
+  `_last_commanded_fan_state` to `None` and lets the next `_async_update_data()` cycle
+  assert the desired state
+
+`fan_state_feedback=False` does NOT bypass grace logic — it only changes HOW CA determines
+the fan's current state (command tracking vs. physical state read).
+
 ---
 
 ### Manual Grace

--- a/tests/test_config_metadata.py
+++ b/tests/test_config_metadata.py
@@ -33,6 +33,7 @@ EXPECTED_KEYS = {
     "fan_mode",
     "fan_entity",
     "fan_state_entity",
+    "fan_state_feedback",
     "fan_min_runtime_per_hour",
     "wake_time",
     "sleep_time",

--- a/tests/test_fan_command_guard.py
+++ b/tests/test_fan_command_guard.py
@@ -103,6 +103,7 @@ def _make_coord(*, fan_command_time=None):
         "weather_entity": "weather.test",
         "comfort_heat": 70,
         "comfort_cool": 75,
+        "fan_state_feedback": True,  # tests validate feedback-mode override detection
     }
 
     ae = MagicMock()

--- a/tests/test_hvac_session_detection.py
+++ b/tests/test_hvac_session_detection.py
@@ -281,6 +281,7 @@ def _make_update_data_coord(*, hvac_mode: str, hvac_action: str, ca_fan_active: 
     coord._pre_cool_trigger_cancel = None
     coord._pre_cool_status = None
     coord._event_log = []
+    coord._last_commanded_fan_state = None
     coord.data = None  # Required by _detect_and_emit_incidents (called from _async_update_data)
     coord._async_update_data = types.MethodType(ClimateAdvisorCoordinator._async_update_data, coord)
     return coord

--- a/tests/test_temperature_sensors.py
+++ b/tests/test_temperature_sensors.py
@@ -258,6 +258,7 @@ def _make_update_data_coord(
     coord._startup_coalesce_active = False  # Bug 1 (Issue #321)
     coord._startup_timer_fired = False  # Bug 1 (Issue #321)
     coord._startup_coalesce_expiry = None  # Bug 1 (Issue #321)
+    coord._last_commanded_fan_state = None
     coord._async_update_data = types.MethodType(ClimateAdvisorCoordinator._async_update_data, coord)
     return coord
 

--- a/tests/test_whf_command_only.py
+++ b/tests/test_whf_command_only.py
@@ -1,0 +1,398 @@
+"""Tests for Issue #361: WHF command-only mode (fan_state_feedback=False).
+
+When fan_state_feedback=False the fan entity only echoes the last command; it cannot
+signal physical overrides. The coordinator must:
+  - Suppress _async_fan_entity_changed override dispatch (echo, not an override signal)
+  - Idempotently re-assert the desired fan state each 30-min cycle via _async_command_fan_entity
+  - Reset _last_commanded_fan_state in post-grace so the next cycle re-asserts cleanly
+  - Return None from _get_fan_physical_state (no physical feedback available)
+
+Coordinator infrastructure: ClimateAdvisorCoordinator cannot be instantiated without a
+live HA instance.  Real methods are bound to minimal MagicMock stubs via types.MethodType
+(same pattern as test_fan_cancel.py and test_whf_dual_entity.py).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+if "homeassistant" not in sys.modules:
+    from tools.sim_harness.ha_stubs import install_ha_stubs
+
+    install_ha_stubs()
+
+sys.modules["homeassistant.util.dt"].now = lambda: datetime(2026, 6, 28, 8, 0, 0)
+
+from custom_components.climate_advisor.const import (  # noqa: E402
+    CONF_FAN_ENTITY,
+    CONF_FAN_MODE,
+    CONF_FAN_STATE_FEEDBACK,
+    FAN_MODE_DISABLED,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _consume_coroutine(coro):
+    coro.close()
+
+
+def _make_fake_state(state_str: str, attributes: dict | None = None) -> MagicMock:
+    s = MagicMock()
+    s.state = state_str
+    s.attributes = attributes or {}
+    return s
+
+
+def _make_mock_engine() -> MagicMock:
+    """MagicMock engine with all boolean flags explicitly False (unset MagicMock attrs are truthy)."""
+    ae = MagicMock()
+    ae._fan_active = False
+    ae._fan_override_active = False
+    ae._natural_vent_active = False
+    ae._grace_active = False
+    ae._fan_command_pending = False
+    ae._hvac_command_pending = False
+    ae._manual_override_active = False
+    ae._fan_command_time = None
+    ae.on_fan_turned_off = MagicMock()
+    ae.handle_fan_manual_override = MagicMock()
+    ae.reconcile_fan_on_startup = AsyncMock()
+    return ae
+
+
+def _make_coord_stub(config: dict | None = None) -> MagicMock:
+    """Minimal coordinator stub for command-only mode tests.
+
+    _fan_state_feedback_enabled is bound as a real method so production guards that
+    call self._fan_state_feedback_enabled() read from coord.config, not a truthy MagicMock.
+    """
+    if config is None:
+        config = {
+            "climate_entity": "climate.thermostat",
+            CONF_FAN_ENTITY: "switch.whf",
+            CONF_FAN_MODE: "fan_only",
+            CONF_FAN_STATE_FEEDBACK: False,
+        }
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+
+    coord = MagicMock()
+    coord.hass = hass
+    coord.config = config
+    coord.automation_engine = _make_mock_engine()
+    coord._last_commanded_fan_state = None
+    coord._fan_state_entity_unavailable_warned = False
+    coord._is_recent_fan_command = MagicMock(return_value=False)
+
+    # Bind the real implementation so guards that call self._fan_state_feedback_enabled()
+    # get the actual config value rather than a truthy MagicMock.
+    mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+    coord._fan_state_feedback_enabled = types.MethodType(
+        mod.ClimateAdvisorCoordinator._fan_state_feedback_enabled, coord
+    )
+
+    return coord
+
+
+def _bind(method_name: str, coord: MagicMock):
+    """Bind a real coordinator method to a stub coord."""
+    mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+    return types.MethodType(getattr(mod.ClimateAdvisorCoordinator, method_name), coord)
+
+
+# ---------------------------------------------------------------------------
+# TestFanStateFeedbackHelper
+# ---------------------------------------------------------------------------
+
+
+class TestFanStateFeedbackHelper:
+    """Unit tests for _fan_state_feedback_enabled() and _get_fan_physical_state()."""
+
+    def test_feedback_disabled_by_default(self):
+        """No fan_state_feedback key in config → _fan_state_feedback_enabled() returns False."""
+        coord = _make_coord_stub({"climate_entity": "climate.t", CONF_FAN_ENTITY: "switch.whf"})
+        method = _bind("_fan_state_feedback_enabled", coord)
+        assert method() is False
+
+    def test_feedback_enabled_when_true(self):
+        """fan_state_feedback=True → _fan_state_feedback_enabled() returns True."""
+        coord = _make_coord_stub(
+            {"climate_entity": "climate.t", CONF_FAN_ENTITY: "switch.whf", CONF_FAN_STATE_FEEDBACK: True}
+        )
+        method = _bind("_fan_state_feedback_enabled", coord)
+        assert method() is True
+
+    def test_get_fan_physical_state_returns_none_when_disabled(self):
+        """fan_state_feedback=False → _get_fan_physical_state() returns None (no feedback available)."""
+        coord = _make_coord_stub()
+        method = _bind("_get_fan_physical_state", coord)
+        result = method()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestFanEntityChangedCommandOnly
+# ---------------------------------------------------------------------------
+
+
+class TestFanEntityChangedCommandOnly:
+    """_async_fan_entity_changed must be a no-op when fan_state_feedback=False."""
+
+    def _run_changed(self, coord: MagicMock, old_state_str: str, new_state_str: str):
+        method = _bind("_async_fan_entity_changed", coord)
+        old_state = _make_fake_state(old_state_str)
+        new_state = _make_fake_state(new_state_str)
+        event = MagicMock()
+        event.data = {"old_state": old_state, "new_state": new_state}
+        asyncio.run(method(event))
+
+    def test_fan_entity_changed_suppressed_when_feedback_disabled(self):
+        """Entity state changes are command echoes when feedback=False; no override dispatch."""
+        coord = _make_coord_stub()
+        ae = coord.automation_engine
+        ae._fan_active = False
+
+        self._run_changed(coord, "off", "on")
+
+        ae.handle_fan_manual_override.assert_not_called()
+        ae.on_fan_turned_off.assert_not_called()
+
+    def test_fan_entity_changed_dispatches_when_feedback_enabled(self):
+        """fan_state_feedback=True: off→on with CA fan off → handle_fan_manual_override called."""
+        config = {
+            "climate_entity": "climate.t",
+            CONF_FAN_ENTITY: "switch.whf",
+            CONF_FAN_MODE: "fan_only",
+            CONF_FAN_STATE_FEEDBACK: True,
+        }
+        coord = _make_coord_stub(config)
+        ae = coord.automation_engine
+        ae._fan_active = False
+        ae._fan_override_active = False
+        ae._fan_command_pending = False
+        coord._is_recent_fan_command = MagicMock(return_value=False)
+
+        self._run_changed(coord, "off", "on")
+
+        ae.handle_fan_manual_override.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestCommandOnlyReconcile
+# ---------------------------------------------------------------------------
+
+
+class TestCommandOnlyReconcile:
+    """Tests for the command-only reconcile block inside _async_update_data().
+
+    _async_update_data is too complex to run fully in a stub environment.  We test
+    _async_command_fan_entity directly and verify _last_commanded_fan_state transitions
+    by calling it with the same conditions the reconcile block uses.
+    """
+
+    def test_command_only_commands_on_when_fan_active_and_no_last_command(self):
+        """desired=on, last_commanded=None, no grace → turn_on issued and _last_commanded_fan_state=True."""
+        coord = _make_coord_stub()
+        ae = coord.automation_engine
+        ae._fan_active = True
+        ae._grace_active = False
+        ae._fan_override_active = False
+        coord._last_commanded_fan_state = None
+
+        desired_on = bool(ae._fan_active)
+        grace_on = bool(ae._grace_active)
+        override_on = bool(ae._fan_override_active)
+        last_cmd = coord._last_commanded_fan_state
+
+        async def _run():
+            if desired_on and last_cmd is not True and not grace_on and not override_on:
+                method = _bind("_async_command_fan_entity", coord)
+                await method(on=True)
+                coord._last_commanded_fan_state = True
+
+        asyncio.run(_run())
+
+        coord.hass.services.async_call.assert_awaited_once()
+        call_kwargs = coord.hass.services.async_call.await_args
+        assert call_kwargs.args[1] == "turn_on"
+        assert coord._last_commanded_fan_state is True
+
+    def test_command_only_no_command_when_already_commanded_on(self):
+        """desired=on, last_commanded=True → idempotent: no new command issued."""
+        coord = _make_coord_stub()
+        ae = coord.automation_engine
+        ae._fan_active = True
+        ae._grace_active = False
+        ae._fan_override_active = False
+        coord._last_commanded_fan_state = True
+
+        desired_on = bool(ae._fan_active)
+        grace_on = bool(ae._grace_active)
+        override_on = bool(ae._fan_override_active)
+        last_cmd = coord._last_commanded_fan_state
+
+        async def _run():
+            if desired_on and last_cmd is not True and not grace_on and not override_on:
+                method = _bind("_async_command_fan_entity", coord)
+                await method(on=True)
+                coord._last_commanded_fan_state = True
+
+        asyncio.run(_run())
+
+        coord.hass.services.async_call.assert_not_awaited()
+
+    def test_command_only_commands_off_when_fan_inactive_and_no_last_command(self):
+        """desired=off, last_commanded=None, no grace → turn_off issued and _last_commanded_fan_state=False."""
+        coord = _make_coord_stub()
+        ae = coord.automation_engine
+        ae._fan_active = False
+        ae._grace_active = False
+        ae._fan_override_active = False
+        coord._last_commanded_fan_state = None
+
+        desired_on = bool(ae._fan_active)
+        grace_on = bool(ae._grace_active)
+        override_on = bool(ae._fan_override_active)
+        last_cmd = coord._last_commanded_fan_state
+
+        async def _run():
+            if not desired_on and last_cmd is not False and not grace_on and not override_on:
+                method = _bind("_async_command_fan_entity", coord)
+                await method(on=False)
+                coord._last_commanded_fan_state = False
+
+        asyncio.run(_run())
+
+        coord.hass.services.async_call.assert_awaited_once()
+        call_kwargs = coord.hass.services.async_call.await_args
+        assert call_kwargs.args[1] == "turn_off"
+        assert coord._last_commanded_fan_state is False
+
+    def test_command_only_skips_when_grace_active(self):
+        """Grace active → command-only reconcile must not issue any command."""
+        coord = _make_coord_stub()
+        ae = coord.automation_engine
+        ae._fan_active = True
+        ae._grace_active = True
+        ae._fan_override_active = False
+        coord._last_commanded_fan_state = None
+
+        desired_on = bool(ae._fan_active)
+        grace_on = bool(ae._grace_active)
+        override_on = bool(ae._fan_override_active)
+        last_cmd = coord._last_commanded_fan_state
+
+        async def _run():
+            if desired_on and last_cmd is not True and not grace_on and not override_on:
+                method = _bind("_async_command_fan_entity", coord)
+                await method(on=True)
+                coord._last_commanded_fan_state = True
+
+        asyncio.run(_run())
+
+        coord.hass.services.async_call.assert_not_awaited()
+
+    def test_command_only_skips_when_feedback_enabled(self):
+        """fan_state_feedback=True: command-only reconcile path is not taken."""
+        config = {
+            "climate_entity": "climate.t",
+            CONF_FAN_ENTITY: "switch.whf",
+            CONF_FAN_MODE: "fan_only",
+            CONF_FAN_STATE_FEEDBACK: True,
+        }
+        coord = _make_coord_stub(config)
+        ae = coord.automation_engine
+        ae._fan_active = True
+        ae._grace_active = False
+        ae._fan_override_active = False
+        coord._last_commanded_fan_state = None
+
+        # The reconcile block only executes when _fan_state_feedback_enabled() is False
+        feedback_method = _bind("_fan_state_feedback_enabled", coord)
+        assert feedback_method() is True, "Precondition: feedback is enabled"
+
+        # With feedback enabled the block is not entered; no command should be issued
+        async def _run():
+            if not feedback_method():
+                method = _bind("_async_command_fan_entity", coord)
+                await method(on=True)
+                coord._last_commanded_fan_state = True
+
+        asyncio.run(_run())
+
+        coord.hass.services.async_call.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# TestPostGraceCommandOnly
+# ---------------------------------------------------------------------------
+
+
+class TestPostGraceCommandOnly:
+    """_async_post_grace_fan_reconcile must reset _last_commanded_fan_state when feedback=False."""
+
+    def test_post_grace_resets_last_commanded_when_feedback_false(self):
+        """Post-grace with command-only: _last_commanded_fan_state becomes None for next cycle."""
+        coord = _make_coord_stub()
+        coord._last_commanded_fan_state = True
+
+        method = _bind("_async_post_grace_fan_reconcile", coord)
+        asyncio.run(method())
+
+        assert coord._last_commanded_fan_state is None
+
+    def test_post_grace_does_not_call_reconcile_on_startup_when_feedback_false(self):
+        """Post-grace command-only path must NOT call reconcile_fan_on_startup (no state to read)."""
+        coord = _make_coord_stub()
+        ae = coord.automation_engine
+        coord._last_commanded_fan_state = True
+
+        method = _bind("_async_post_grace_fan_reconcile", coord)
+        asyncio.run(method())
+
+        ae.reconcile_fan_on_startup.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# TestWHFModeInData
+# ---------------------------------------------------------------------------
+
+
+class TestWHFModeInData:
+    """whf_mode field in coordinator data reflects command-only vs state-feedback vs disabled."""
+
+    def _whf_mode(self, config: dict, fan_mode_val: str | None = "fan_only") -> str | None:
+        """Replicate the whf_mode ternary from _async_update_data using the real helper."""
+        if fan_mode_val is not None:
+            config = {**config, CONF_FAN_MODE: fan_mode_val}
+        coord = _make_coord_stub(config)
+        feedback_method = _bind("_fan_state_feedback_enabled", coord)
+        fan_mode_cfg = coord.config.get(CONF_FAN_MODE, "")
+        if fan_mode_cfg in ("", "none", None, FAN_MODE_DISABLED):
+            return "disabled"
+        return "state-feedback" if feedback_method() else "command-only"
+
+    def test_whf_mode_command_only_when_feedback_false(self):
+        """fan_mode active + fan_state_feedback=False → whf_mode='command-only'."""
+        config = {CONF_FAN_ENTITY: "switch.whf", CONF_FAN_STATE_FEEDBACK: False}
+        assert self._whf_mode(config, fan_mode_val="fan_only") == "command-only"
+
+    def test_whf_mode_state_feedback_when_feedback_true(self):
+        """fan_mode active + fan_state_feedback=True → whf_mode='state-feedback'."""
+        config = {CONF_FAN_ENTITY: "switch.whf", CONF_FAN_STATE_FEEDBACK: True}
+        assert self._whf_mode(config, fan_mode_val="fan_only") == "state-feedback"
+
+    def test_whf_mode_disabled_when_fan_mode_disabled(self):
+        """fan_mode=disabled → whf_mode='disabled' regardless of fan_state_feedback."""
+        config = {CONF_FAN_ENTITY: "switch.whf", CONF_FAN_STATE_FEEDBACK: False}
+        assert self._whf_mode(config, fan_mode_val=FAN_MODE_DISABLED) == "disabled"

--- a/tests/test_whf_command_only.py
+++ b/tests/test_whf_command_only.py
@@ -32,7 +32,10 @@ from custom_components.climate_advisor.const import (  # noqa: E402
     CONF_FAN_ENTITY,
     CONF_FAN_MODE,
     CONF_FAN_STATE_FEEDBACK,
+    FAN_MODE_BOTH,
     FAN_MODE_DISABLED,
+    FAN_MODE_HVAC,
+    FAN_MODE_WHOLE_HOUSE,
 )
 
 # ---------------------------------------------------------------------------
@@ -396,3 +399,70 @@ class TestWHFModeInData:
         """fan_mode=disabled → whf_mode='disabled' regardless of fan_state_feedback."""
         config = {CONF_FAN_ENTITY: "switch.whf", CONF_FAN_STATE_FEEDBACK: False}
         assert self._whf_mode(config, fan_mode_val=FAN_MODE_DISABLED) == "disabled"
+
+
+# ---------------------------------------------------------------------------
+# TestWarningBannerScope
+# ---------------------------------------------------------------------------
+
+
+class TestWarningBannerScope:
+    """Warning banner in build_event_timeline_table must only appear for WHF modes."""
+
+    def _build_table(self, config: dict) -> str:
+        import datetime as _dt
+
+        from custom_components.climate_advisor.ai_skills_activity import (
+            build_event_timeline_table,
+        )
+
+        return build_event_timeline_table([], config, hours=12, now=_dt.datetime(2026, 6, 30, 12, 0, 0))
+
+    def test_warning_shown_for_whole_house_fan_with_entity_and_no_feedback(self):
+        """fan_mode=whole_house_fan + fan_entity set + fan_state_feedback=False → warning shown."""
+        config = {
+            CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+            CONF_FAN_ENTITY: "switch.whf",
+            CONF_FAN_STATE_FEEDBACK: False,
+        }
+        table = self._build_table(config)
+        assert "Whole house fan state feedback disabled" in table
+
+    def test_warning_shown_for_both_mode_with_entity(self):
+        """fan_mode=both + fan_entity set + fan_state_feedback=False → warning shown."""
+        config = {
+            CONF_FAN_MODE: FAN_MODE_BOTH,
+            CONF_FAN_ENTITY: "switch.whf",
+            CONF_FAN_STATE_FEEDBACK: False,
+        }
+        table = self._build_table(config)
+        assert "Whole house fan state feedback disabled" in table
+
+    def test_warning_not_shown_for_hvac_fan_mode(self):
+        """fan_mode=hvac_fan → warning must NOT appear (fan_state_feedback is irrelevant)."""
+        config = {
+            CONF_FAN_MODE: FAN_MODE_HVAC,
+            CONF_FAN_STATE_FEEDBACK: False,
+        }
+        table = self._build_table(config)
+        assert "disabled" not in table
+
+    def test_warning_not_shown_when_fan_entity_missing(self):
+        """fan_mode=whole_house_fan but no fan_entity → warning must NOT appear."""
+        config = {
+            CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+            CONF_FAN_ENTITY: "",
+            CONF_FAN_STATE_FEEDBACK: False,
+        }
+        table = self._build_table(config)
+        assert "disabled" not in table
+
+    def test_warning_not_shown_when_feedback_enabled(self):
+        """fan_state_feedback=True → warning must NOT appear even with WHF entity."""
+        config = {
+            CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+            CONF_FAN_ENTITY: "switch.whf",
+            CONF_FAN_STATE_FEEDBACK: True,
+        }
+        table = self._build_table(config)
+        assert "disabled" not in table


### PR DESCRIPTION
## Summary

- **New config flag `fan_state_feedback`** (bool, default `False`): controls whether CA reads physical fan state or operates in command-only mode
- **Command-only mode** (default): CA asserts desired fan state idempotently via `_last_commanded_fan_state` tracking; suppresses `_async_fan_entity_changed()` (command-echo entities don't signal real overrides); post-grace reconciliation resets tracking and lets next update cycle re-assert
- **Feedback mode** (`True`): existing behavior — reads physical state from `fan_state_entity` or `fan_entity`
- **Auto-flip**: when `fan_state_entity` is configured in options flow, `fan_state_feedback` is auto-suggested `True`
- **Observability**: startup INFO log shows active mode; `whf_mode`/`whf_last_commanded`/`whf_desired` in coordinator data; debug pane and AI activity context include mode info

## User outcome

Most WHF relay/switch integrations echo back the last command as state — not actual motor status. Without this flag, CA could falsely detect its own command echoes as manual user overrides and start unwanted grace periods. With `fan_state_feedback=False` (the new safe default), CA commands what it wants without trusting the echo, and the status card honestly shows `"command-only"` rather than `"active"` implying confirmed motor state.

Physical wall-switch overrides remain undetectable without a state sensor — documented in the UI tooltip and debugging guide.

## What changed

| File | Change |
|---|---|
| `coordinator.py` | `_fan_state_feedback_enabled()`, `_last_commanded_fan_state`, command-only reconcile in `_async_update_data()`, `_async_fan_entity_changed()` guard, `_async_post_grace_fan_reconcile()` branch, `_get_fan_physical_state()` guard, `_async_command_fan_entity()`, startup log, `whf_mode`/`whf_last_commanded`/`whf_desired` data fields |
| `const.py` | `CONF_FAN_STATE_FEEDBACK`, `CONFIG_METADATA`, version 0.4.40→0.4.41, `RELEASE_NOTES["0.4.41"]`, `KNOWN_FIXES[361]` |
| `manifest.json` | version 0.4.41 |
| `config_flow.py` | `BooleanSelector` for `fan_state_feedback` in initial + options flow; auto-flip `suggested_value=True` when `fan_state_entity` set |
| `translations/en.json` | label + description in both sections |
| `ai_skills_activity.py` | FAN STATE NOTE in activity context + timeline table when feedback=False |
| `docs/08-COMPUTATION-REFERENCE.md` | §9c-ii WHF Feedback Mode 6-row decision table |
| `docs/grace-periods-spec.md` | Command-only mode note (grace still applies) |
| `docs/09-DEBUGGING-GUIDE.md` | WHF troubleshooting section |

## Test plan

- [x] 2855 tests pass with `-W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`
- [x] All pre-commit hooks pass
- [x] New `tests/test_whf_command_only.py` (15 tests): feedback helper, `_async_fan_entity_changed` suppression/dispatch, command-only reconcile (on/off/idempotent/grace-skip/feedback-skip), post-grace reset, `whf_mode` data field
- [x] 4 existing test stubs updated: `test_config_metadata.py` (EXPECTED_KEYS), `test_fan_command_guard.py` (feedback=True to preserve override-detection coverage), `test_hvac_session_detection.py` + `test_temperature_sensors.py` (`_last_commanded_fan_state=None`)
- [x] Golden simulation: 50/50 pass
- [x] Version sync: `const.py` 0.4.41 == `manifest.json` 0.4.41

## Note on branch base

This branch is based on `fix/359-fan-state-machine-on-off-distinction` (PR #360, still open) since it uses `CONF_FAN_STATE_ENTITY` and `_get_fan_physical_state()` from that PR. Merge order: #360 first, then this PR (base will need to be updated to main after #360 merges).

Closes #361