### PR TITLE
Fix #376: HACS compliance — executor offload, SDK/JS attribution, configurable thresholds (v0.4.50)

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -148,6 +148,37 @@ Any automation phase that changes the thermostat setpoint (even temporarily) MUS
 
 **Violation protocol**: Same as Security — stop, flag, and ask before shipping if a proposed feature lacks logging, status page wiring, or chart coverage.
 
+### Thread-Safety Requirements (CRITICAL)
+
+**Decision**: Any heavy synchronous computation called from an `async` method MUST be offloaded to a thread-pool executor via `await hass.async_add_executor_job()`. Blocking the HA event loop with CPU-bound work causes event loop jitter and can trigger HA watchdog restarts.
+
+#### Rule
+
+Before calling a function from inside an `async def` method, ask: **"Does this run more than ~10 ms of synchronous Python?"** If yes, offload it:
+
+```python
+import functools
+
+result = await self.hass.async_add_executor_job(
+    functools.partial(heavy_sync_function, arg1, arg2, keyword=value)
+)
+```
+
+**Capture all arguments in the event loop thread** (i.e., evaluate `self.*` attributes and helper calls like `self._get_indoor_temp()` before `functools.partial`, not inside the executor). The executor runs the partial with no additional arguments.
+
+#### Canonical Examples
+
+- `_build_predicted_indoor_future()` in `coordinator.py` — ODE integration + OLS math (~400 lines). Called from `_async_update_data()` and `_async_send_briefing()` via executor. Fixed in Issue #376.
+- OLS regression functions in `learning.py` (`compute_k_passive`, `compute_k_active`, etc.) — called from synchronous commit helpers that are themselves invoked via `async_add_executor_job`. Already correct.
+
+#### What Does NOT Need Offloading
+
+- Simple dict lookups, attribute reads, string formatting — these complete in microseconds.
+- Coroutine calls (`await some_async_fn()`) — already non-blocking by definition.
+- I/O already wrapped in `async_add_executor_job` (file reads, DB writes) — do not double-wrap.
+
+**Violation protocol**: Same as Security — stop, flag, and ask before shipping new CPU-heavy code that runs synchronously inside an `async` method.
+
 ### Security Requirements (CRITICAL)
 
 **Decision**: All code written for Climate Advisor MUST follow these security rules. They apply to the integration, deployment tools, and tests.

--- a/custom_components/climate_advisor/__init__.py
+++ b/custom_components/climate_advisor/__init__.py
@@ -59,6 +59,10 @@ from .const import (
     CONF_SLEEP_COOL,
     CONF_SLEEP_HEAT,
     CONF_TEMP_UNIT,
+    CONF_THRESHOLD_COOL,
+    CONF_THRESHOLD_HOT,
+    CONF_THRESHOLD_MILD,
+    CONF_THRESHOLD_WARM,
     CONF_VACATION_TOGGLE,
     CONF_VACATION_TOGGLE_INVERT,
     CONF_WELCOME_HOME_DEBOUNCE,
@@ -80,6 +84,10 @@ from .const import (
     DEFAULT_SENSOR_DEBOUNCE_SECONDS,
     DEFAULT_SETBACK_DEPTH_COOL_F,
     DEFAULT_SETBACK_DEPTH_F,
+    DEFAULT_THRESHOLD_COOL,
+    DEFAULT_THRESHOLD_HOT,
+    DEFAULT_THRESHOLD_MILD,
+    DEFAULT_THRESHOLD_WARM,
     DEFAULT_WELCOME_HOME_DEBOUNCE_SECONDS,
     DOMAIN,
     PANEL_FRONTEND_PATH,
@@ -314,6 +322,16 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         )
         hass.config_entries.async_update_entry(config_entry, data=new_data, version=15)
         _LOGGER.info("Migration to version 15 complete")
+
+    if config_entry.version == 15:
+        _LOGGER.info("Migrating Climate Advisor config entry from version 15 to 16")
+        new_data = {**config_entry.data}
+        new_data.setdefault(CONF_THRESHOLD_HOT, DEFAULT_THRESHOLD_HOT)
+        new_data.setdefault(CONF_THRESHOLD_WARM, DEFAULT_THRESHOLD_WARM)
+        new_data.setdefault(CONF_THRESHOLD_MILD, DEFAULT_THRESHOLD_MILD)
+        new_data.setdefault(CONF_THRESHOLD_COOL, DEFAULT_THRESHOLD_COOL)
+        hass.config_entries.async_update_entry(config_entry, data=new_data, version=16)
+        _LOGGER.info("Migration to version 16 complete")
 
     return True
 

--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 from dataclasses import asdict
@@ -225,7 +226,11 @@ class ClimateAdvisorChartDataView(HomeAssistantView):
             except (ValueError, TypeError):
                 before_ts = None
 
-        return self.json(coordinator.get_chart_data(range_str=range_str, before_ts=before_ts))
+        # get_chart_data runs ODE prediction inline — offload to executor to avoid blocking event loop.
+        chart_data = await hass.async_add_executor_job(
+            functools.partial(coordinator.get_chart_data, range_str=range_str, before_ts=before_ts)
+        )
+        return self.json(chart_data)
 
 
 class ClimateAdvisorAutomationStateView(HomeAssistantView):

--- a/custom_components/climate_advisor/classifier.py
+++ b/custom_components/climate_advisor/classifier.py
@@ -163,25 +163,34 @@ _BAND_LOWER_THRESHOLD = {
 }
 
 
-def _should_stick(today_high: float, previous_day_type: str, margin: float) -> bool:
+def _should_stick(
+    today_high: float,
+    previous_day_type: str,
+    margin: float,
+    band_thresholds: dict[str, float] | None = None,
+) -> bool:
     """Return True if the temperature is in the dead zone around a threshold.
 
     When a prior classification exists, the temperature must move beyond
     the threshold by *margin* degrees to justify switching.  This prevents
     bouncing when the forecast fluctuates near a boundary.
+
+    band_thresholds: optional dict mapping day-type → lower threshold (°F).
+    Defaults to the module-level _BAND_LOWER_THRESHOLD when not supplied.
     """
+    thresholds = band_thresholds if band_thresholds is not None else _BAND_LOWER_THRESHOLD
     prev_idx = _DAY_TYPE_ORDER.index(previous_day_type)
 
     # Upper boundary: to move UP, temp must reach next band's threshold + margin
     if prev_idx < len(_DAY_TYPE_ORDER) - 1:
         upper_type = _DAY_TYPE_ORDER[prev_idx + 1]
-        upper_threshold = _BAND_LOWER_THRESHOLD[upper_type]
+        upper_threshold = thresholds[upper_type]
         if today_high >= upper_threshold and today_high < upper_threshold + margin:
             return True
 
     # Lower boundary: to move DOWN, temp must drop below own threshold - margin
     if prev_idx > 0:
-        own_threshold = _BAND_LOWER_THRESHOLD[previous_day_type]
+        own_threshold = thresholds[previous_day_type]
         if today_high < own_threshold and today_high >= own_threshold - margin:
             return True
 
@@ -191,6 +200,11 @@ def _should_stick(today_high: float, previous_day_type: str, margin: float) -> b
 def classify_day(
     forecast: ForecastSnapshot,
     previous_day_type: str | None = None,
+    *,
+    threshold_hot: float = THRESHOLD_HOT,
+    threshold_warm: float = THRESHOLD_WARM,
+    threshold_mild: float = THRESHOLD_MILD,
+    threshold_cool: float = THRESHOLD_COOL,
 ) -> DayClassification:
     """Classify the day type and trend from forecast data.
 
@@ -198,6 +212,10 @@ def classify_day(
         forecast: Current forecast snapshot with today/tomorrow temps.
         previous_day_type: If set, apply hysteresis to prevent threshold
             bouncing when the forecast fluctuates near a boundary.
+        threshold_hot: Forecast high at/above which the day is "hot" (°F).
+        threshold_warm: Forecast high at/above which the day is "warm" (°F).
+        threshold_mild: Forecast high at/above which the day is "mild" (°F).
+        threshold_cool: Forecast high at/above which the day is "cool" (°F).
 
     Returns:
         DayClassification with day type, trend, and recommendations.
@@ -205,14 +223,22 @@ def classify_day(
     today_high = forecast.today_high
     tomorrow_high = forecast.tomorrow_high
 
+    # Per-call band threshold dict for hysteresis (uses caller-supplied values).
+    _band = {
+        DAY_TYPE_COOL: threshold_cool,
+        DAY_TYPE_MILD: threshold_mild,
+        DAY_TYPE_WARM: threshold_warm,
+        DAY_TYPE_HOT: threshold_hot,
+    }
+
     # Classify day type based on today's high
-    if today_high >= THRESHOLD_HOT:
+    if today_high >= threshold_hot:
         day_type = DAY_TYPE_HOT
-    elif today_high >= THRESHOLD_WARM:
+    elif today_high >= threshold_warm:
         day_type = DAY_TYPE_WARM
-    elif today_high >= THRESHOLD_MILD:
+    elif today_high >= threshold_mild:
         day_type = DAY_TYPE_MILD
-    elif today_high >= THRESHOLD_COOL:
+    elif today_high >= threshold_cool:
         day_type = DAY_TYPE_COOL
     else:
         day_type = DAY_TYPE_COLD
@@ -222,7 +248,7 @@ def classify_day(
     if (
         previous_day_type is not None
         and day_type != previous_day_type
-        and _should_stick(today_high, previous_day_type, CLASSIFICATION_HYSTERESIS_F)
+        and _should_stick(today_high, previous_day_type, CLASSIFICATION_HYSTERESIS_F, _band)
     ):
         _LOGGER.debug(
             "Hysteresis — today_high=%.0f°F would be %s but sticking with %s",

--- a/custom_components/climate_advisor/claude_api.py
+++ b/custom_components/climate_advisor/claude_api.py
@@ -109,7 +109,11 @@ class _BudgetTracker:
 
 
 class ClaudeAPIClient:
-    """Centralized Anthropic Claude API client with rate limiting, circuit breaking, and budget tracking."""
+    """Centralized Anthropic Claude API client with rate limiting, circuit breaking, and budget tracking.
+
+    Networking: uses the official Anthropic Python SDK (AsyncAnthropic) declared as
+    ``anthropic>=0.49.0`` in manifest.json requirements — no raw HTTP client is used.
+    """
 
     def __init__(
         self,

--- a/custom_components/climate_advisor/config_flow.py
+++ b/custom_components/climate_advisor/config_flow.py
@@ -55,6 +55,10 @@ from .const import (
     CONF_SENSOR_DEBOUNCE,
     CONF_SENSOR_POLARITY_INVERTED,
     CONF_TEMP_UNIT,
+    CONF_THRESHOLD_COOL,
+    CONF_THRESHOLD_HOT,
+    CONF_THRESHOLD_MILD,
+    CONF_THRESHOLD_WARM,
     CONF_VACATION_TOGGLE,
     CONF_VACATION_TOGGLE_INVERT,
     CONF_WELCOME_HOME_DEBOUNCE,
@@ -84,6 +88,10 @@ from .const import (
     DEFAULT_SLEEP_COOL,
     DEFAULT_SLEEP_HEAT,
     DEFAULT_TEMP_UNIT,
+    DEFAULT_THRESHOLD_COOL,
+    DEFAULT_THRESHOLD_HOT,
+    DEFAULT_THRESHOLD_MILD,
+    DEFAULT_THRESHOLD_WARM,
     DEFAULT_WELCOME_HOME_DEBOUNCE_SECONDS,
     DOMAIN,
     FAN_MODE_BOTH,
@@ -130,6 +138,7 @@ OPTIONS_MENU_OPTIONS = [
     "schedule",
     "notifications",
     "advanced",
+    "classification_thresholds",
     "ai_settings",
     "github_settings",
     "save",
@@ -157,7 +166,7 @@ def _entity_selector_for_source(source: str) -> selector.EntitySelector:
 class ClimateAdvisorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Climate Advisor."""
 
-    VERSION = 15
+    VERSION = 16
 
     def __init__(self) -> None:
         """Initialize the config flow."""
@@ -1149,6 +1158,104 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
                         "aggressive_savings",
                         default=current.get("aggressive_savings", False),
                     ): selector.BooleanSelector(),
+                }
+            ),
+            errors=errors,
+        )
+
+    # ---- Classification Thresholds ----
+
+    async def async_step_classification_thresholds(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Day-type classification threshold temperatures."""
+        errors: dict[str, str] = {}
+
+        current = self.config_entry.data
+        unit = current.get(CONF_TEMP_UNIT, FAHRENHEIT)
+        is_celsius = unit == CELSIUS
+
+        if user_input is not None:
+            # Validate ordering: cool < mild < warm < hot
+            t_cool = user_input.get(CONF_THRESHOLD_COOL, DEFAULT_THRESHOLD_COOL)
+            t_mild = user_input.get(CONF_THRESHOLD_MILD, DEFAULT_THRESHOLD_MILD)
+            t_warm = user_input.get(CONF_THRESHOLD_WARM, DEFAULT_THRESHOLD_WARM)
+            t_hot = user_input.get(CONF_THRESHOLD_HOT, DEFAULT_THRESHOLD_HOT)
+            if not (t_cool < t_mild < t_warm < t_hot):
+                errors[CONF_THRESHOLD_COOL] = "thresholds_must_be_ascending"
+            if not errors:
+                converted = {}
+                for key in (CONF_THRESHOLD_HOT, CONF_THRESHOLD_WARM, CONF_THRESHOLD_MILD, CONF_THRESHOLD_COOL):
+                    if key in user_input:
+                        converted[key] = to_fahrenheit(user_input[key], unit)
+                self._updates.update(converted)
+                return await self.async_step_init()
+
+        if is_celsius:
+            ranges = {
+                CONF_THRESHOLD_HOT: (24, 43, 0.5),
+                CONF_THRESHOLD_WARM: (15, 35, 0.5),
+                CONF_THRESHOLD_MILD: (7, 26, 0.5),
+                CONF_THRESHOLD_COOL: (-2, 18, 0.5),
+            }
+            unit_label = "°C"
+            hot_disp = from_fahrenheit(current.get(CONF_THRESHOLD_HOT, DEFAULT_THRESHOLD_HOT), unit)
+            warm_disp = from_fahrenheit(current.get(CONF_THRESHOLD_WARM, DEFAULT_THRESHOLD_WARM), unit)
+            mild_disp = from_fahrenheit(current.get(CONF_THRESHOLD_MILD, DEFAULT_THRESHOLD_MILD), unit)
+            cool_disp = from_fahrenheit(current.get(CONF_THRESHOLD_COOL, DEFAULT_THRESHOLD_COOL), unit)
+        else:
+            ranges = {
+                CONF_THRESHOLD_HOT: (75, 110, 1),
+                CONF_THRESHOLD_WARM: (60, 95, 1),
+                CONF_THRESHOLD_MILD: (45, 80, 1),
+                CONF_THRESHOLD_COOL: (30, 65, 1),
+            }
+            unit_label = "°F"
+            hot_disp = current.get(CONF_THRESHOLD_HOT, DEFAULT_THRESHOLD_HOT)
+            warm_disp = current.get(CONF_THRESHOLD_WARM, DEFAULT_THRESHOLD_WARM)
+            mild_disp = current.get(CONF_THRESHOLD_MILD, DEFAULT_THRESHOLD_MILD)
+            cool_disp = current.get(CONF_THRESHOLD_COOL, DEFAULT_THRESHOLD_COOL)
+
+        return self.async_show_form(
+            step_id="classification_thresholds",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_THRESHOLD_HOT, default=hot_disp): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=ranges[CONF_THRESHOLD_HOT][0],
+                            max=ranges[CONF_THRESHOLD_HOT][1],
+                            step=ranges[CONF_THRESHOLD_HOT][2],
+                            unit_of_measurement=unit_label,
+                            mode="slider",
+                        )
+                    ),
+                    vol.Required(CONF_THRESHOLD_WARM, default=warm_disp): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=ranges[CONF_THRESHOLD_WARM][0],
+                            max=ranges[CONF_THRESHOLD_WARM][1],
+                            step=ranges[CONF_THRESHOLD_WARM][2],
+                            unit_of_measurement=unit_label,
+                            mode="slider",
+                        )
+                    ),
+                    vol.Required(CONF_THRESHOLD_MILD, default=mild_disp): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=ranges[CONF_THRESHOLD_MILD][0],
+                            max=ranges[CONF_THRESHOLD_MILD][1],
+                            step=ranges[CONF_THRESHOLD_MILD][2],
+                            unit_of_measurement=unit_label,
+                            mode="slider",
+                        )
+                    ),
+                    vol.Required(CONF_THRESHOLD_COOL, default=cool_disp): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=ranges[CONF_THRESHOLD_COOL][0],
+                            max=ranges[CONF_THRESHOLD_COOL][1],
+                            step=ranges[CONF_THRESHOLD_COOL][2],
+                            unit_of_measurement=unit_label,
+                            mode="slider",
+                        )
+                    ),
                 }
             ),
             errors=errors,

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.49"
+VERSION = "0.4.50"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.50": [
+        "Feat #376: Day-type classification thresholds (Hot/Warm/Mild/Cool) are now configurable"
+        " in Settings → Day-Type Thresholds. Defaults remain 85/75/60/45°F so existing users see"
+        " no change until they opt to adjust.",
+        "Feat #376: Thresholds display in the user's chosen temperature unit (°F or °C) with"
+        " slider inputs and ascending-order validation.",
+        "Feat #376: Config entry migrated from version 15 → 16; existing installations receive"
+        " the default threshold values automatically on upgrade.",
+    ],
     "0.4.49": [
         "Fix #376: ODE/OLS prediction math (_build_predicted_indoor_future) now runs in a thread-pool"
         " executor instead of directly on the HA event loop — eliminates periodic event-loop blocking"
@@ -597,8 +606,10 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
     376: {
-        "version_fixed": "0.4.49",
-        "title": "HACS compliance: ODE executor offload + SDK attribution + JS library attribution",
+        "version_fixed": "0.4.50",
+        "title": (
+            "HACS compliance: ODE executor offload + SDK/JS attribution + classification threshold configurability"
+        ),
         "scope_covered": (
             "coordinator.py _async_update_data() and _async_send_briefing(): "
             "_build_predicted_indoor_future() wrapped in await hass.async_add_executor_job(functools.partial(...))."
@@ -607,12 +618,17 @@ KNOWN_FIXES: dict[int, dict] = {
             " frontend/index.html: Chart.js, Hammer.js, chartjs-plugin-zoom attributed with upstream URLs."
             " CLAUDE.md: Thread-Safety Requirements section added documenting the executor offload rule."
             " tests/test_executor_offload.py: AST regression tests for all three offload callsites."
+            " classifier.py classify_day(): threshold keyword args (threshold_hot/warm/mild/cool) with"
+            " module-constant defaults — fully backward-compatible."
+            " config_flow.py: Day-Type Thresholds step with slider inputs, Celsius/Fahrenheit conversion,"
+            " ascending-order validation, config entry migration v15→v16."
+            " const.py: CONF_THRESHOLD_* + DEFAULT_THRESHOLD_* + 4 CONFIG_METADATA entries (category=advanced)."
         ),
         "scope_not_covered": (
-            "Stage 3 (classification threshold configurability) is a separate PR (v0.4.50)."
-            " get_chart_data() still calls self.learning.get_thermal_model() + chart_log.get_entries()"
+            "get_chart_data() still calls self.learning.get_thermal_model() + chart_log.get_entries()"
             " synchronously inside the executor — these are I/O and could be further optimized,"
             " but are already off the event loop after this fix."
+            " HACS Issue #5 (repo description phrasing) is a manual gh repo edit — not tracked in code."
         ),
     },
     377: {
@@ -2224,12 +2240,24 @@ DAY_TYPE_MILD = "mild"
 DAY_TYPE_COOL = "cool"
 DAY_TYPE_COLD = "cold"
 
-# Day type thresholds (°F)
+# Day type thresholds (°F) — used as defaults when user has not customised them.
 THRESHOLD_HOT = 85
 THRESHOLD_WARM = 75
 THRESHOLD_MILD = 60
 THRESHOLD_COOL = 45
 CLASSIFICATION_HYSTERESIS_F = 2  # °F dead zone to prevent threshold bouncing
+
+# Configurable day-type threshold keys and defaults.
+# These mirror the THRESHOLD_* constants above; existing installs receive the
+# same values via the v15→v16 migration default, so behaviour is unchanged.
+CONF_THRESHOLD_HOT = "threshold_hot"
+CONF_THRESHOLD_WARM = "threshold_warm"
+CONF_THRESHOLD_MILD = "threshold_mild"
+CONF_THRESHOLD_COOL = "threshold_cool"
+DEFAULT_THRESHOLD_HOT = THRESHOLD_HOT
+DEFAULT_THRESHOLD_WARM = THRESHOLD_WARM
+DEFAULT_THRESHOLD_MILD = THRESHOLD_MILD
+DEFAULT_THRESHOLD_COOL = THRESHOLD_COOL
 
 # Trend thresholds (°F difference to trigger predictive behavior)
 TREND_THRESHOLD_SIGNIFICANT = 10
@@ -2794,6 +2822,37 @@ CONFIG_METADATA = {
             "When enabled, favors energy savings: the economizer skips AC-assisted cooling"
             " (ventilation only when windows open), and setbacks may be more aggressive."
             " When disabled, AC actively cools to comfort when outdoor temps drop."
+        ),
+        "category": "advanced",
+    },
+    "threshold_hot": {
+        "label": "Hot Day Threshold",
+        "description": (
+            "Days whose forecast high is at or above this temperature are classified as Hot. Default: 85°F / 29°C."
+        ),
+        "category": "advanced",
+    },
+    "threshold_warm": {
+        "label": "Warm Day Threshold",
+        "description": (
+            "Days whose forecast high is at or above this temperature (but below Hot) are"
+            " classified as Warm. Default: 75°F / 24°C."
+        ),
+        "category": "advanced",
+    },
+    "threshold_mild": {
+        "label": "Mild Day Threshold",
+        "description": (
+            "Days whose forecast high is at or above this temperature (but below Warm) are"
+            " classified as Mild. Default: 60°F / 16°C."
+        ),
+        "category": "advanced",
+    },
+    "threshold_cool": {
+        "label": "Cool Day Threshold",
+        "description": (
+            "Days whose forecast high is at or above this temperature (but below Mild) are"
+            " classified as Cool; below is Cold. Default: 45°F / 7°C."
         ),
         "category": "advanced",
     },

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,19 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.48"
+VERSION = "0.4.49"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.49": [
+        "Fix #376: ODE/OLS prediction math (_build_predicted_indoor_future) now runs in a thread-pool"
+        " executor instead of directly on the HA event loop — eliminates periodic event-loop blocking"
+        " on every coordinator refresh cycle and morning briefing.",
+        "Fix #376: Chart data API endpoint (get_chart_data) also offloaded to executor — same ODE"
+        " computation ran inline on every chart panel load.",
+        "Fix #376: HACS compliance — official Anthropic SDK usage documented in ClaudeAPIClient"
+        " docstring; bundled JS libraries (Chart.js, Hammer.js, chartjs-plugin-zoom) attributed"
+        " with upstream URLs in index.html.",
+    ],
     "0.4.48": [
         "Feat #377: AI investigator context is now built from 11 independently-testable provider"
         " functions in a new ai_skills_context module — replaces the 773-line monolith with a"
@@ -586,6 +596,25 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    376: {
+        "version_fixed": "0.4.49",
+        "title": "HACS compliance: ODE executor offload + SDK attribution + JS library attribution",
+        "scope_covered": (
+            "coordinator.py _async_update_data() and _async_send_briefing(): "
+            "_build_predicted_indoor_future() wrapped in await hass.async_add_executor_job(functools.partial(...))."
+            " api.py ClimateAdvisorChartDataView.get(): coordinator.get_chart_data() offloaded via executor."
+            " claude_api.py ClaudeAPIClient docstring: official Anthropic SDK (AsyncAnthropic) use documented."
+            " frontend/index.html: Chart.js, Hammer.js, chartjs-plugin-zoom attributed with upstream URLs."
+            " CLAUDE.md: Thread-Safety Requirements section added documenting the executor offload rule."
+            " tests/test_executor_offload.py: AST regression tests for all three offload callsites."
+        ),
+        "scope_not_covered": (
+            "Stage 3 (classification threshold configurability) is a separate PR (v0.4.50)."
+            " get_chart_data() still calls self.learning.get_thermal_model() + chart_log.get_entries()"
+            " synchronously inside the executor — these are I/O and could be further optimized,"
+            " but are already off the event loop after this fix."
+        ),
+    },
     377: {
         "version_fixed": "0.4.48",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import logging
 import math
 from datetime import UTC, date, datetime, time, timedelta
@@ -1496,15 +1497,19 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     self._solar_phase_offset,
                 )
 
-            # Compute and cache ODE prediction for ceiling guard + chart reuse
-            self._last_predicted_indoor = _build_predicted_indoor_future(
-                self._hourly_forecast_temps,
-                self.config,
-                dt_util.now(),
-                current_indoor_temp=self._get_indoor_temp(),
-                thermal_model=self.automation_engine._thermal_model if self.automation_engine else {},
-                occupancy_mode=self._occupancy_mode,
-                classification=self._current_classification,
+            # Compute and cache ODE prediction for ceiling guard + chart reuse.
+            # Offloaded to executor — ODE integration + OLS math blocks the event loop otherwise.
+            self._last_predicted_indoor = await self.hass.async_add_executor_job(
+                functools.partial(
+                    _build_predicted_indoor_future,
+                    self._hourly_forecast_temps,
+                    self.config,
+                    dt_util.now(),
+                    current_indoor_temp=self._get_indoor_temp(),
+                    thermal_model=self.automation_engine._thermal_model if self.automation_engine else {},
+                    occupancy_mode=self._occupancy_mode,
+                    classification=self._current_classification,
+                )
             )
             _LOGGER.debug(
                 "Caching predicted indoor curve: %d points, [0]=%s",
@@ -2327,14 +2332,18 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         )
         # Update cached ODE prediction for ceiling guard.
         # thermal_model is already computed from self.learning.get_thermal_model() above.
-        self._last_predicted_indoor = _build_predicted_indoor_future(
-            self._hourly_forecast_temps,
-            self.config,
-            dt_util.now(),
-            current_indoor_temp=self._get_indoor_temp(),
-            thermal_model=thermal_model,
-            occupancy_mode=self._occupancy_mode,
-            classification=classification,
+        # Offloaded to executor — ODE integration + OLS math blocks the event loop otherwise.
+        self._last_predicted_indoor = await self.hass.async_add_executor_job(
+            functools.partial(
+                _build_predicted_indoor_future,
+                self._hourly_forecast_temps,
+                self.config,
+                dt_util.now(),
+                current_indoor_temp=self._get_indoor_temp(),
+                thermal_model=thermal_model,
+                occupancy_mode=self._occupancy_mode,
+                classification=classification,
+            )
         )
         _LOGGER.debug(
             "Caching predicted indoor curve (briefing): %d points",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -84,6 +84,10 @@ from .const import (
     CONF_MANUAL_GRACE_PERIOD,
     CONF_SENSOR_DEBOUNCE,
     CONF_SENSOR_POLARITY_INVERTED,
+    CONF_THRESHOLD_COOL,
+    CONF_THRESHOLD_HOT,
+    CONF_THRESHOLD_MILD,
+    CONF_THRESHOLD_WARM,
     CONF_VACATION_TOGGLE,
     CONF_VACATION_TOGGLE_INVERT,
     CONF_WEATHER_BIAS,
@@ -94,6 +98,10 @@ from .const import (
     DEFAULT_SENSOR_DEBOUNCE_SECONDS,
     DEFAULT_SETBACK_DEPTH_COOL_F,
     DEFAULT_SETBACK_DEPTH_F,
+    DEFAULT_THRESHOLD_COOL,
+    DEFAULT_THRESHOLD_HOT,
+    DEFAULT_THRESHOLD_MILD,
+    DEFAULT_THRESHOLD_WARM,
     DOMAIN,
     ECONOMIZER_EVENING_START_HOUR,
     ECONOMIZER_MORNING_END_HOUR,
@@ -1355,7 +1363,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self.automation_engine._hourly_forecast_temps = self._hourly_forecast_temps
         if forecast:
             prev_type = self._current_classification.day_type if self._current_classification else None
-            self._current_classification = classify_day(forecast, previous_day_type=prev_type)
+            _thresh = {
+                "threshold_hot": self.config.get(CONF_THRESHOLD_HOT, DEFAULT_THRESHOLD_HOT),
+                "threshold_warm": self.config.get(CONF_THRESHOLD_WARM, DEFAULT_THRESHOLD_WARM),
+                "threshold_mild": self.config.get(CONF_THRESHOLD_MILD, DEFAULT_THRESHOLD_MILD),
+                "threshold_cool": self.config.get(CONF_THRESHOLD_COOL, DEFAULT_THRESHOLD_COOL),
+            }
+            self._current_classification = classify_day(forecast, previous_day_type=prev_type, **_thresh)
             self._last_outdoor_temp = forecast.current_outdoor_temp
             self._apply_outdoor_windows_gate()
 
@@ -2300,7 +2314,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             return
 
         prev_type = self._current_classification.day_type if self._current_classification else None
-        classification = classify_day(forecast, previous_day_type=prev_type)
+        _thresh = {
+            "threshold_hot": self.config.get(CONF_THRESHOLD_HOT, DEFAULT_THRESHOLD_HOT),
+            "threshold_warm": self.config.get(CONF_THRESHOLD_WARM, DEFAULT_THRESHOLD_WARM),
+            "threshold_mild": self.config.get(CONF_THRESHOLD_MILD, DEFAULT_THRESHOLD_MILD),
+            "threshold_cool": self.config.get(CONF_THRESHOLD_COOL, DEFAULT_THRESHOLD_COOL),
+        }
+        classification = classify_day(forecast, previous_day_type=prev_type, **_thresh)
         self._current_classification = classification
         self._last_outdoor_temp = forecast.current_outdoor_temp
         self._apply_outdoor_windows_gate()
@@ -5711,7 +5731,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             tomorrow_low=c.tomorrow_low,
             current_outdoor_temp=c.today_low,
         )
-        tomorrow_class = classify_day(tomorrow_forecast)
+        tomorrow_class = classify_day(
+            tomorrow_forecast,
+            threshold_hot=self.config.get(CONF_THRESHOLD_HOT, DEFAULT_THRESHOLD_HOT),
+            threshold_warm=self.config.get(CONF_THRESHOLD_WARM, DEFAULT_THRESHOLD_WARM),
+            threshold_mild=self.config.get(CONF_THRESHOLD_MILD, DEFAULT_THRESHOLD_MILD),
+            threshold_cool=self.config.get(CONF_THRESHOLD_COOL, DEFAULT_THRESHOLD_COOL),
+        )
 
         return {
             "date": tomorrow_str,

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -490,8 +490,11 @@
 .tm-health-row-label { color: var(--text-primary, inherit); }
 .tm-health-row-value { color: var(--text-secondary, #666); text-align: right; }
 </style>
+<!-- Hammer.js (MIT) — https://github.com/hammerjs/hammer.js -->
 <script src="hammer.min.js"></script>
+<!-- Chart.js v4 (MIT) — https://github.com/chartjs/Chart.js -->
 <script src="chart.umd.min.js"></script>
+<!-- chartjs-plugin-zoom (MIT) — https://github.com/chartjs/chartjs-plugin-zoom -->
 <script src="chartjs-plugin-zoom.min.js"></script>
 </head>
 <body>

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.48"
+  "version": "0.4.49"
 }

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.49"
+  "version": "0.4.50"
 }

--- a/custom_components/climate_advisor/strings.json
+++ b/custom_components/climate_advisor/strings.json
@@ -142,6 +142,7 @@
           "schedule": "Schedule",
           "notifications": "Notifications",
           "advanced": "Learning & Behavior",
+          "classification_thresholds": "Day-Type Thresholds",
           "ai_settings": "AI Settings (Claude)",
           "github_settings": "GitHub Integration",
           "save": "Save & Close"
@@ -315,6 +316,22 @@
           "preheat_safety_margin": "Multiplier applied to model-computed pre-heat time as a buffer (e.g. 1.2 = 20% extra).",
           "max_setback_depth_f": "Largest overnight setback the adaptive engine may compute.",
           "aggressive_savings": "When enabled, Climate Advisor favors energy savings over comfort \u2014 for example, using wider temperature swings and earlier setbacks."
+        }
+      },
+      "classification_thresholds": {
+        "title": "Day-Type Thresholds",
+        "description": "Temperature thresholds Climate Advisor uses to classify each day. Days at or above the Hot threshold run AC; below Cool threshold use heating. Defaults: Hot 85°F (29°C), Warm 75°F (24°C), Mild 60°F (16°C), Cool 45°F (7°C).",
+        "data": {
+          "threshold_hot": "Hot day threshold",
+          "threshold_warm": "Warm day threshold",
+          "threshold_mild": "Mild day threshold",
+          "threshold_cool": "Cool day threshold"
+        },
+        "data_description": {
+          "threshold_hot": "Days with a forecast high at or above this temperature are classified as Hot (AC mode). Default: 85°F / 29°C.",
+          "threshold_warm": "Days with a forecast high at or above this temperature are classified as Warm (windows recommended, no AC). Default: 75°F / 24°C.",
+          "threshold_mild": "Days with a forecast high at or above this temperature are classified as Mild (comfortable, windows open). Default: 60°F / 16°C.",
+          "threshold_cool": "Days with a forecast high at or above this temperature are classified as Cool (heating light). Below this is Cold (full heating). Default: 45°F / 7°C."
         }
       },
       "ai_settings": {

--- a/custom_components/climate_advisor/translations/en.json
+++ b/custom_components/climate_advisor/translations/en.json
@@ -146,6 +146,7 @@
           "schedule": "Schedule",
           "notifications": "Notifications",
           "advanced": "Learning & Behavior",
+          "classification_thresholds": "Day-Type Thresholds",
           "ai_settings": "AI Settings (Claude)",
           "github_settings": "GitHub Integration",
           "save": "Save & Close"
@@ -323,6 +324,22 @@
           "preheat_safety_margin": "Multiplier applied to model-computed pre-heat time as a buffer (e.g. 1.2 = 20% extra).",
           "max_setback_depth_f": "Largest overnight setback the adaptive engine may compute.",
           "aggressive_savings": "When enabled, Climate Advisor favors energy savings over comfort \u2014 for example, using wider temperature swings and earlier setbacks."
+        }
+      },
+      "classification_thresholds": {
+        "title": "Day-Type Thresholds",
+        "description": "Temperature thresholds Climate Advisor uses to classify each day. Days at or above the Hot threshold run AC; below Cool threshold use heating. Defaults: Hot 85°F (29°C), Warm 75°F (24°C), Mild 60°F (16°C), Cool 45°F (7°C).",
+        "data": {
+          "threshold_hot": "Hot day threshold",
+          "threshold_warm": "Warm day threshold",
+          "threshold_mild": "Mild day threshold",
+          "threshold_cool": "Cool day threshold"
+        },
+        "data_description": {
+          "threshold_hot": "Days with a forecast high at or above this temperature are classified as Hot (AC mode). Default: 85°F / 29°C.",
+          "threshold_warm": "Days with a forecast high at or above this temperature are classified as Warm (windows recommended, no AC). Default: 75°F / 24°C.",
+          "threshold_mild": "Days with a forecast high at or above this temperature are classified as Mild (comfortable, windows open). Default: 60°F / 16°C.",
+          "threshold_cool": "Days with a forecast high at or above this temperature are classified as Cool (heating light). Below this is Cold (full heating). Default: 45°F / 7°C."
         }
       },
       "ai_settings": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -937,7 +937,7 @@ class TestMigrationV8ToV9:
         result = asyncio.run(async_migrate_entry(hass, entry))
         assert result is True
         assert final_data.get("temp_unit") == "fahrenheit"
-        assert entry.version == 15
+        assert entry.version == 16
 
     def test_chain_from_v1_includes_temp_unit(self):
         """v1 entry chains through all migrations and ends up with temp_unit."""
@@ -969,7 +969,7 @@ class TestMigrationV8ToV9:
         result = asyncio.run(async_migrate_entry(hass, entry))
         assert result is True
         assert final_data.get("temp_unit") == "fahrenheit"
-        assert entry.version == 15
+        assert entry.version == 16
 
 
 # ---------------------------------------------------------------------------
@@ -1030,7 +1030,7 @@ class TestMigrationV9ToV10:
         result = asyncio.run(async_migrate_entry(hass, entry))
         assert result is True
         assert final_data.get("welcome_home_debounce_seconds") == 3600
-        assert entry.version == 15
+        assert entry.version == 16
 
     def test_chain_from_v1_includes_debounce(self):
         """v1 entry chains through all migrations and ends up with welcome_home_debounce_seconds."""
@@ -1062,7 +1062,7 @@ class TestMigrationV9ToV10:
         assert result is True
         assert final_data.get("welcome_home_debounce_seconds") == 3600
         assert final_data.get("temp_unit") == "fahrenheit"
-        assert entry.version == 15
+        assert entry.version == 16
 
 
 class TestMigrationV10ToV11:
@@ -1118,7 +1118,7 @@ class TestMigrationV10ToV11:
         assert final_data.get("adaptive_preheat_enabled") is True
         assert final_data.get("adaptive_setback_enabled") is True
         assert final_data.get("weather_bias_enabled") is True
-        assert entry.version == 15
+        assert entry.version == 16
 
 
 class TestMigrationV11ToV12:
@@ -1146,7 +1146,7 @@ class TestMigrationV11ToV12:
         assert final_data.get("default_preheat_minutes") == 120
         assert final_data.get("preheat_safety_margin") == 1.3
         assert final_data.get("max_setback_depth_f") == 8.0
-        assert entry.version == 15
+        assert entry.version == 16
 
     def test_v11_to_v12_existing_values_preserved(self):
         """v11 entry with all threshold keys set retains those values after migration."""
@@ -1178,7 +1178,7 @@ class TestMigrationV11ToV12:
         assert final_data.get("default_preheat_minutes") == 90
         assert final_data.get("preheat_safety_margin") == 1.5
         assert final_data.get("max_setback_depth_f") == 6.0
-        assert entry.version == 15
+        assert entry.version == 16
 
     def test_v11_to_v12_invalid_type_replaced(self):
         """v11 entry where min_preheat_minutes is a non-numeric string gets the default."""
@@ -1199,7 +1199,7 @@ class TestMigrationV11ToV12:
         result = asyncio.run(async_migrate_entry(hass, entry))
         assert result is True
         assert final_data.get("min_preheat_minutes") == 30
-        assert entry.version == 15
+        assert entry.version == 16
 
     def test_v11_to_v12_from_v10_chain(self):
         """v10 entry chains through v11 and v12 migrations; all five threshold keys get defaults."""
@@ -1218,7 +1218,7 @@ class TestMigrationV11ToV12:
         hass.config_entries.async_update_entry.side_effect = capture_update
         result = asyncio.run(async_migrate_entry(hass, entry))
         assert result is True
-        assert entry.version == 15
+        assert entry.version == 16
         assert final_data.get("min_preheat_minutes") == 30
         assert final_data.get("max_preheat_minutes") == 240
         assert final_data.get("default_preheat_minutes") == 120
@@ -1320,7 +1320,7 @@ class TestMigrationV12ToV13:
         hass.config_entries.async_update_entry.side_effect = capture_update
         result = asyncio.run(async_migrate_entry(hass, entry))
         assert result is True
-        assert entry.version == 15
+        assert entry.version == 16
         assert final_data.get("ai_enabled") is DEFAULT_AI_ENABLED
         assert final_data.get("ai_api_key") == ""
         assert final_data.get("ai_model") == DEFAULT_AI_MODEL
@@ -1348,7 +1348,7 @@ class TestMigrationV12ToV13:
         hass.config_entries.async_update_entry.side_effect = capture_update
         result = asyncio.run(async_migrate_entry(hass, entry))
         assert result is True
-        assert entry.version == 15
+        assert entry.version == 16
         assert final_data.get("ai_enabled") is False
         assert final_data.get("ai_model") == "claude-sonnet-4-6"
         assert final_data.get("ai_max_tokens") == 4096
@@ -1406,11 +1406,13 @@ class TestMigrationV13ToV14:
         assert result.get("ai_investigator_requests_per_day") == DEFAULT_AI_INVESTIGATOR_RPD
 
     def test_v13_to_v14_adds_exactly_five_investigator_keys_plus_sleep_keys(self):
-        """Migration v13→v15 adds the five investigator keys and the two sleep keys."""
+        """Migration v13→v16 adds the five investigator keys, two sleep keys, and four threshold keys."""
         result = self._run_v13_to_v14_migration(dict(FULL_CONFIG))
         new_keys = set(result) - set(FULL_CONFIG)
-        # v13→v14 adds 5 investigator keys; v14→v15 fall-through adds sleep_heat + sleep_cool
-        assert new_keys == set(_INVESTIGATOR_KEYS) | {"sleep_heat", "sleep_cool"}
+        # v13→v14 adds 5 investigator keys; v14→v15 adds sleep_heat + sleep_cool;
+        # v15→v16 adds threshold_hot/warm/mild/cool
+        _threshold_keys = {"threshold_hot", "threshold_warm", "threshold_mild", "threshold_cool"}
+        assert new_keys == set(_INVESTIGATOR_KEYS) | {"sleep_heat", "sleep_cool"} | _threshold_keys
 
     def test_v13_to_v14_preserves_existing_fields(self):
         """All existing v13 fields survive migration unchanged."""
@@ -1448,7 +1450,7 @@ class TestMigrationV13ToV14:
         hass.config_entries.async_update_entry.side_effect = capture_update
         result = asyncio.run(async_migrate_entry(hass, entry))
         assert result is True
-        assert entry.version == 15
+        assert entry.version == 16
         assert final_data.get("ai_investigator_enabled") is DEFAULT_AI_INVESTIGATOR_ENABLED
         assert final_data.get("ai_investigator_model") == DEFAULT_AI_INVESTIGATOR_MODEL
         assert final_data.get("ai_investigator_reasoning_effort") == DEFAULT_AI_INVESTIGATOR_REASONING
@@ -1604,7 +1606,7 @@ class TestMigrationV14ToV15:
         assert data["sleep_heat"] < 64.0  # below comfort_heat
 
     def test_migration_returns_true_and_bumps_version(self):
-        """async_migrate_entry returns True and entry reaches version 15."""
+        """async_migrate_entry returns True and entry reaches current version."""
         from custom_components.climate_advisor import async_migrate_entry
 
         entry = _make_config_entry(dict(_FULL_CONFIG_V14), version=14)
@@ -1619,7 +1621,7 @@ class TestMigrationV14ToV15:
         hass.config_entries.async_update_entry.side_effect = capture_update
         result = asyncio.run(async_migrate_entry(hass, entry))
         assert result is True
-        assert final_version[0] == 15
+        assert final_version[0] == 16
 
 
 # ---------------------------------------------------------------------------
@@ -1643,6 +1645,7 @@ class TestOptionsFlowMenu:
             "schedule",
             "notifications",
             "advanced",
+            "classification_thresholds",
             "ai_settings",
             "github_settings",
             "save",

--- a/tests/test_config_metadata.py
+++ b/tests/test_config_metadata.py
@@ -73,6 +73,10 @@ EXPECTED_KEYS = {
     "ai_investigator_max_tokens",
     "ai_investigator_requests_per_day",
     "override_confirm_seconds",
+    "threshold_hot",
+    "threshold_warm",
+    "threshold_mild",
+    "threshold_cool",
 }
 
 VALID_CATEGORIES = {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -366,6 +366,10 @@ class TestBriefingNotificationSplit:
         coord._apply_outdoor_windows_gate = MagicMock()
         coord._last_predicted_indoor = []
 
+        # async_add_executor_job is now awaited by _async_send_briefing for ODE offload.
+        # Execute the partial synchronously so patched _build_predicted_indoor_future is used.
+        coord.hass.async_add_executor_job = AsyncMock(side_effect=lambda fn: fn())
+
         # Bind the real methods to our mock
         coord._async_send_briefing = types.MethodType(ClimateAdvisorCoordinator._async_send_briefing, coord)
         coord._build_briefing_text = types.MethodType(ClimateAdvisorCoordinator._build_briefing_text, coord)
@@ -753,6 +757,9 @@ class TestBriefingRegeneration:
         coord._apply_outdoor_windows_gate = MagicMock()
         coord._last_predicted_indoor = []
         coord._current_classification = None
+
+        # async_add_executor_job is now awaited by _async_update_data/_async_send_briefing for ODE offload.
+        coord.hass.async_add_executor_job = AsyncMock(side_effect=lambda fn: fn())
 
         coord._build_briefing_text = types.MethodType(ClimateAdvisorCoordinator._build_briefing_text, coord)
 

--- a/tests/test_daily_record.py
+++ b/tests/test_daily_record.py
@@ -180,6 +180,7 @@ class TestTomorrowPlan:
     def test_returns_valid_dict_with_classification(self):
         """A classification with tomorrow data → dict with expected keys."""
         coord = MagicMock()
+        coord.config = {}
         coord._current_classification = _make_classification(
             tomorrow_high=78,
             tomorrow_low=60,
@@ -204,6 +205,7 @@ class TestTomorrowPlan:
     def test_tomorrow_plan_hot_day(self):
         """tomorrow_high=95 should yield day_type='hot'."""
         coord = MagicMock()
+        coord.config = {}
         coord._current_classification = _make_classification(
             tomorrow_high=95,
             tomorrow_low=75,
@@ -220,6 +222,7 @@ class TestTomorrowPlan:
     def test_tomorrow_plan_cool_day(self):
         """tomorrow_high=50 should yield day_type='cool'."""
         coord = MagicMock()
+        coord.config = {}
         coord._current_classification = _make_classification(
             tomorrow_high=50,
             tomorrow_low=35,
@@ -236,6 +239,7 @@ class TestTomorrowPlan:
     def test_tomorrow_plan_trend_stable(self):
         """Tomorrow plan should show stable trend (same hi/lo for today and tomorrow)."""
         coord = MagicMock()
+        coord.config = {}
         coord._current_classification = _make_classification(
             tomorrow_high=72,
             tomorrow_low=55,

--- a/tests/test_daily_record_accuracy.py
+++ b/tests/test_daily_record_accuracy.py
@@ -445,6 +445,7 @@ class TestDailyRecordBriefingPreservation:
         hass.services = MagicMock()
         hass.services.async_call = AsyncMock()
         hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda fn: fn())
         coord.hass = hass
 
         # Pre-restart accumulated record — date matches patched dt_util.now() "2026-04-05"
@@ -521,6 +522,7 @@ class TestDailyRecordBriefingPreservation:
         hass.services = MagicMock()
         hass.services.async_call = AsyncMock()
         hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda fn: fn())
         coord.hass = hass
 
         # Yesterday's record — different date

--- a/tests/test_executor_offload.py
+++ b/tests/test_executor_offload.py
@@ -1,0 +1,178 @@
+"""Regression tests for Issue #376: ODE/OLS computation executor offload.
+
+Verifies that _build_predicted_indoor_future is never called directly from
+async methods in coordinator.py (which would block the HA event loop).
+
+The fix wraps all async callsites in await hass.async_add_executor_job(functools.partial(...)).
+If someone removes the wrapper, the AST test catches it at test time rather than in prod.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+COORDINATOR_PY = Path(__file__).parent.parent / "custom_components" / "climate_advisor" / "coordinator.py"
+API_PY = Path(__file__).parent.parent / "custom_components" / "climate_advisor" / "api.py"
+
+_TARGET_FN = "_build_predicted_indoor_future"
+
+
+def _is_direct_call(node: ast.AST) -> bool:
+    """Return True if node is a direct call to _TARGET_FN (not inside functools.partial)."""
+    return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == _TARGET_FN
+
+
+def _extract_async_methods(tree: ast.AST) -> list[tuple[str, ast.AsyncFunctionDef]]:
+    """Return (name, node) for all async methods in the module."""
+    results = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef):
+            results.append((node.name, node))
+    return results
+
+
+def _find_direct_calls_in_node(fn_node: ast.AST) -> list[ast.Call]:
+    """Walk fn_node and return any direct (non-partial) calls to _TARGET_FN.
+
+    A call is "direct" if _TARGET_FN appears as the immediate callee, not as
+    an argument inside functools.partial(). We skip nodes that are arguments
+    to a functools.partial call.
+    """
+    direct_calls = []
+
+    class _Visitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+            # Check if this is functools.partial(...) — if so, don't recurse
+            # into its arguments (those calls are fine; they're the wrapped fn).
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "partial"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "functools"
+            ):
+                # Don't descend into partial() arguments.
+                return
+
+            # Check if this call itself is a direct invocation of _TARGET_FN
+            if _is_direct_call(node):
+                direct_calls.append(node)
+
+            # Recurse into sub-expressions (but we already skipped partial args above)
+            self.generic_visit(node)
+
+    _Visitor().visit(fn_node)
+    return direct_calls
+
+
+class TestODEExecutorOffload:
+    """_build_predicted_indoor_future must not be called directly from async methods."""
+
+    def test_no_direct_calls_in_async_update_data(self):
+        """_async_update_data must use async_add_executor_job for the ODE call.
+
+        Regression for Issue #376: direct call blocked the event loop on every
+        coordinator refresh (every 30 min).
+        """
+        source = COORDINATOR_PY.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        async_methods = {name: node for name, node in _extract_async_methods(tree)}
+        assert "_async_update_data" in async_methods, (
+            "_async_update_data not found in coordinator.py — method was renamed?"
+        )
+
+        direct = _find_direct_calls_in_node(async_methods["_async_update_data"])
+        assert not direct, (
+            f"_build_predicted_indoor_future called directly (not via functools.partial) "
+            f"in _async_update_data at line(s): {[c.lineno for c in direct]}. "
+            "Wrap in await hass.async_add_executor_job(functools.partial(...)) to avoid "
+            "blocking the HA event loop."
+        )
+
+    def test_no_direct_calls_in_async_send_briefing(self):
+        """_async_send_briefing must use async_add_executor_job for the ODE call.
+
+        Regression for Issue #376: direct call blocked the event loop on each
+        morning briefing.
+        """
+        source = COORDINATOR_PY.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        async_methods = {name: node for name, node in _extract_async_methods(tree)}
+        assert "_async_send_briefing" in async_methods, (
+            "_async_send_briefing not found in coordinator.py — method was renamed?"
+        )
+
+        direct = _find_direct_calls_in_node(async_methods["_async_send_briefing"])
+        assert not direct, (
+            f"_build_predicted_indoor_future called directly (not via functools.partial) "
+            f"in _async_send_briefing at line(s): {[c.lineno for c in direct]}. "
+            "Wrap in await hass.async_add_executor_job(functools.partial(...)) to avoid "
+            "blocking the HA event loop."
+        )
+
+    def test_chart_data_view_uses_executor(self):
+        """ClimateAdvisorChartDataView.get() must offload get_chart_data to executor.
+
+        get_chart_data() runs _build_predicted_indoor_future inline (ODE+OLS math).
+        Calling it directly from the async aiohttp handler blocks the event loop.
+        Fix: await hass.async_add_executor_job(functools.partial(coordinator.get_chart_data, ...))
+        """
+        source = API_PY.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        # Find ClimateAdvisorChartDataView class
+        chart_class = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "ClimateAdvisorChartDataView":
+                chart_class = node
+                break
+        assert chart_class is not None, "ClimateAdvisorChartDataView not found in api.py"
+
+        # Find the get() method inside it
+        get_method = None
+        for node in ast.walk(chart_class):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "get":
+                get_method = node
+                break
+        assert get_method is not None, "ClimateAdvisorChartDataView.get() not found"
+
+        # Verify get_chart_data is NOT called directly (i.e., not as a plain Call outside partial)
+        direct_chart_calls = []
+
+        class _ChartVisitor(ast.NodeVisitor):
+            def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+                if (
+                    isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "partial"
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == "functools"
+                ):
+                    return
+                if isinstance(node.func, ast.Attribute) and node.func.attr == "get_chart_data":
+                    direct_chart_calls.append(node)
+                self.generic_visit(node)
+
+        _ChartVisitor().visit(get_method)
+
+        assert not direct_chart_calls, (
+            f"coordinator.get_chart_data() called directly (not via executor) in "
+            f"ClimateAdvisorChartDataView.get() at line(s): {[c.lineno for c in direct_chart_calls]}. "
+            "Offload via await hass.async_add_executor_job(functools.partial(coordinator.get_chart_data, ...))."
+        )
+
+        # Also verify async_add_executor_job IS referenced in the get() method
+        executor_calls = []
+
+        class _ExecutorVisitor(ast.NodeVisitor):
+            def visit_Attribute(self, node: ast.Attribute) -> None:  # noqa: N802
+                if node.attr == "async_add_executor_job":
+                    executor_calls.append(node)
+                self.generic_visit(node)
+
+        _ExecutorVisitor().visit(get_method)
+        assert executor_calls, (
+            "async_add_executor_job not found in ClimateAdvisorChartDataView.get(). "
+            "The chart endpoint must offload get_chart_data to the thread pool."
+        )

--- a/tests/test_temperature_sensors.py
+++ b/tests/test_temperature_sensors.py
@@ -124,6 +124,7 @@ def _make_update_data_coord(
     climate_state = _make_state(hvac_mode, hvac_action)
     hass.states.get = MagicMock(return_value=climate_state)
     hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda fn: fn())
     coord.hass = hass
 
     coord.config = {


### PR DESCRIPTION
## Summary

Addresses all five HACS reviewer concerns from Issue #376. Stages 1–3 complete.

- **Issue #1 (SDK networking):** Already compliant — `AsyncAnthropic` from official Anthropic SDK. Added docstring to `ClaudeAPIClient` so reviewers see it without digging.
- **Issue #2 (frontend panel):** Already compliant — native `async_register_built_in_panel()` + `async_register_static_paths()`. Added upstream URL attribution comments for the three bundled JS libraries (`chart.umd.min.js`, `hammer.min.js`, `chartjs-plugin-zoom.min.js`) in `index.html`.
- **Issue #3 (thread-safety — real bug):** `_build_predicted_indoor_future()` (~400 lines of ODE integration + OLS regression) was blocking the HA event loop synchronously on every 30-min coordinator refresh, every morning briefing, and every chart panel load. All three callsites now offloaded via `await hass.async_add_executor_job(functools.partial(...))`. Thread-Safety Requirements rule added to `CLAUDE.md`. AST regression tests added in `tests/test_executor_offload.py` to prevent re-introduction.
- **Issue #4 (hardcoded thresholds):** The four day-type classification thresholds (`Hot ≥85°F`, `Warm ≥75°F`, `Mild ≥60°F`, `Cool ≥45°F`) are now user-configurable in **Settings → Day-Type Thresholds**. Sliders display in the user's chosen unit (°F or °C). Defaults are the existing constants — no behavior change for users who never open that screen. Config entry migrated v15→v16; existing installations receive defaults automatically on upgrade.
- **Issue #5 (description phrasing):** Repo description updated to `"Weather-aware HVAC automation with thermal learning"`.

## Changes by file

| File | Stage | What changed |
|------|-------|-------------|
| `claude_api.py` | 1 | Docstring confirming official SDK use |
| `frontend/index.html` | 1 | JS library attribution comments |
| `coordinator.py` | 2+3 | Executor offload for 2 ODE callsites; threshold kwargs on 3 `classify_day()` callsites |
| `api.py` | 2 | Executor offload for chart data endpoint |
| `CLAUDE.md` | 2 | Thread-Safety Requirements section |
| `tests/test_executor_offload.py` | 2 | 3 new AST regression tests |
| `classifier.py` | 3 | `classify_day()` + `_should_stick()` accept threshold keyword args with defaults |
| `config_flow.py` | 3 | `async_step_classification_thresholds()`, VERSION=16, menu entry |
| `__init__.py` | 3 | v15→v16 migration block + threshold imports |
| `const.py` | 3 | `CONF_THRESHOLD_*`, `DEFAULT_THRESHOLD_*`, CONFIG_METADATA entries, v0.4.50 |
| `manifest.json` | 3 | Version 0.4.50 |
| `strings.json` + `translations/en.json` | 3 | Menu entry + step block with data_description |
| `tests/test_config_flow.py` | 3 | Migration chain version assertions, menu list, key count |
| `tests/test_config_metadata.py` | 3 | 4 threshold keys added to EXPECTED_KEYS |
| `tests/test_daily_record.py` | 3 | `coord.config = {}` stubs for tomorrow_plan tests |

## Test plan

- [x] `python -m pytest tests/ -W error::RuntimeWarning -W error::PytestUnraisableExceptionWarning` — **2908 passed**
- [x] `python -m pytest tests/test_executor_offload.py` — 3 AST tests; fail if any executor wrapper is removed
- [x] `python -m pytest tests/test_config_flow.py tests/test_config_metadata.py tests/test_version_sync.py` — all pass
- [x] `python -m ruff check custom_components/climate_advisor/ tests/` — clean