### PR TITLE
Feat #367: status pane Conditions card (day type + trend + outdoor temp) + HVAC inline indoor

### DIFF
--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -102,8 +102,10 @@ class ClimateAdvisorStatusView(HomeAssistantView):
             target_temp_high = climate_state.attributes.get("target_temp_high")
 
         indoor_temp = coordinator._get_indoor_temp()
+        outdoor_temp = coordinator._last_outdoor_temp
         unit = coordinator.config.get("temp_unit", "fahrenheit")
         indoor_temp_display = round(from_fahrenheit(indoor_temp, unit), 1) if indoor_temp is not None else None
+        outdoor_temp_display = round(from_fahrenheit(outdoor_temp, unit), 1) if outdoor_temp is not None else None
         trend_magnitude_display = round(convert_delta(data.get(ATTR_TREND_MAGNITUDE, 0), unit), 1)
 
         return self.json(
@@ -119,6 +121,7 @@ class ClimateAdvisorStatusView(HomeAssistantView):
                 "target_temp_low": target_temp_low,
                 "target_temp_high": target_temp_high,
                 ATTR_INDOOR_TEMP: indoor_temp_display,
+                "outdoor_temp": outdoor_temp_display,
                 "unit": unit,
                 "automation_status": data.get(ATTR_AUTOMATION_STATUS, "unknown"),
                 "compliance_score": data.get(ATTR_COMPLIANCE_SCORE, 1.0),

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,14 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.43"
+VERSION = "0.4.44"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.44": [
+        "Feat #367: Status pane Conditions card combines day type badge, trend direction/magnitude,"
+        " and current outdoor temperature into a single card. HVAC Mode card now shows indoor"
+        " temperature inline. Standalone Day Type, Trend, and Indoor cards removed.",
+    ],
     "0.4.43": [
         "Fix #365: Fan status now correctly shows 'running (manual override)' when the user"
         " manually turns on a WHF and CA records it as an override (not adopted as nat-vent)."
@@ -549,6 +554,26 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    367: {
+        "version_fixed": "0.4.44",
+        "title": "Status pane: combined Conditions card + HVAC+indoor card",
+        "scope_covered": (
+            "api.py: outdoor_temp added to status response (from coordinator._last_outdoor_temp,"
+            " converted via from_fahrenheit to display unit, same pattern as indoor_temp). "
+            "frontend/index.html loadStatus(): Day Type + Trend cards replaced by Conditions card"
+            " showing badge, trend arrow/magnitude, and outdoor temp; HVAC Mode card renamed 'HVAC'"
+            " and shows indoor temp inline; standalone Indoor card removed. "
+            "tests/test_api.py: _simulate_status_get helper gains outdoor_temp field;"
+            " _make_coordinator gains outdoor_temp param; 3 new tests for outdoor_temp conversion,"
+            " None handling, and Fahrenheit passthrough. "
+            "docs/rest-api.md: status endpoint field list updated."
+        ),
+        "scope_not_covered": (
+            "nat_vent_active and pause_suppressed_classification remain absent from the status API"
+            " response (pre-existing gap — those fields exist in coordinator.data but were not"
+            " wired into api.py before this PR and are not part of this scope)."
+        ),
+    },
     365: {
         "version_fixed": "0.4.43",
         "title": "_compute_fan_status() showed 'off (manual override)' when fan physically running under override",

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -880,27 +880,28 @@
         hvacTemps = data.current_setpoint + unitSym;
       }
 
+      const outdoorDisplay = data.outdoor_temp != null ? data.outdoor_temp.toFixed(1) + unitSym : '—';
+      const indoorDisplay = data.indoor_temp != null ? data.indoor_temp.toFixed(1) + unitSym : '—';
+      const trendLabel = data.trend_direction === 'warming' ? 'warming'
+        : data.trend_direction === 'cooling' ? 'cooling' : 'stable';
+
       grid.innerHTML = `
         <div class="status-item">
-          <div class="label">Day Type</div>
-          <div class="value"><span class="badge ${dayType}">${dayType}</span></div>
+          <div class="label">Conditions</div>
+          <div class="value">
+            <span class="badge ${dayType}">${dayType}</span>
+            <span style="margin-left:0.5rem"><span class="trend-arrow">${trendArrow}</span> ${trendLabel} ${(data.trend_magnitude || 0).toFixed(1)}${unitSym}</span>
+            <br><span style="font-size:0.85rem;opacity:0.75">${outdoorDisplay} outdoors</span>
+          </div>
         </div>
         <div class="status-item">
-          <div class="label">Trend</div>
-          <div class="value"><span class="trend-arrow">${trendArrow}</span> ${(data.trend_magnitude || 0).toFixed(1)}${unitSym}</div>
-        </div>
-        <div class="status-item">
-          <div class="label">HVAC Mode</div>
-          <div class="value">${data.hvac_mode || 'unknown'}${hvacTemps ? `<br><span style="font-size:0.8rem;opacity:0.85">${hvacTemps}</span>` : ''}</div>
+          <div class="label">HVAC</div>
+          <div class="value">${data.hvac_mode || 'unknown'}${hvacTemps ? `<br><span style="font-size:0.8rem;opacity:0.85">${hvacTemps}</span>` : ''}<br><span style="font-size:0.85rem;opacity:0.75">${indoorDisplay} indoors</span></div>
         </div>
         <div class="status-item">
           <div class="label">Status</div>
           <div class="value">${data.automation_status || 'unknown'}</div>
           ${data.pause_suppressed_classification ? `<div class="value">Classification suppressed — HVAC held off until windows close</div>` : ''}
-        </div>
-        <div class="status-item">
-          <div class="label">Indoor</div>
-          <div class="value">${data.indoor_temp != null ? data.indoor_temp.toFixed(1) + unitSym : '—'}</div>
         </div>
         <div class="status-item">
           <div class="label">Occupancy</div>

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.43"
+  "version": "0.4.44"
 }

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -39,7 +39,7 @@ All 19 view classes set `requires_auth = True`. HA handles token validation befo
 
 | URL | Purpose | Key response fields |
 |---|---|---|
-| `/api/climate_advisor/status` | Current system snapshot | `day_type`, `hvac_mode`, `hvac_action`, `indoor_temp`, `unit`, `automation_status`, `occupancy_mode`, `fan_status`, `contact_status`, `manual_override_active`, `next_action`, `compliance_score` |
+| `/api/climate_advisor/status` | Current system snapshot | `day_type`, `trend_direction`, `trend_magnitude`, `hvac_mode`, `hvac_action`, `indoor_temp`, `outdoor_temp`, `unit`, `automation_status`, `occupancy_mode`, `fan_status`, `contact_status`, `manual_override_active`, `next_action`, `compliance_score` |
 | `/api/climate_advisor/briefing` | Today's daily briefing text | `briefing`, `briefing_sent_today`, `verbosity` |
 | `/api/climate_advisor/chart_data` | Temperature forecast chart data | Delegated to `coordinator.get_chart_data(range_str=..., before_ts=...)`. Query params: `range` (string, default `24h`) and `before_ts` (Unix ms, optional). When `before_ts` is absent the window ends at now (live mode); when present the window is anchored at that point for historical navigation. Response includes `target_band` time-series array, `historical_setpoint`, and `predicted_setpoint` arrays (Issue #151, #160). |
 | `/api/climate_advisor/automation_state` | Full automation engine debug state | Delegated to `coordinator.get_debug_state()` |
@@ -100,7 +100,7 @@ Before returning config values, `ClimateAdvisorConfigView` applies these transfo
 
 - **Primary**: `coordinator.data.get(key, default)` — reads from the last 30-minute update cycle snapshot.
 - **Freshness bypass**: `hass.states.get(climate_entity_id)` is called directly for live HVAC state to avoid serving stale data between update cycles.
-- **Private attribute access**: `api.py` reads these coordinator attributes directly by name: `coordinator._last_briefing`, `coordinator._briefing_sent_today`, `coordinator._occupancy_mode`, `coordinator._event_log`, `coordinator._current_classification`, `coordinator.automation_engine` (and the engine's private fields).
+- **Private attribute access**: `api.py` reads these coordinator attributes directly by name: `coordinator._last_briefing`, `coordinator._briefing_sent_today`, `coordinator._occupancy_mode`, `coordinator._event_log`, `coordinator._current_classification`, `coordinator._last_outdoor_temp`, `coordinator.automation_engine` (and the engine's private fields).
 
 ## Security Notes
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -269,7 +269,9 @@ def _simulate_status_get(coordinator):
     data = coordinator.data or {}
     unit = coordinator.config.get("temp_unit", "fahrenheit")
     indoor_temp = coordinator._get_indoor_temp()
+    outdoor_temp = coordinator._last_outdoor_temp
     indoor_temp_display = round(from_fahrenheit(indoor_temp, unit), 1) if indoor_temp is not None else None
+    outdoor_temp_display = round(from_fahrenheit(outdoor_temp, unit), 1) if outdoor_temp is not None else None
     trend_magnitude_display = round(convert_delta(data.get(ATTR_TREND_MAGNITUDE, 0), unit), 1)
     return {
         "day_type": data.get(ATTR_DAY_TYPE, "unknown"),
@@ -277,6 +279,7 @@ def _simulate_status_get(coordinator):
         "trend_magnitude": trend_magnitude_display,
         "hvac_mode": "off",
         "indoor_temp": indoor_temp_display,
+        "outdoor_temp": outdoor_temp_display,
         "current_setpoint": None,
         "target_temp_low": None,
         "target_temp_high": None,
@@ -356,7 +359,7 @@ class TestStatusSetpointExtraction:
 class TestStatusViewCelsiusUnit:
     """Status API must convert temperatures and include 'unit' when temp_unit=celsius."""
 
-    def _make_coordinator(self, temp_unit="celsius", indoor_temp=68.0, trend_magnitude=9.0):
+    def _make_coordinator(self, temp_unit="celsius", indoor_temp=68.0, outdoor_temp=86.0, trend_magnitude=9.0):
         coord = MagicMock()
         coord.config = {"temp_unit": temp_unit, "climate_entity": "climate.test"}
         coord.data = {
@@ -367,6 +370,7 @@ class TestStatusViewCelsiusUnit:
             "compliance_score": 1.0,
         }
         coord._get_indoor_temp.return_value = indoor_temp
+        coord._last_outdoor_temp = outdoor_temp
         coord.automation_enabled = True
         coord._occupancy_mode = "home"
         ae = MagicMock()
@@ -403,6 +407,28 @@ class TestStatusViewCelsiusUnit:
         response = _simulate_status_get(coord)
         assert "unit" in response  # KeyError before fix
         assert response["unit"] == "fahrenheit"
+
+    def test_status_celsius_converts_outdoor_temp(self):
+        """outdoor_temp must be in Celsius when unit=celsius configured (Issue #367)."""
+        import pytest
+
+        coord = self._make_coordinator(temp_unit="celsius", outdoor_temp=86.0)
+        response = _simulate_status_get(coord)
+        assert "outdoor_temp" in response
+        assert response["outdoor_temp"] == pytest.approx(30.0, abs=0.1)  # 86°F → 30°C
+
+    def test_status_outdoor_temp_none_when_unavailable(self):
+        """outdoor_temp must be None when coordinator has no outdoor reading (Issue #367)."""
+        coord = self._make_coordinator(temp_unit="fahrenheit", outdoor_temp=None)
+        coord._last_outdoor_temp = None
+        response = _simulate_status_get(coord)
+        assert response["outdoor_temp"] is None
+
+    def test_status_fahrenheit_outdoor_temp_passthrough(self):
+        """outdoor_temp passes through unconverted when unit=fahrenheit (Issue #367)."""
+        coord = self._make_coordinator(temp_unit="fahrenheit", outdoor_temp=92.0)
+        response = _simulate_status_get(coord)
+        assert response["outdoor_temp"] == 92.0
 
 
 class TestLearningViewCelsiusUnit:


### PR DESCRIPTION
## Summary

- **New Conditions card** — replaces the separate Day Type and Trend cards with a single card showing the day type badge, trend arrow + magnitude, and current outdoor temperature (new API field)
- **HVAC card** — renamed from "HVAC Mode", now shows indoor temperature inline beneath mode and setpoints
- **Eliminated standalone cards**: Day Type, Trend, Indoor (3 cards → 2, net -1 card from grid)

## API change

`GET /api/climate_advisor/status` gains `outdoor_temp` (display-unit float or null), sourced from `coordinator._last_outdoor_temp` using the same `from_fahrenheit()` conversion as `indoor_temp`.

## Files changed

| File | Change |
|---|---|
| `api.py` | Add `outdoor_temp` to status response |
| `frontend/index.html` | Replace Day Type + Trend with Conditions card; add indoor temp to HVAC card; remove Indoor card |
| `tests/test_api.py` | Update `_simulate_status_get` helper; add `outdoor_temp` param to stub; 3 new tests |
| `docs/rest-api.md` | Add `outdoor_temp` and `trend_*` fields to status endpoint field list |
| `const.py` | v0.4.44 RELEASE_NOTES + KNOWN_FIXES #367 |
| `manifest.json` | Version 0.4.44 |

## Test plan

- [ ] All 31 tests in `test_api.py` + `test_version_sync.py` pass with `-W error` flags
- [ ] Status pane shows Conditions card with day type badge, trend arrow + magnitude, outdoor temp
- [ ] Status pane HVAC card shows indoor temp beneath mode/setpoints
- [ ] Day Type, Trend, and Indoor standalone cards are gone
- [ ] `outdoor_temp` is null-safe (shows `—` when coordinator has no outdoor reading)
- [ ] Celsius users see outdoor temp in °C