### PR TITLE
Fix #388: integration_type helper->service restores Integrations page visibility (v0.4.54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.4.54] — 2026-07-02
+
+- Fix #388: Climate Advisor was missing from the Integrations page in Settings → Devices & Services — v0.4.53 set manifest.json integration_type to 'helper', which Home Assistant's frontend excludes from the Integrations dashboard and routes to the Helpers tab instead. Corrected to 'service', the accurate HA taxonomy value for a full custom integration.
+
 ## [0.4.53] — 2026-07-02
 
 - Feat #384: HACS compliance — integration_type field added to manifest, dynamic README version badge replaces hardcoded string, state file permissions hardened (0o600), HACS knowledge base added to docs.

--- a/claude.md
+++ b/claude.md
@@ -224,9 +224,14 @@ Full spec: `docs/hacs-compliance.md`
 
 #### Invariants — Never Break These
 
-1. **`integration_type: "helper"`** must remain in `manifest.json`. CA is an automation helper that
-   assists users with HVAC control — not a hardware hub or cloud service. See `docs/hacs-compliance.md`
-   for the full rationale.
+1. **`integration_type: "service"`** must remain in `manifest.json`. CA is a full custom integration
+   with its own config entry, coordinator, devices, sensors, and API — matching HA's `service`
+   taxonomy ("provides a single service, like DuckDNS or AdGuard"), not the lightweight `helper`
+   category (input_boolean, derivative, group). **Do not set this to `"helper"`** — HA's frontend
+   excludes `helper`-typed config entries from the Settings → Devices & Services → Integrations
+   dashboard (`type_filter: ["device","hub","service","hardware"]`) and routes them to the
+   separate Helpers tab instead, which made CA disappear from Integrations in v0.4.53 (Issue #388).
+   See `docs/hacs-compliance.md` for the full rationale.
 
 2. **`brand/icon.png`** must remain at the repo root. It is required by HACS (not HA core) and
    provides the store icon. Never delete or move it.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,15 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.53"
+VERSION = "0.4.54"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.54": [
+        "Fix #388: Climate Advisor was missing from the Integrations page in Settings → Devices &"
+        " Services — v0.4.53 set manifest.json integration_type to 'helper', which Home Assistant's"
+        " frontend excludes from the Integrations dashboard and routes to the Helpers tab instead."
+        " Corrected to 'service', the accurate HA taxonomy value for a full custom integration.",
+    ],
     "0.4.53": [
         "Feat #384: HACS compliance — integration_type field added to manifest, dynamic README version"
         " badge replaces hardcoded string, state file permissions hardened (0o600), HACS knowledge"
@@ -620,6 +626,22 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    388: {
+        "version_fixed": "0.4.54",
+        "title": "Integration missing from Settings → Devices & Services → Integrations page",
+        "scope_covered": (
+            "manifest.json integration_type corrected from 'helper' to 'service'. HA's frontend"
+            " (ha-config-integrations.ts) subscribes to config entries with"
+            " type_filter=['device','hub','service','hardware'] for the Integrations dashboard —"
+            " 'helper' is excluded from that query and routed to the separate Helpers tab instead."
+            " docs/hacs-compliance.md and CLAUDE.md HACS Compliance Requirements updated to match."
+        ),
+        "scope_not_covered": (
+            "Users who already have the v0.4.53 entry showing under the Helpers tab may need to"
+            " restart Home Assistant after updating for the entry to reappear under Integrations;"
+            " no automatic migration moves it back without a restart."
+        ),
+    },
     384: {
         "version_fixed": "0.4.53",
         "title": "HACS compliance — integration_type, dynamic README badge, state permissions, knowledge base",

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -5,9 +5,9 @@
   "config_flow": true,
   "dependencies": ["weather", "climate", "http"],
   "documentation": "https://github.com/gunkl/ClimateAdvisor",
-  "integration_type": "helper",
+  "integration_type": "service",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.53"
+  "version": "0.4.54"
 }

--- a/docs/hacs-compliance.md
+++ b/docs/hacs-compliance.md
@@ -7,15 +7,23 @@ This document captures all requirements for ClimateAdvisor to remain compliant w
 
 ## Integration Type
 
-`manifest.json` must contain `"integration_type": "helper"`.
+`manifest.json` must contain `"integration_type": "service"`.
 
-**Why `helper`:**
-- HA docs define `helper` as "provides an entity to help the user with automations like input
-  boolean, derivative or group"
-- Climate Advisor assists users with HVAC automation — it is an automation helper that sits above
-  the thermostat and climate entities rather than a hardware hub or cloud service in its own right.
+**Why `service`, not `helper` (Issue #388):**
+- HA docs define `service` as "provides a single service, like DuckDNS or AdGuard" and `helper` as
+  "provides an entity to help the user with automations like input_boolean, derivative or group."
+  Climate Advisor is a full custom integration with its own config entry, coordinator, devices,
+  sensors, and API — it matches `service`, not the lightweight helper-entity category.
+- v0.4.53 briefly set this to `"helper"` on the theory that CA "helps" the user with HVAC
+  automation — a category mistake conflating the plain-English word with HA's specific taxonomy.
+  HA's frontend (`ha-config-integrations.ts`) subscribes to config entries for the Settings →
+  Devices & Services → **Integrations** dashboard with
+  `type_filter: ["device", "hub", "service", "hardware"]` — `"helper"` is excluded from that
+  query entirely and routed instead to the separate **Helpers** tab
+  (`ha-config-helpers.ts` dynamically includes any manifest with `integration_type === "helper"`).
+  This made CA disappear from the Integrations page for every installed user. Fixed in v0.4.54.
 
-**Rule:** Never change `integration_type` away from `"helper"` without updating this doc.
+**Rule:** Never change `integration_type` away from `"service"` without updating this doc.
 
 ## manifest.json Required Fields
 
@@ -30,7 +38,7 @@ any human reviewer sees the PR.
 | `config_flow` | Yes | `true` | All CA config is via config flow |
 | `dependencies` | Yes | `["weather", "climate", "http"]` | Required HA integrations |
 | `documentation` | Yes | GitHub repo URL | Must resolve to a real page |
-| `integration_type` | Yes | `"helper"` | See section above — do not change |
+| `integration_type` | Yes | `"service"` | See section above — do not change |
 | `iot_class` | Yes | `"local_polling"` | CA polls local HA entities |
 | `issue_tracker` | Yes | GitHub issues URL | Must resolve to real issues page |
 | `requirements` | Yes | `["anthropic>=0.49.0"]` | pip packages |


### PR DESCRIPTION
## Summary
- v0.4.53 (PR #385) set `manifest.json` `integration_type` to `"helper"` for HACS compliance. HA's frontend excludes `helper`-typed config entries from the Settings → Devices & Services → **Integrations** dashboard (`type_filter: ["device","hub","service","hardware"]`) and routes them to the separate **Helpers** tab instead — causing Climate Advisor to vanish from the Integrations page for every installed user.
- Corrected `integration_type` to `"service"`, matching HA's own taxonomy definition for a full custom integration (config entry, coordinator, devices, sensors, API) and the value `docs/hacs-compliance.md`'s own "Invariants" section already specified but was never reconciled with the rest of the doc.
- Version bump to 0.4.54, RELEASE_NOTES/KNOWN_FIXES/CHANGELOG entries, docs/hacs-compliance.md and CLAUDE.md updated to match.

Full investigation: #388

## Test plan
- [x] `python -m pytest tests/ -q` — 2909 passed
- [x] `python -m pytest tests/test_version_sync.py -q` — 2 passed
- [x] `python -m ruff check` / `ruff format` on modified files — clean
- [x] `python tools/validate.py` — all checks passed
- [x] User confirms integration reappears on Integrations page after deploy + HA restart