### PR TITLE
Fix #392: archetype-aware nat-vent ceiling guard + fan-type activity log labels

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -461,44 +461,62 @@ def _render_grace_expired(p: dict, unit: str) -> tuple[str, str]:
 def _render_nat_vent_fan_on(p: dict, unit: str) -> tuple[str, str]:
     indoor = p.get("indoor_temp")
     on_thr = p.get("on_threshold")
+    fan_device = p.get("fan_device", "fan")
     label = "Nat-vent fan on (cycling)"
     if indoor is not None and on_thr is not None:
         with contextlib.suppress(TypeError, ValueError):
             label = (
                 f"Nat-vent fan on -- indoor {format_temp(float(indoor), unit)} >= {format_temp(float(on_thr), unit)}"
             )
-    return label, "fan: auto->on"
+    return label, f"{fan_device}: auto->on"
 
 
 def _render_nat_vent_fan_off(p: dict, unit: str) -> tuple[str, str]:
     indoor = p.get("indoor_temp")
     off_thr = p.get("off_threshold")
+    fan_device = p.get("fan_device", "fan")
     label = "Nat-vent fan off (cycling)"
     if indoor is not None and off_thr is not None:
         with contextlib.suppress(TypeError, ValueError):
             label = (
                 f"Nat-vent fan off -- indoor {format_temp(float(indoor), unit)} <= {format_temp(float(off_thr), unit)}"
             )
-    return label, "fan: on->auto"
+    return label, f"{fan_device}: on->auto"
 
 
 def _render_fan_activated(p: dict, unit: str) -> tuple[str, str]:
     reason = str(p.get("reason", "")).strip()
+    fan_device = p.get("fan_device", "fan")
     label = f"Fan activated -- {reason}" if reason else "Fan activated"
-    return label, "fan: off->on"
+    return label, f"{fan_device}: off->on"
 
 
 def _render_fan_deactivated(p: dict, unit: str) -> tuple[str, str]:
     reason = str(p.get("reason", "")).strip()
+    fan_device = p.get("fan_device", "fan")
     label = f"Fan deactivated -- {reason}" if reason else "Fan deactivated"
-    return label, "fan: on->off"
+    return label, f"{fan_device}: on->off"
+
+
+def _render_hvac_write_blocked_whf_active(p: dict, unit: str) -> tuple[str, str]:
+    """Issue #392 Fix 1b: choke-point guard intercepted an HVAC write while WHF owns the thermostat.
+
+    Makes the structural WHF/AC mutual-exclusion guarantee visible in the Activity Log
+    instead of silently dropping the blocked write.
+    """
+    attempted_mode = str(p.get("attempted_mode", "")).strip()
+    reason = str(p.get("reason", "")).strip()
+    label = f"HVAC write blocked (whole-house fan active) -- {reason}" if reason else "HVAC write blocked"
+    settings = f"hvac: blocked ({attempted_mode})" if attempted_mode else ""
+    return label, settings
 
 
 def _render_fan_manual_override(p: dict, unit: str) -> tuple[str, str]:
     fan_before = str(p.get("fan_before", "")).strip()
     fan_after = str(p.get("fan_after", "")).strip()
+    fan_device = p.get("fan_device", "fan")
     change = f"{fan_before}->{fan_after}" if fan_before and fan_after else ""
-    settings = f"fan: {change}" if change else ""
+    settings = f"{fan_device}: {change}" if change else ""
     return "Fan manual override", settings
 
 
@@ -517,7 +535,8 @@ def _render_fan_untracked_cleared(p: dict, unit: str) -> tuple[str, str]:
 def _render_fan_cancel(p: dict, unit: str) -> tuple[str, str]:
     fan_before = str(p.get("fan_before", "?")).strip()
     fan_after = str(p.get("fan_after", "?")).strip()
-    settings = f"fan: {fan_before}->{fan_after}" if fan_before and fan_after else ""
+    fan_device = p.get("fan_device", "fan")
+    settings = f"{fan_device}: {fan_before}->{fan_after}" if fan_before and fan_after else ""
     return "Fan cancel (user turned off)", settings
 
 
@@ -816,6 +835,7 @@ EVENT_RENDERERS: dict[str, Callable[[dict, str], tuple[str, str]]] = {
     "fan_activated": _render_fan_activated,
     "fan_deactivated": _render_fan_deactivated,
     "fan_manual_override": _render_fan_manual_override,
+    "hvac_write_blocked_whf_active": _render_hvac_write_blocked_whf_active,
     "fan_running_untracked": _render_fan_running_untracked,
     "fan_untracked_cleared": _render_fan_untracked_cleared,
     "fan_cancel": _render_fan_cancel,

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -6,6 +6,7 @@ based on the day classification and learning state.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 from collections.abc import Callable
@@ -386,6 +387,18 @@ class AutomationEngine:
         self._paused_by_door = False
         self._pre_pause_mode: str | None = None
 
+        # Issue #392 Fix 3: serialize the six automation decision-pass entry points
+        # (apply_classification, handle_door_window_open, handle_all_doors_windows_closed,
+        # check_natural_vent_conditions, _re_pause_for_open_sensor, nat_vent_temperature_check)
+        # against each other. asyncio is single-threaded but not atomic across awaits — without
+        # this lock, two triggers firing close together (e.g. a sensor-open debounce callback and
+        # a thermostat temperature-tick callback) can interleave and race on shared engine state
+        # (_natural_vent_active, _fan_active, _pre_fan_hvac_mode, _paused_by_door). See
+        # docs/08-COMPUTATION-REFERENCE.md §9g for the deadlock-avoidance analysis (none of the
+        # six methods calls another of the six directly in the same stack, so a plain
+        # `async with self._decision_lock:` wrap is safe — no `_impl` extraction needed).
+        self._decision_lock = asyncio.Lock()
+
         # Dry-run mode: when True, all service calls are logged but skipped
         self.dry_run: bool = False
 
@@ -526,6 +539,17 @@ class AutomationEngine:
     def natural_vent_active(self) -> bool:
         """Whether natural ventilation mode is currently active."""
         return self._natural_vent_active
+
+    @property
+    def _fan_running(self) -> bool:
+        """Whether any CA-owned fan (HVAC blower or whole-house) is currently running.
+
+        Collapses the recurring ``self._fan_active or self._natural_vent_active`` OR
+        pattern into a single derived property (Issue #392 Fix 1e) — the two flags are
+        one concept ("is CA's fan on") fractured into two names. Stepping stone toward a
+        future ``FanSession`` extraction (see Issue #392 shaping analysis).
+        """
+        return self._fan_active or self._natural_vent_active
 
     _VALID_OCCUPANCY_MODES = {OCCUPANCY_HOME, OCCUPANCY_AWAY, OCCUPANCY_VACATION, OCCUPANCY_GUEST}
 
@@ -669,6 +693,7 @@ class AutomationEngine:
                     "fan_before": fan_before,
                     "fan_after": fan_after,
                     "override_active_since": self._fan_override_time,
+                    "fan_device": _fan_device_label(self.config),
                 },
             )
         self._start_grace_period("manual", trigger="fan_manual_override")
@@ -716,6 +741,7 @@ class AutomationEngine:
                     "fan_before": fan_before,
                     "fan_after": fan_after,
                     "trigger": "fan_off",
+                    "fan_device": _fan_device_label(self.config),
                 },
             )
 
@@ -1013,327 +1039,343 @@ class AutomationEngine:
                 to evaluate the pre-cool achievement gate (Issue #295). When
                 None the achievement check is skipped for this cycle.
         """
-        self._current_classification = classification
+        async with self._decision_lock:
+            self._current_classification = classification
 
-        if self._manual_override_active:
-            _LOGGER.info(
-                "Manual override active (mode=%s since %s) — skipping HVAC mode change",
-                self._manual_override_mode,
-                self._manual_override_time,
-            )
-            return
-
-        if self._override_confirm_pending:
-            _LOGGER.info(
-                "Override confirmation pending (detected=%s at %s) — skipping HVAC mode change",
-                self._override_confirm_mode,
-                self._override_confirm_time,
-            )
-            return
-
-        # Issue #85: respect occupancy mode — don't overwrite setback with comfort
-        if self._occupancy_mode == OCCUPANCY_VACATION:
-            _LOGGER.info("Vacation mode — skipping classification temp change (deep setback preserved)")
-            return
-        if self._occupancy_mode == OCCUPANCY_AWAY:
-            _LOGGER.info("Away mode — reapplying setback instead of comfort temps")
-            await self.handle_occupancy_away()
-            return
-
-        # Issue #337: while paused by open door/window, suppress the band and hold HVAC off.
-        if self._paused_by_door:
-            _LOGGER.warning(
-                "apply_classification: door/window open (_paused_by_door=True) — "
-                "suppressing band, ensuring HVAC off; day_type=%s",
-                classification.day_type,
-            )
-            _cs_paused = self.hass.states.get(self.climate_entity)
-            if _cs_paused is not None and _cs_paused.state != "off":
+            if self._manual_override_active:
                 _LOGGER.info(
-                    "apply_classification: thermostat in state=%r — forcing off (windows open)",
-                    _cs_paused.state,
+                    "Manual override active (mode=%s since %s) — skipping HVAC mode change",
+                    self._manual_override_mode,
+                    self._manual_override_time,
                 )
-                await self._set_hvac_mode(
-                    "off",
-                    reason="classification cycle: door/window open — HVAC suppressed while paused",
-                )
-            else:
-                _LOGGER.info("apply_classification: thermostat already off — no mode change needed (windows open)")
-            if self._emit_event_callback:
-                self._emit_event_callback(
-                    "classification_suppressed_paused",
-                    {"day_type": classification.day_type, "hvac_mode": classification.hvac_mode},
-                )
-            return
-
-        # Issue #338: while nat-vent is active with savings mode, enforce floor-only HVAC so the
-        # 30-minute cycle cannot re-arm the ceiling (compressor) through open windows.
-        # With savings off, call the helper to keep the full band current, then continue so the
-        # ODE ceiling guard can still fire as a safety backstop if a breach is predicted.
-        if self._natural_vent_active:
-            _aggressive = bool(self.config.get("aggressive_savings", False))
-            _LOGGER.info(
-                "apply_classification: nat-vent active — enforcing nat-vent band ac_assist=%s day_type=%s",
-                not _aggressive,
-                classification.day_type,
-            )
-            await self._apply_nat_vent_hvac_state()
-            if _aggressive:
-                # Savings mode: no compressor through open windows — skip ceiling guard
                 return
 
-        _cs = self.hass.states.get(self.climate_entity)
-        _LOGGER.debug(
-            "apply_classification: wants=%r, thermostat=%r",
-            classification.hvac_mode,
-            _cs.state if _cs else "unavailable",
-        )
-
-        unit = self.config.get("temp_unit", "fahrenheit")
-        _LOGGER.warning(
-            "Applying classification: %s (trend: %s %s)",
-            classification.day_type,
-            classification.trend_direction,
-            format_temp_delta(classification.trend_magnitude, unit),
-        )
-        _old_mode_cls = _cs.state if _cs else None
-        _cls_key = (classification.day_type, classification.hvac_mode)
-        if _cls_key != self._last_classification_applied:
-            self._last_classification_applied = _cls_key
-            if self._emit_event_callback:
-                self._emit_event_callback(
-                    "classification_applied",
-                    {
-                        "day_type": classification.day_type,
-                        "hvac_mode": classification.hvac_mode,
-                        "trend": classification.trend_direction,
-                        "old_hvac_mode": _old_mode_cls,
-                        "indoor_f": indoor_temp,
-                    },
-                )
-        else:
-            _LOGGER.debug(
-                "classification_applied suppressed — same as last (%s/%s)",
-                classification.day_type,
-                classification.hvac_mode,
-            )
-
-        # Issue #295: pre-cool achievement gate — daily reset + detection.
-        # Reset the flag at the start of each new calendar day so the pre-cool
-        # ceiling offset re-arms each morning.  Check whether the home has
-        # already reached the pre-cool target temperature; if so, set the flag
-        # so select_comfort_band() reverts to comfort_cool for the rest of the day.
-        _today = dt_util.now().strftime("%Y-%m-%d")
-        if self._pre_condition_achieved_date != _today:
-            self._pre_condition_achieved = False
-            self._pre_condition_achieved_date = _today
-
-        if (
-            not self._pre_condition_achieved
-            and classification.pre_condition
-            and classification.pre_condition_target is not None
-            and classification.pre_condition_target < 0
-            and indoor_temp is not None
-        ):
-            _absolute_target = float(self.config.get("comfort_cool", 75)) + float(classification.pre_condition_target)
-            if indoor_temp <= _absolute_target:
-                self._pre_condition_achieved = True
+            if self._override_confirm_pending:
                 _LOGGER.info(
-                    "Pre-cool achieved (indoor=%.1f°F ≤ target=%.1f°F) — reverting to comfort ceiling for rest of day",
-                    indoor_temp,
-                    _absolute_target,
+                    "Override confirmation pending (detected=%s at %s) — skipping HVAC mode change",
+                    self._override_confirm_mode,
+                    self._override_confirm_time,
                 )
+                return
 
-        # Arm the comfort band — the thermostat holds the house; no mode-specific dispatch needed.
-        cls_reason = (
-            f"daily classification — {classification.day_type} day,"
-            f" trend {classification.trend_direction} {format_temp_delta(classification.trend_magnitude, unit)}"
-        )
-        _band = select_comfort_band(
-            classification,
-            self.config,
-            occupancy_mode=self._occupancy_mode,
-            in_sleep_window=_in_sleep_window(dt_util.now(), self.config),
-            aggressive_savings=bool(self.config.get("aggressive_savings", False)),
-            pre_condition_achieved=self._pre_condition_achieved,
-        )
-        await self._apply_comfort_band(_band, reason=cls_reason)
+            # Issue #85: respect occupancy mode — don't overwrite setback with comfort
+            if self._occupancy_mode == OCCUPANCY_VACATION:
+                _LOGGER.info("Vacation mode — skipping classification temp change (deep setback preserved)")
+                return
+            if self._occupancy_mode == OCCUPANCY_AWAY:
+                _LOGGER.info("Away mode — reapplying setback instead of comfort temps")
+                await self.handle_occupancy_away()
+                return
 
-        # ODE ceiling guard (Issue #136): if thermal model predicts indoor will breach
-        # comfort_cool within lead_time AND outdoor is already warmer than indoor
-        # (nat-vent unavailable), set HVAC to cool proactively.
-        # Re-evaluated on every 30-min cycle — no flag needed; adapts to forecast changes.
-        if predicted_indoor and classification.hvac_mode == "off":
-            _thermal = self._thermal_model or {}
-            _k_passive = _thermal.get("k_passive")
-            _conf = _thermal.get("confidence_k_passive") or _thermal.get("confidence", "none")
-            _k_via_bridge = bool(_thermal.get("k_passive_via_bridge"))
-            _k_active_cool = _thermal.get("k_active_cool")
-            _comfort_cool_cg = self.config.get("comfort_cool")
-            _tolerance = CEILING_BRIDGE_TOLERANCE_F if _k_via_bridge else 0.0
-
-            _model_eligible = (
-                _k_passive is not None
-                and _k_passive < 0
-                and (_conf != "none" or _k_via_bridge)
-                and _comfort_cool_cg is not None
-            )
-
-            _outdoor = self._last_outdoor_temp
-            _indoor_cg = self._get_indoor_temp_f()
-
-            _LOGGER.debug(
-                "ODE ceiling guard eval: %d points, comfort_cool=%s, outdoor=%s, indoor=%s,"
-                " k_passive=%s, conf=%s, bridge=%s",
-                len(predicted_indoor),
-                _comfort_cool_cg,
-                _outdoor,
-                _indoor_cg,
-                _k_passive,
-                _conf,
-                _k_via_bridge,
-            )
-
-            # Issue #247: dormancy is THREE conditions (the change #218 specified but its commit
-            # omitted — only the escalation-on-fire half landed). Defer to free cooling ONLY when
-            # outdoor is cooler AND nat-vent is actually running AND indoor is still within band.
-            # If indoor has breached the ceiling (free cooling losing to solar/internal gains), or
-            # nat-vent is not actually running (sensors closed / fan override — #215), the guard must
-            # evaluate and escalate to AC even though outdoor <= indoor. aggressive_savings widens the
-            # in-band threshold so savings homes tolerate a small overshoot before paying for cooling.
-            _aggressive = bool(self.config.get("aggressive_savings", False))
-            _ceiling_threshold = (
-                _comfort_cool_cg + CEILING_ESCALATION_SAVINGS_MARGIN_F
-                if (_aggressive and _comfort_cool_cg is not None)
-                else _comfort_cool_cg
-            )
-            if not _model_eligible:
-                _LOGGER.debug("ODE ceiling guard: skipped — k_passive=%s, conf=%s", _k_passive, _conf)
-            elif _outdoor is None or _indoor_cg is None:
-                _LOGGER.debug("ODE ceiling guard: skipped — missing outdoor/indoor temps")
-            elif _outdoor <= _indoor_cg and self._natural_vent_active and _indoor_cg <= _ceiling_threshold:
-                _LOGGER.debug(
-                    "ODE ceiling guard: dormant — outdoor %.1f <= indoor %.1f, nat-vent running,"
-                    " indoor <= ceiling threshold %.1f (free cooling viable)",
-                    _outdoor,
-                    _indoor_cg,
-                    _ceiling_threshold,
+            # Issue #337: while paused by open door/window, suppress the band and hold HVAC off.
+            if self._paused_by_door:
+                _LOGGER.warning(
+                    "apply_classification: door/window open (_paused_by_door=True) — "
+                    "suppressing band, ensuring HVAC off; day_type=%s",
+                    classification.day_type,
                 )
-            else:
-                # Dormancy lifted (outdoor rose above indoor, OR nat-vent is not running, OR indoor
-                # breached the ceiling under active nat-vent — Issue #247). Scan the predicted curve
-                # for a ceiling breach.
-                # Inline equivalent of _find_ceiling_breach_time() — avoids circular import.
-                _breach_ts: datetime | None = None
-                _threshold = _comfort_cool_cg + _tolerance
-                for _entry in predicted_indoor:
-                    _t = _entry.get("temp")
-                    if _t is not None and _t > _threshold:
-                        with contextlib.suppress(KeyError, ValueError, TypeError):
-                            _breach_ts = datetime.fromisoformat(_entry["ts"])
-                        break
-
-                if _breach_ts is None:
-                    _LOGGER.debug(
-                        "ODE ceiling guard: dormant — no breach above %.1f°F predicted",
-                        _threshold,
+                _cs_paused = self.hass.states.get(self.climate_entity)
+                if _cs_paused is not None and _cs_paused.state != "off":
+                    _LOGGER.info(
+                        "apply_classification: thermostat in state=%r — forcing off (windows open)",
+                        _cs_paused.state,
+                    )
+                    await self._set_hvac_mode(
+                        "off",
+                        reason="classification cycle: door/window open — HVAC suppressed while paused",
                     )
                 else:
-                    _now_cg = dt_util.now()
-                    # Normalize both to UTC for reliable subtraction
-                    _now_utc = (
-                        _now_cg.astimezone(UTC)
-                        if getattr(_now_cg, "tzinfo", None) is not None
-                        else _now_cg.replace(tzinfo=UTC)
+                    _LOGGER.info("apply_classification: thermostat already off — no mode change needed (windows open)")
+                if self._emit_event_callback:
+                    self._emit_event_callback(
+                        "classification_suppressed_paused",
+                        {"day_type": classification.day_type, "hvac_mode": classification.hvac_mode},
                     )
-                    _breach_utc = (
-                        _breach_ts.astimezone(UTC) if _breach_ts.tzinfo is not None else _breach_ts.replace(tzinfo=UTC)
+                return
+
+            # Issue #338: while nat-vent is active with savings mode, enforce floor-only HVAC so the
+            # 30-minute cycle cannot re-arm the ceiling (compressor) through open windows.
+            # With savings off, call the helper to keep the full band current, then continue so the
+            # ODE ceiling guard can still fire as a safety backstop if a breach is predicted.
+            if self._natural_vent_active:
+                _aggressive = bool(self.config.get("aggressive_savings", False))
+                _LOGGER.info(
+                    "apply_classification: nat-vent active — enforcing nat-vent band ac_assist=%s day_type=%s",
+                    not _aggressive,
+                    classification.day_type,
+                )
+                await self._apply_nat_vent_hvac_state()
+                if _aggressive:
+                    # Savings mode: no compressor through open windows — skip ceiling guard
+                    return
+                # Issue #392 Fix 1b: WHF/BOTH is mutually exclusive with the compressor by
+                # design (_activate_fan suppresses HVAC) — skip select_comfort_band()/the ODE
+                # ceiling guard entirely rather than letting the choke-point guard silently drop
+                # the write. FAN_MODE_HVAC keeps falling through (fan/AC coexist safely).
+                _fan_cfg_cls = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
+                if _fan_cfg_cls in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
+                    return
+
+            _cs = self.hass.states.get(self.climate_entity)
+            _LOGGER.debug(
+                "apply_classification: wants=%r, thermostat=%r",
+                classification.hvac_mode,
+                _cs.state if _cs else "unavailable",
+            )
+
+            unit = self.config.get("temp_unit", "fahrenheit")
+            _LOGGER.warning(
+                "Applying classification: %s (trend: %s %s)",
+                classification.day_type,
+                classification.trend_direction,
+                format_temp_delta(classification.trend_magnitude, unit),
+            )
+            _old_mode_cls = _cs.state if _cs else None
+            _cls_key = (classification.day_type, classification.hvac_mode)
+            if _cls_key != self._last_classification_applied:
+                self._last_classification_applied = _cls_key
+                if self._emit_event_callback:
+                    self._emit_event_callback(
+                        "classification_applied",
+                        {
+                            "day_type": classification.day_type,
+                            "hvac_mode": classification.hvac_mode,
+                            "trend": classification.trend_direction,
+                            "old_hvac_mode": _old_mode_cls,
+                            "indoor_f": indoor_temp,
+                        },
                     )
-                    _hours_to_breach = (_breach_utc - _now_utc).total_seconds() / 3600
+            else:
+                _LOGGER.debug(
+                    "classification_applied suppressed — same as last (%s/%s)",
+                    classification.day_type,
+                    classification.hvac_mode,
+                )
 
-                    if _k_active_cool is not None and abs(_k_active_cool) > 0:
-                        _lead_min = ((_comfort_cool_cg - _indoor_cg) / abs(_k_active_cool)) * 60 * 1.3
-                    else:
-                        _lead_min = float(CEILING_PRECOOL_FALLBACK_MIN)
-                    _lead_min = max(30.0, min(240.0, _lead_min))
+            # Issue #295: pre-cool achievement gate — daily reset + detection.
+            # Reset the flag at the start of each new calendar day so the pre-cool
+            # ceiling offset re-arms each morning.  Check whether the home has
+            # already reached the pre-cool target temperature; if so, set the flag
+            # so select_comfort_band() reverts to comfort_cool for the rest of the day.
+            _today = dt_util.now().strftime("%Y-%m-%d")
+            if self._pre_condition_achieved_date != _today:
+                self._pre_condition_achieved = False
+                self._pre_condition_achieved_date = _today
 
+            if (
+                not self._pre_condition_achieved
+                and classification.pre_condition
+                and classification.pre_condition_target is not None
+                and classification.pre_condition_target < 0
+                and indoor_temp is not None
+            ):
+                _absolute_target = float(self.config.get("comfort_cool", 75)) + float(
+                    classification.pre_condition_target
+                )
+                if indoor_temp <= _absolute_target:
+                    self._pre_condition_achieved = True
                     _LOGGER.info(
-                        "ODE ceiling guard: breach predicted at %s (%.1fh away), outdoor=%.1f, indoor=%.1f,"
-                        " nat_vent=%s",
-                        _breach_ts.strftime("%H:%M"),
-                        _hours_to_breach,
+                        "Pre-cool achieved (indoor=%.1f°F ≤ target=%.1f°F) — reverting to comfort"
+                        " ceiling for rest of day",
+                        indoor_temp,
+                        _absolute_target,
+                    )
+
+            # Arm the comfort band — the thermostat holds the house; no mode-specific dispatch needed.
+            cls_reason = (
+                f"daily classification — {classification.day_type} day,"
+                f" trend {classification.trend_direction} {format_temp_delta(classification.trend_magnitude, unit)}"
+            )
+            _band = select_comfort_band(
+                classification,
+                self.config,
+                occupancy_mode=self._occupancy_mode,
+                in_sleep_window=_in_sleep_window(dt_util.now(), self.config),
+                aggressive_savings=bool(self.config.get("aggressive_savings", False)),
+                pre_condition_achieved=self._pre_condition_achieved,
+            )
+            await self._apply_comfort_band(_band, reason=cls_reason)
+
+            # ODE ceiling guard (Issue #136): if thermal model predicts indoor will breach
+            # comfort_cool within lead_time AND outdoor is already warmer than indoor
+            # (nat-vent unavailable), set HVAC to cool proactively.
+            # Re-evaluated on every 30-min cycle — no flag needed; adapts to forecast changes.
+            if predicted_indoor and classification.hvac_mode == "off":
+                _thermal = self._thermal_model or {}
+                _k_passive = _thermal.get("k_passive")
+                _conf = _thermal.get("confidence_k_passive") or _thermal.get("confidence", "none")
+                _k_via_bridge = bool(_thermal.get("k_passive_via_bridge"))
+                _k_active_cool = _thermal.get("k_active_cool")
+                _comfort_cool_cg = self.config.get("comfort_cool")
+                _tolerance = CEILING_BRIDGE_TOLERANCE_F if _k_via_bridge else 0.0
+
+                _model_eligible = (
+                    _k_passive is not None
+                    and _k_passive < 0
+                    and (_conf != "none" or _k_via_bridge)
+                    and _comfort_cool_cg is not None
+                )
+
+                _outdoor = self._last_outdoor_temp
+                _indoor_cg = self._get_indoor_temp_f()
+
+                _LOGGER.debug(
+                    "ODE ceiling guard eval: %d points, comfort_cool=%s, outdoor=%s, indoor=%s,"
+                    " k_passive=%s, conf=%s, bridge=%s",
+                    len(predicted_indoor),
+                    _comfort_cool_cg,
+                    _outdoor,
+                    _indoor_cg,
+                    _k_passive,
+                    _conf,
+                    _k_via_bridge,
+                )
+
+                # Issue #247: dormancy is THREE conditions (the change #218 specified but its commit
+                # omitted — only the escalation-on-fire half landed). Defer to free cooling ONLY when
+                # outdoor is cooler AND nat-vent is actually running AND indoor is still within band.
+                # If indoor has breached the ceiling (free cooling losing to solar/internal gains), or
+                # nat-vent is not actually running (sensors closed / fan override — #215), the guard must
+                # evaluate and escalate to AC even though outdoor <= indoor. aggressive_savings widens the
+                # in-band threshold so savings homes tolerate a small overshoot before paying for cooling.
+                # Issue #392 Fix 1: the ceiling threshold is archetype-aware — None for whole-house-fan
+                # mode (direction-only, no ceiling handoff; see _ceiling_threshold() docstring).
+                _ceiling_threshold_val = self._ceiling_threshold(_comfort_cool_cg)
+                if not _model_eligible:
+                    _LOGGER.debug("ODE ceiling guard: skipped — k_passive=%s, conf=%s", _k_passive, _conf)
+                elif _outdoor is None or _indoor_cg is None:
+                    _LOGGER.debug("ODE ceiling guard: skipped — missing outdoor/indoor temps")
+                elif (
+                    _outdoor <= _indoor_cg
+                    and self._natural_vent_active
+                    and (_ceiling_threshold_val is None or _indoor_cg <= _ceiling_threshold_val)
+                ):
+                    _LOGGER.debug(
+                        "ODE ceiling guard: dormant — outdoor %.1f <= indoor %.1f, nat-vent running,"
+                        " indoor <= ceiling threshold %s (free cooling viable)",
                         _outdoor,
                         _indoor_cg,
-                        self._natural_vent_active,
+                        _ceiling_threshold_val,
                     )
+                else:
+                    # Dormancy lifted (outdoor rose above indoor, OR nat-vent is not running, OR indoor
+                    # breached the ceiling under active nat-vent — Issue #247). Scan the predicted curve
+                    # for a ceiling breach.
+                    # Inline equivalent of _find_ceiling_breach_time() — avoids circular import.
+                    _breach_ts: datetime | None = None
+                    _threshold = _comfort_cool_cg + _tolerance
+                    for _entry in predicted_indoor:
+                        _t = _entry.get("temp")
+                        if _t is not None and _t > _threshold:
+                            with contextlib.suppress(KeyError, ValueError, TypeError):
+                                _breach_ts = datetime.fromisoformat(_entry["ts"])
+                            break
 
-                    if _hours_to_breach <= _lead_min / 60:
-                        _LOGGER.info(
-                            "ODE ceiling guard: active — setting HVAC cool, target=%.1f"
-                            " (breach %.1fh, lead=%.0fmin, k_cool=%s)",
-                            _comfort_cool_cg,
-                            _hours_to_breach,
-                            _lead_min,
-                            _k_active_cool,
+                    if _breach_ts is None:
+                        _LOGGER.debug(
+                            "ODE ceiling guard: dormant — no breach above %.1f°F predicted",
+                            _threshold,
                         )
-                        if self._natural_vent_active:
-                            await self._deactivate_fan(reason="ceiling guard override -- nat-vent to active cooling")
-                            self._natural_vent_active = False
+                    else:
+                        _now_cg = dt_util.now()
+                        # Normalize both to UTC for reliable subtraction
+                        _now_utc = (
+                            _now_cg.astimezone(UTC)
+                            if getattr(_now_cg, "tzinfo", None) is not None
+                            else _now_cg.replace(tzinfo=UTC)
+                        )
+                        _breach_utc = (
+                            _breach_ts.astimezone(UTC)
+                            if _breach_ts.tzinfo is not None
+                            else _breach_ts.replace(tzinfo=UTC)
+                        )
+                        _hours_to_breach = (_breach_utc - _now_utc).total_seconds() / 3600
+
+                        if _k_active_cool is not None and abs(_k_active_cool) > 0:
+                            _lead_min = ((_comfort_cool_cg - _indoor_cg) / abs(_k_active_cool)) * 60 * 1.3
+                        else:
+                            _lead_min = float(CEILING_PRECOOL_FALLBACK_MIN)
+                        _lead_min = max(30.0, min(240.0, _lead_min))
+
+                        _LOGGER.info(
+                            "ODE ceiling guard: breach predicted at %s (%.1fh away), outdoor=%.1f, indoor=%.1f,"
+                            " nat_vent=%s",
+                            _breach_ts.strftime("%H:%M"),
+                            _hours_to_breach,
+                            _outdoor,
+                            _indoor_cg,
+                            self._natural_vent_active,
+                        )
+
+                        if _hours_to_breach <= _lead_min / 60:
+                            _LOGGER.info(
+                                "ODE ceiling guard: active — setting HVAC cool, target=%.1f"
+                                " (breach %.1fh, lead=%.0fmin, k_cool=%s)",
+                                _comfort_cool_cg,
+                                _hours_to_breach,
+                                _lead_min,
+                                _k_active_cool,
+                            )
+                            if self._natural_vent_active:
+                                await self._deactivate_fan(
+                                    reason="ceiling guard override -- nat-vent to active cooling"
+                                )
+                                self._natural_vent_active = False
+                                if self._emit_event_callback:
+                                    self._emit_event_callback(
+                                        "nat_vent_ceiling_escalation",
+                                        {
+                                            "indoor": _indoor_cg,
+                                            "outdoor": _outdoor,
+                                            "comfort_cool": _comfort_cool_cg,
+                                        },
+                                    )
+                            _cs_cg = self.hass.states.get(self.climate_entity)
+                            _old_mode_cg = _cs_cg.state if _cs_cg else None
+                            _old_setpoint_raw_cg = _cs_cg.attributes.get("temperature") if _cs_cg else None
+                            _old_setpoint_f_cg = (
+                                to_fahrenheit(_old_setpoint_raw_cg, unit) if _old_setpoint_raw_cg is not None else None
+                            )
+                            await self._set_hvac_mode(
+                                "cool",
+                                reason=(f"ODE ceiling guard — breach predicted at {_breach_ts.strftime('%H:%M')}"),
+                            )
+                            await self._set_temperature(
+                                _comfort_cool_cg,
+                                reason="ODE ceiling guard — target comfort_cool",
+                                mode="cool",
+                            )
                             if self._emit_event_callback:
                                 self._emit_event_callback(
-                                    "nat_vent_ceiling_escalation",
+                                    "ceiling_guard_fired",
                                     {
-                                        "indoor": _indoor_cg,
-                                        "outdoor": _outdoor,
-                                        "comfort_cool": _comfort_cool_cg,
+                                        "breach_time": _breach_ts.isoformat(),
+                                        "hours_to_breach": round(_hours_to_breach, 1),
+                                        "lead_time_min": round(_lead_min),
+                                        "old_hvac_mode": _old_mode_cg,
+                                        "new_hvac_mode": "cool",
+                                        "new_setpoint_f": _comfort_cool_cg,
+                                        "old_setpoint_f": _old_setpoint_f_cg,
                                     },
                                 )
-                        _cs_cg = self.hass.states.get(self.climate_entity)
-                        _old_mode_cg = _cs_cg.state if _cs_cg else None
-                        _old_setpoint_raw_cg = _cs_cg.attributes.get("temperature") if _cs_cg else None
-                        _old_setpoint_f_cg = (
-                            to_fahrenheit(_old_setpoint_raw_cg, unit) if _old_setpoint_raw_cg is not None else None
-                        )
-                        await self._set_hvac_mode(
-                            "cool",
-                            reason=(f"ODE ceiling guard — breach predicted at {_breach_ts.strftime('%H:%M')}"),
-                        )
-                        await self._set_temperature(
-                            _comfort_cool_cg,
-                            reason="ODE ceiling guard — target comfort_cool",
-                            mode="cool",
-                        )
-                        if self._emit_event_callback:
-                            self._emit_event_callback(
-                                "ceiling_guard_fired",
-                                {
-                                    "breach_time": _breach_ts.isoformat(),
-                                    "hours_to_breach": round(_hours_to_breach, 1),
-                                    "lead_time_min": round(_lead_min),
-                                    "old_hvac_mode": _old_mode_cg,
-                                    "new_hvac_mode": "cool",
-                                    "new_setpoint_f": _comfort_cool_cg,
-                                    "old_setpoint_f": _old_setpoint_f_cg,
-                                },
+                        else:
+                            _LOGGER.debug(
+                                "ODE ceiling guard: standing by — breach %.1fh away, need %.0fmin lead time",
+                                _hours_to_breach,
+                                _lead_min,
                             )
-                    else:
-                        _LOGGER.debug(
-                            "ODE ceiling guard: standing by — breach %.1fh away, need %.0fmin lead time",
-                            _hours_to_breach,
-                            _lead_min,
-                        )
 
-        # Handle pre-conditioning
-        if classification.pre_condition and classification.pre_condition_target:
-            await self._schedule_pre_condition(classification)
+            # Handle pre-conditioning
+            if classification.pre_condition and classification.pre_condition_target:
+                await self._schedule_pre_condition(classification)
 
-        # Issue #96 Root Cause E: apply_classification() runs on every coordinator refresh
-        # (30-min scheduled AND 5-min revisits). Cancel any revisit _record_action() scheduled —
-        # the 30-min cycle provides sufficient re-evaluation frequency.
-        if self._revisit_cancel:
-            self._revisit_cancel()
-            self._revisit_cancel = None
-        _LOGGER.debug("apply_classification: revisit canceled — 30-min cycle handles re-evaluation")
+            # Issue #96 Root Cause E: apply_classification() runs on every coordinator refresh
+            # (30-min scheduled AND 5-min revisits). Cancel any revisit _record_action() scheduled —
+            # the 30-min cycle provides sufficient re-evaluation frequency.
+            if self._revisit_cancel:
+                self._revisit_cancel()
+                self._revisit_cancel = None
+            _LOGGER.debug("apply_classification: revisit canceled — 30-min cycle handles re-evaluation")
 
     async def _apply_comfort_band(self, band: ComfortBand, *, reason: str) -> None:
         """Arm the thermostat with the comfort band (always single-setpoint).
@@ -1385,6 +1427,16 @@ class AutomationEngine:
 
     async def _set_hvac_mode(self, mode: str, *, reason: str) -> None:
         """Set the thermostat HVAC mode."""
+        # Issue #392 Fix 1b: structural choke-point guard — WHF/AC mutual exclusion is
+        # enforced here rather than by convention at every one of the ~13 call sites.
+        if mode != "off" and self._whf_owns_hvac():
+            _LOGGER.warning("HVAC write blocked — whole-house fan owns thermostat (%s)", reason)
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "hvac_write_blocked_whf_active",
+                    {"attempted_mode": mode, "reason": reason},
+                )
+            return
         if self.dry_run:
             _LOGGER.info("[DRY RUN] Would set HVAC mode to %s — %s", mode, reason)
             return
@@ -1436,6 +1488,16 @@ class AutomationEngine:
                 correct mode and HA deduplication is bypassed (the mode key makes
                 every call distinct even when temperature hasn't changed).
         """
+        # Issue #392 Fix 1b: structural choke-point guard — WHF/AC mutual exclusion is
+        # enforced here rather than by convention at every call site.
+        if mode != "off" and self._whf_owns_hvac():
+            _LOGGER.warning("HVAC write blocked — whole-house fan owns thermostat (%s)", reason)
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "hvac_write_blocked_whf_active",
+                    {"attempted_mode": mode, "reason": reason},
+                )
+            return
         unit = self.config.get("temp_unit", "fahrenheit")
         # Convert internal °F to user's unit before sending to HA climate entity
         service_temp = from_fahrenheit(temperature, unit)
@@ -1705,264 +1767,279 @@ class AutomationEngine:
 
         Called by the coordinator after the debounce period.
         """
-        if self._paused_by_door:
-            return  # Already paused
+        async with self._decision_lock:
+            if self._paused_by_door:
+                return  # Already paused
 
-        if self._grace_active:
+            if self._grace_active:
+                outdoor = self._last_outdoor_temp
+                comfort_cool = float(self.config.get("comfort_cool", 75))
+                nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
+                nat_vent_threshold = comfort_cool + nat_vent_delta
+                if outdoor is not None and outdoor < nat_vent_threshold:
+                    pass  # outdoor cool enough — fall through to nat-vent check below
+                else:
+                    _LOGGER.info(
+                        "Door/window open (%s) but %s grace period active — not pausing",
+                        entity_id,
+                        self._last_resume_source,
+                    )
+                    return
+
+            if self._is_within_planned_window_period():
+                _LOGGER.info(
+                    "Door/window open (%s) during planned window period — not pausing "
+                    "(windows recommended, HVAC off, day_type=%s)",
+                    entity_id,
+                    self._current_classification.day_type if self._current_classification else "unknown",
+                )
+                return
+
+            # Check for natural ventilation opportunity before falling through to pause
             outdoor = self._last_outdoor_temp
             comfort_cool = float(self.config.get("comfort_cool", 75))
             nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
             nat_vent_threshold = comfort_cool + nat_vent_delta
-            if outdoor is not None and outdoor < nat_vent_threshold:
-                pass  # outdoor cool enough — fall through to nat-vent check below
-            else:
-                _LOGGER.info(
-                    "Door/window open (%s) but %s grace period active — not pausing",
-                    entity_id,
-                    self._last_resume_source,
-                )
-                return
-
-        if self._is_within_planned_window_period():
-            _LOGGER.info(
-                "Door/window open (%s) during planned window period — not pausing "
-                "(windows recommended, HVAC off, day_type=%s)",
+            indoor = self._get_indoor_temp_f()
+            comfort_heat = float(self.config.get("comfort_heat", 70))
+            _LOGGER.debug(
+                "Nat vent gate check (%s): outdoor=%s indoor=%s comfort_heat=%.1f threshold=%.1f | "
+                "dir=%s floor=%s ceiling=%s",
                 entity_id,
-                self._current_classification.day_type if self._current_classification else "unknown",
+                f"{outdoor:.1f}" if outdoor is not None else "unavailable",
+                f"{indoor:.1f}" if indoor is not None else "unavailable",
+                comfort_heat,
+                nat_vent_threshold,
+                outdoor is not None and indoor is not None and outdoor < indoor,
+                indoor is not None and indoor > comfort_heat,
+                outdoor is not None and outdoor < nat_vent_threshold,
             )
-            return
+            # Issue #392 Fix 1: mirror the ODE ceiling guard's dormancy condition on reactivation —
+            # None (WHF, direction-only) always passes; FAN_MODE_HVAC blocks reactivation once indoor
+            # is already past the ceiling.
+            _ceiling_threshold_dw = self._ceiling_threshold(comfort_cool)
+            _ceiling_ok_dw = _ceiling_threshold_dw is None or (indoor is not None and indoor <= _ceiling_threshold_dw)
+            _nat_vent_gate_entered = False
+            if (
+                outdoor is not None
+                and indoor is not None
+                and outdoor < indoor  # outdoor must be cooler than indoor
+                and indoor > comfort_heat  # indoor must be above comfort floor
+                and outdoor < nat_vent_threshold
+                and _ceiling_ok_dw
+            ):
+                _nat_vent_gate_entered = True
+                _skip_nat_vent = False
 
-        # Check for natural ventilation opportunity before falling through to pause
-        outdoor = self._last_outdoor_temp
-        comfort_cool = float(self.config.get("comfort_cool", 75))
-        nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
-        nat_vent_threshold = comfort_cool + nat_vent_delta
-        indoor = self._get_indoor_temp_f()
-        comfort_heat = float(self.config.get("comfort_heat", 70))
-        _LOGGER.debug(
-            "Nat vent gate check (%s): outdoor=%s indoor=%s comfort_heat=%.1f threshold=%.1f | "
-            "dir=%s floor=%s ceiling=%s",
-            entity_id,
-            f"{outdoor:.1f}" if outdoor is not None else "unavailable",
-            f"{indoor:.1f}" if indoor is not None else "unavailable",
-            comfort_heat,
-            nat_vent_threshold,
-            outdoor is not None and indoor is not None and outdoor < indoor,
-            indoor is not None and indoor > comfort_heat,
-            outdoor is not None and outdoor < nat_vent_threshold,
-        )
-        _nat_vent_gate_entered = False
-        if (
-            outdoor is not None
-            and indoor is not None
-            and outdoor < indoor  # outdoor must be cooler than indoor
-            and indoor > comfort_heat  # indoor must be above comfort floor
-            and outdoor < nat_vent_threshold
-        ):
-            _nat_vent_gate_entered = True
-            _skip_nat_vent = False
+                # Phase 2 Guard 1: rising outdoor forecast
+                hourly = self._hourly_forecast_temps or []
+                if hourly:
+                    now_dt = dt_util.now()
+                    # Ensure timezone-aware for comparison with forecast datetimes
+                    if now_dt.tzinfo is None:
+                        now_dt = now_dt.replace(tzinfo=UTC)
+                    lookahead_temps = [
+                        h["temperature"]
+                        for h in hourly
+                        if h.get("temperature") is not None
+                        and (parsed := _parse_forecast_dt(h.get("datetime"))) is not None
+                        and now_dt < parsed <= now_dt + timedelta(hours=2)
+                    ]
+                    if lookahead_temps and max(lookahead_temps) > nat_vent_threshold:
+                        _skip_nat_vent = True
+                        _LOGGER.info(
+                            "Nat vent skipped: forecast peak %.1f°F > threshold %.1f°F within 2 hr",
+                            max(lookahead_temps),
+                            nat_vent_threshold,
+                        )
+                        if self._emit_event_callback:
+                            self._emit_event_callback(
+                                "nat_vent_forecast_skip",
+                                {"forecast_peak": max(lookahead_temps), "threshold": nat_vent_threshold},
+                            )
 
-            # Phase 2 Guard 1: rising outdoor forecast
-            hourly = self._hourly_forecast_temps or []
-            if hourly:
-                now_dt = dt_util.now()
-                # Ensure timezone-aware for comparison with forecast datetimes
-                if now_dt.tzinfo is None:
-                    now_dt = now_dt.replace(tzinfo=UTC)
-                lookahead_temps = [
-                    h["temperature"]
-                    for h in hourly
-                    if h.get("temperature") is not None
-                    and (parsed := _parse_forecast_dt(h.get("datetime"))) is not None
-                    and now_dt < parsed <= now_dt + timedelta(hours=2)
-                ]
-                if lookahead_temps and max(lookahead_temps) > nat_vent_threshold:
-                    _skip_nat_vent = True
+                # Phase 2 Guard 2: thermal model floor imminence
+                if not _skip_nat_vent:
+                    thermal = self._thermal_model or {}
+                    confidence = thermal.get("confidence", "none")
+                    if confidence in ("medium", "high"):
+                        k_passive = thermal.get("k_passive")
+                        if k_passive is not None and k_passive < 0:
+                            passive_rate = k_passive * (indoor - outdoor)  # °F/hr, negative
+                            if passive_rate < 0:
+                                time_to_floor = (indoor - comfort_heat) / abs(passive_rate)
+                                if time_to_floor < MIN_VIABLE_NAT_VENT_HOURS:
+                                    _skip_nat_vent = True
+                                    _LOGGER.info(
+                                        "Nat vent skipped: floor predicted in %.2f hr < %.1f hr"
+                                        " threshold (k_passive=%.3f)",
+                                        time_to_floor,
+                                        MIN_VIABLE_NAT_VENT_HOURS,
+                                        k_passive,
+                                    )
+                                    if self._emit_event_callback:
+                                        self._emit_event_callback(
+                                            "nat_vent_floor_imminent_skip",
+                                            {"time_to_floor_hr": round(time_to_floor, 2)},
+                                        )
+
+                if not _skip_nat_vent:
+                    # Capture mode before nat_vent changes
+                    _old_mode_nv = self.hass.states.get(self.climate_entity)
+                    _old_mode_nv = _old_mode_nv.state if _old_mode_nv else "unknown"
+
+                    nat_vent_reason = (
+                        f"natural ventilation: outdoor {outdoor:.1f}F < indoor {indoor:.1f}F,"
+                        f" outdoor {outdoor:.1f}F <= {nat_vent_threshold:.1f}F"
+                    )
+                    await self._activate_fan(reason=nat_vent_reason)
+                    self._natural_vent_active = True
                     _LOGGER.info(
-                        "Nat vent skipped: forecast peak %.1f°F > threshold %.1f°F within 2 hr",
-                        max(lookahead_temps),
+                        "Natural ventilation mode: outdoor %.1f°F < indoor %.1f°F,"
+                        " outdoor ≤ target %.1f°F — fan on, applying nat-vent HVAC state",
+                        outdoor,
+                        indoor,
                         nat_vent_threshold,
                     )
+                    await self._apply_nat_vent_hvac_state()
                     if self._emit_event_callback:
                         self._emit_event_callback(
-                            "nat_vent_forecast_skip",
-                            {"forecast_peak": max(lookahead_temps), "threshold": nat_vent_threshold},
+                            "sensor_opened",
+                            {
+                                "entity": entity_id,
+                                "result": "natural_ventilation",
+                                "hvac_mode_change": f"{_old_mode_nv}→band-armed",
+                                "fan_mode_change": "auto→on",
+                            },
                         )
+                    return
 
-            # Phase 2 Guard 2: thermal model floor imminence
-            if not _skip_nat_vent:
-                thermal = self._thermal_model or {}
-                confidence = thermal.get("confidence", "none")
-                if confidence in ("medium", "high"):
-                    k_passive = thermal.get("k_passive")
-                    if k_passive is not None and k_passive < 0:
-                        passive_rate = k_passive * (indoor - outdoor)  # °F/hr, negative
-                        if passive_rate < 0:
-                            time_to_floor = (indoor - comfort_heat) / abs(passive_rate)
-                            if time_to_floor < MIN_VIABLE_NAT_VENT_HOURS:
-                                _skip_nat_vent = True
-                                _LOGGER.info(
-                                    "Nat vent skipped: floor predicted in %.2f hr < %.1f hr threshold (k_passive=%.3f)",
-                                    time_to_floor,
-                                    MIN_VIABLE_NAT_VENT_HOURS,
-                                    k_passive,
-                                )
-                                if self._emit_event_callback:
-                                    self._emit_event_callback(
-                                        "nat_vent_floor_imminent_skip",
-                                        {"time_to_floor_hr": round(time_to_floor, 2)},
-                                    )
-
-            if not _skip_nat_vent:
-                # Capture mode before nat_vent changes
-                _old_mode_nv = self.hass.states.get(self.climate_entity)
-                _old_mode_nv = _old_mode_nv.state if _old_mode_nv else "unknown"
-
-                nat_vent_reason = (
-                    f"natural ventilation: outdoor {outdoor:.1f}F < indoor {indoor:.1f}F,"
-                    f" outdoor {outdoor:.1f}F <= {nat_vent_threshold:.1f}F"
-                )
-                await self._activate_fan(reason=nat_vent_reason)
-                self._natural_vent_active = True
+            if not _nat_vent_gate_entered:
                 _LOGGER.info(
-                    "Natural ventilation mode: outdoor %.1f°F < indoor %.1f°F,"
-                    " outdoor ≤ target %.1f°F — fan on, applying nat-vent HVAC state",
-                    outdoor,
-                    indoor,
-                    nat_vent_threshold,
+                    "Nat vent not started (%s): outdoor=%s indoor=%s — "
+                    "primary gates failed (dir=%s floor=%s ceiling=%s) — proceeding to HVAC pause check",
+                    entity_id,
+                    f"{outdoor:.1f}" if outdoor is not None else "unavailable",
+                    f"{indoor:.1f}" if indoor is not None else "unavailable",
+                    outdoor is not None and indoor is not None and outdoor < indoor,
+                    indoor is not None and indoor > comfort_heat,
+                    outdoor is not None and outdoor < nat_vent_threshold,
                 )
-                await self._apply_nat_vent_hvac_state()
+
+            # Get current mode before pausing
+            state = self.hass.states.get(self.climate_entity)
+            if state:
+                self._pre_pause_mode = state.state
+
+            if self._pre_pause_mode and self._pre_pause_mode != "off":
+                self._paused_by_door = True
                 if self._emit_event_callback:
                     self._emit_event_callback(
                         "sensor_opened",
                         {
                             "entity": entity_id,
-                            "result": "natural_ventilation",
-                            "hvac_mode_change": f"{_old_mode_nv}→band-armed",
-                            "fan_mode_change": "auto→on",
+                            "result": "paused",
+                            "hvac_mode_change": f"{self._pre_pause_mode}→off",
                         },
                     )
-                return
-
-        if not _nat_vent_gate_entered:
-            _LOGGER.info(
-                "Nat vent not started (%s): outdoor=%s indoor=%s — "
-                "primary gates failed (dir=%s floor=%s ceiling=%s) — proceeding to HVAC pause check",
-                entity_id,
-                f"{outdoor:.1f}" if outdoor is not None else "unavailable",
-                f"{indoor:.1f}" if indoor is not None else "unavailable",
-                outdoor is not None and indoor is not None and outdoor < indoor,
-                indoor is not None and indoor > comfort_heat,
-                outdoor is not None and outdoor < nat_vent_threshold,
-            )
-
-        # Get current mode before pausing
-        state = self.hass.states.get(self.climate_entity)
-        if state:
-            self._pre_pause_mode = state.state
-
-        if self._pre_pause_mode and self._pre_pause_mode != "off":
-            self._paused_by_door = True
-            if self._emit_event_callback:
-                self._emit_event_callback(
-                    "sensor_opened",
-                    {
-                        "entity": entity_id,
-                        "result": "paused",
-                        "hvac_mode_change": f"{self._pre_pause_mode}→off",
-                    },
+                await self._set_hvac_mode(
+                    "off",
+                    reason=f"door/window open — {entity_id}, was {self._pre_pause_mode} mode",
                 )
-            await self._set_hvac_mode(
-                "off",
-                reason=f"door/window open — {entity_id}, was {self._pre_pause_mode} mode",
-            )
 
-            # Notify
-            debounce_minutes = self.config.get(CONF_SENSOR_DEBOUNCE, DEFAULT_SENSOR_DEBOUNCE_SECONDS) // 60
-            friendly_name = entity_id.split(".")[-1].replace("_", " ").title()
-            await self._notify(
-                f"🚪 HVAC paused — {friendly_name} has been open for "
-                f"{debounce_minutes} minutes. "
-                f"Heating/cooling will resume when it's closed.",
-                "Climate Advisor",
-                notification_type="door_window_pause",
-            )
+                # Notify
+                debounce_minutes = self.config.get(CONF_SENSOR_DEBOUNCE, DEFAULT_SENSOR_DEBOUNCE_SECONDS) // 60
+                friendly_name = entity_id.split(".")[-1].replace("_", " ").title()
+                await self._notify(
+                    f"🚪 HVAC paused — {friendly_name} has been open for "
+                    f"{debounce_minutes} minutes. "
+                    f"Heating/cooling will resume when it's closed.",
+                    "Climate Advisor",
+                    notification_type="door_window_pause",
+                )
 
     async def handle_all_doors_windows_closed(self) -> None:
         """Resume HVAC after all monitored doors/windows are closed."""
-        was_nat_vent = self._natural_vent_active
-        was_paused = self._paused_by_door
-        if self._emit_event_callback:
-            self._emit_event_callback(
-                "sensor_all_closed",
-                {"was_paused": was_paused, "was_nat_vent": was_nat_vent},
-            )
-
-        # Handle natural ventilation mode cleanup (sensors closed while in nat vent)
-        if self._natural_vent_active:
-            self._natural_vent_active = False
-            # emit_event=False: this transition is reported via sensor_all_closed above.
-            await self._deactivate_fan(reason="door/window closed — ending natural ventilation mode", emit_event=False)
-            # Resume normal classification if we have one
-            if self._current_classification:
-                c = self._current_classification
-                _LOGGER.info(
-                    "sensor_all_closed: nat-vent ended — re-arming HVAC immediately day_type=%s hvac_mode=%s",
-                    c.day_type,
-                    c.hvac_mode,
+        async with self._decision_lock:
+            was_nat_vent = self._natural_vent_active
+            was_paused = self._paused_by_door
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "sensor_all_closed",
+                    {"was_paused": was_paused, "was_nat_vent": was_nat_vent},
                 )
-                if c.hvac_mode in ("heat", "cool"):
-                    # Hot/cool/cold day: restore the classification mode + setpoint directly.
-                    await self._set_hvac_mode(
+
+            # Handle natural ventilation mode cleanup (sensors closed while in nat vent)
+            if self._natural_vent_active:
+                self._natural_vent_active = False
+                # emit_event=False: this transition is reported via sensor_all_closed above.
+                await self._deactivate_fan(
+                    reason="door/window closed — ending natural ventilation mode", emit_event=False
+                )
+                # Resume normal classification if we have one
+                if self._current_classification:
+                    c = self._current_classification
+                    _LOGGER.info(
+                        "sensor_all_closed: nat-vent ended — re-arming HVAC immediately day_type=%s hvac_mode=%s",
+                        c.day_type,
                         c.hvac_mode,
-                        reason="door/window closed — restoring mode after natural ventilation",
                     )
+                    if c.hvac_mode in ("heat", "cool"):
+                        # Hot/cool/cold day: restore the classification mode + setpoint directly.
+                        await self._set_hvac_mode(
+                            c.hvac_mode,
+                            reason="door/window closed — restoring mode after natural ventilation",
+                        )
+                        await self._set_temperature_for_mode(
+                            c,
+                            reason="door/window closed — restoring comfort after natural ventilation",
+                        )
+                    else:
+                        # Warm/mild day: classifier says "off" but actual control is the comfort band
+                        # (Issue #249). Re-arm immediately — don't wait up to 30 min for
+                        # apply_classification() to fire.
+                        _rearm_band = ComfortBand(
+                            floor=float(self.config.get("comfort_heat", 70)),
+                            ceiling=float(self.config.get("comfort_cool", 75)),
+                            active="ceiling",
+                            reason="nat-vent ended (warm/mild day) — immediate comfort band re-arm",
+                        )
+                        await self._apply_comfort_band(
+                            _rearm_band,
+                            reason="door/window closed — re-arming comfort band after nat-vent (warm/mild day)",
+                        )
+                    self._start_grace_period("automation", trigger="sensor_closed_resume")
+                return
+
+            # Fix D (Issue #277): whole-house fan running outside nat-vent must stop
+            # when all sensors close — otherwise it draws outdoor air through a closed
+            # envelope, counteracting HVAC and wasting energy for the occupant.
+            _fan_cfg_d = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
+            if (
+                self._fan_active
+                and _fan_cfg_d in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH)
+                and not self._natural_vent_active
+            ):
+                _LOGGER.info("All sensors closed — stopping whole-house fan (was running outside nat-vent)")
+                # emit_event=False: this transition is reported via sensor_all_closed above.
+                await self._deactivate_fan(reason="all sensors closed — stopping whole-house fan", emit_event=False)
+
+            if not self._paused_by_door:
+                return
+
+            self._paused_by_door = False
+            if self._pre_pause_mode:
+                await self._set_hvac_mode(
+                    self._pre_pause_mode,
+                    reason=f"door/window closed — restoring {self._pre_pause_mode} mode",
+                )
+                if self._current_classification:
                     await self._set_temperature_for_mode(
-                        c,
-                        reason="door/window closed — restoring comfort after natural ventilation",
-                    )
-                else:
-                    # Warm/mild day: classifier says "off" but actual control is the comfort band
-                    # (Issue #249). Re-arm immediately — don't wait up to 30 min for
-                    # apply_classification() to fire.
-                    _rearm_band = ComfortBand(
-                        floor=float(self.config.get("comfort_heat", 70)),
-                        ceiling=float(self.config.get("comfort_cool", 75)),
-                        active="ceiling",
-                        reason="nat-vent ended (warm/mild day) — immediate comfort band re-arm",
-                    )
-                    await self._apply_comfort_band(
-                        _rearm_band,
-                        reason="door/window closed — re-arming comfort band after nat-vent (warm/mild day)",
+                        self._current_classification,
+                        reason="door/window closed — restoring comfort",
                     )
                 self._start_grace_period("automation", trigger="sensor_closed_resume")
-            return
-
-        # Fix D (Issue #277): whole-house fan running outside nat-vent must stop
-        # when all sensors close — otherwise it draws outdoor air through a closed
-        # envelope, counteracting HVAC and wasting energy for the occupant.
-        _fan_cfg_d = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
-        if self._fan_active and _fan_cfg_d in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH) and not self._natural_vent_active:
-            _LOGGER.info("All sensors closed — stopping whole-house fan (was running outside nat-vent)")
-            # emit_event=False: this transition is reported via sensor_all_closed above.
-            await self._deactivate_fan(reason="all sensors closed — stopping whole-house fan", emit_event=False)
-
-        if not self._paused_by_door:
-            return
-
-        self._paused_by_door = False
-        if self._pre_pause_mode:
-            await self._set_hvac_mode(
-                self._pre_pause_mode,
-                reason=f"door/window closed — restoring {self._pre_pause_mode} mode",
-            )
-            if self._current_classification:
-                await self._set_temperature_for_mode(
-                    self._current_classification,
-                    reason="door/window closed — restoring comfort",
-                )
-            self._start_grace_period("automation", trigger="sensor_closed_resume")
-        self._pre_pause_mode = None
+            self._pre_pause_mode = None
 
     async def check_natural_vent_conditions(self) -> None:
         """Re-evaluate natural ventilation vs pause when temperatures change.
@@ -1970,287 +2047,311 @@ class AutomationEngine:
         Called by coordinator on each _async_update_data when sensors are open.
         Mirrors the monitoring logic in tools/simulate.py ClimateSimulator.
         """
-        if not (self._paused_by_door or self._natural_vent_active):
-            # Comfort-ceiling override (Issue #134): if grace is active and indoor has
-            # risen above comfort_cool, allow re-evaluation so nat-vent can engage.
-            # Grace still blocks rapid door-open/close cycling below the comfort ceiling.
-            _indoor = self._get_indoor_temp_f()
-            _cool = float(self.config.get("comfort_cool", 75))
-            # Issue #244: a contact sensor open while HVAC is idle (door opened with
-            # nothing to pause) must still be re-evaluated so nat-vent can engage when
-            # outdoor later cools below indoor — otherwise the occupant misses free
-            # evening cooling. Restricted to HVAC-off so we never fight active heating/cooling.
-            _hvac_state_244 = self.hass.states.get(self.climate_entity)
-            _hvac_off_244 = (_hvac_state_244 is None) or (getattr(_hvac_state_244, "state", "off") == "off")
-            _idle_open = bool(self._sensor_check_callback and self._sensor_check_callback()) and _hvac_off_244
-            if not ((self._grace_active and _indoor is not None and _indoor > _cool) or _idle_open):
-                return
-
-        outdoor = self._last_outdoor_temp
-        comfort_cool = float(self.config.get("comfort_cool", 75))
-        nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
-        threshold = comfort_cool + nat_vent_delta
-
-        # Issue #134: comfort-ceiling re-entry during grace — neither flag is True but
-        # indoor has risen above comfort_cool. Check nat-vent conditions directly.
-        if not (self._paused_by_door or self._natural_vent_active):
-            _indoor = self._get_indoor_temp_f()
-            _comfort_heat = float(self.config.get("comfort_heat", 70))
-            _hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
-            if (
-                outdoor is not None
-                and _indoor is not None
-                and outdoor < _indoor - _hysteresis
-                and _indoor > _comfort_heat
-                and outdoor < threshold
-            ):
-                # Band stays armed — just activate the fan; the compressor self-arbitrates.
-                await self._activate_fan(
-                    reason=(
-                        f"nat vent grace re-entry: indoor {_indoor:.1f}°F"
-                        f" > comfort_cool {comfort_cool:.1f}°F,"
-                        f" outdoor {outdoor:.1f}°F cool"
-                    )
-                )
-                self._natural_vent_active = True
-                await self._apply_nat_vent_hvac_state()
-                # Issue #244: emit so the re-evaluation activation is visible in the
-                # event log / timeline / AI report (previously this path was silent).
-                if self._emit_event_callback:
-                    self._emit_event_callback(
-                        "sensor_opened",
-                        {
-                            "entity": "natural_vent_reeval",
-                            "result": "natural_ventilation",
-                            "trigger": "open_door_reeval",
-                        },
-                    )
-            return
-
-        # Issue #99: Comfort-floor exit — check BEFORE outdoor warmth to avoid conflicting
-        # transitions. If indoor drops to comfort_heat, stop fan and restore heat.
-        # Do NOT enter pause — the house needs to warm up, not wait for nat vent re-evaluation.
-        if self._natural_vent_active:
-            comfort_heat = float(self.config.get("comfort_heat", 70))
-            indoor = self._get_indoor_temp_f()
-            if self._natural_vent_active and indoor is not None and comfort_cool is not None and indoor > comfort_cool:
-                # Issue #247: the ODE ceiling guard now ESCALATES to AC on the classification cycle
-                # when indoor breaches the ceiling under active nat-vent (its three-condition dormancy
-                # lifts), so this is an informational heads-up, not a stuck state.
-                _LOGGER.info(
-                    "Nat-vent active but indoor %.1fF > comfort_cool %.1fF --"
-                    " ceiling guard will escalate to AC this classification cycle",
-                    indoor,
-                    comfort_cool,
-                )
-            # During sleep window, lower the hard exit floor to sleep_heat - hysteresis so the
-            # cycling logic can gracefully pause the fan at sleep_heat before the session terminates.
-            _hysteresis_cv = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
-            if _in_sleep_window(dt_util.now(), self.config):
-                _sleep_heat_cv = float(self.config.get(CONF_SLEEP_HEAT, comfort_heat))
-                _vent_floor = _sleep_heat_cv - _hysteresis_cv
-            else:
-                _vent_floor = comfort_heat
-            if indoor is not None and indoor <= _vent_floor:
-                self._natural_vent_active = False
-                await self._deactivate_fan(
-                    reason=(
-                        f"natural vent exit: indoor {indoor:.1f}\u00b0F \u2264 comfort floor {comfort_heat:.1f}\u00b0F"
-                    )
-                )
-                _LOGGER.info(
-                    "Natural vent exit (comfort floor): indoor %.1f\u00b0F"
-                    " \u2264 comfort_heat %.1f\u00b0F \u2014 restoring heat",
-                    indoor,
-                    comfort_heat,
-                )
-                if self._emit_event_callback:
-                    self._emit_event_callback(
-                        "nat_vent_comfort_floor_exit",
-                        {
-                            "indoor_temp": indoor,
-                            "comfort_heat": comfort_heat,
-                            "fan_mode_change": "on→auto",
-                            "hvac_mode_restored": (
-                                self._current_classification.hvac_mode if self._current_classification else "unknown"
-                            ),
-                        },
-                    )
-                if self._current_classification:
-                    c = self._current_classification
-                    if c.hvac_mode in ("heat", "cool"):
-                        await self._set_hvac_mode(
-                            c.hvac_mode,
-                            reason=f"natural vent comfort-floor exit \u2014 restoring {c.hvac_mode} mode",
-                        )
-                        await self._set_temperature_for_mode(
-                            c,
-                            reason="natural vent comfort-floor exit \u2014 restoring comfort",
-                        )
-                        self._start_grace_period("automation", trigger="nat_vent_exit_resume")
-                return
-
-        # Priority 2b: Away mode ceiling exit — nat-vent exits at home comfort ceiling while away
-        # (away setback is higher than comfort_cool, but nat-vent only free-cools within home band)
-        if self._natural_vent_active and self._occupancy_mode == OCCUPANCY_AWAY:
-            _indoor_away = self._get_indoor_temp_f()
-            if _indoor_away is not None and comfort_cool is not None and _indoor_away >= comfort_cool:
-                _LOGGER.info(
-                    "Nat-vent away-mode ceiling exit: indoor %.1fF >= comfort_cool %.1fF while away",
-                    _indoor_away,
-                    comfort_cool,
-                )
-                self._natural_vent_active = False
-                await self._deactivate_fan(reason="nat-vent ceiling exit (away mode)")
-                # Do NOT pause — just let away setback handle HVAC
-                if self._emit_event_callback:
-                    self._emit_event_callback(
-                        "nat_vent_away_ceiling_exit",
-                        {"indoor": _indoor_away, "comfort_cool": comfort_cool},
-                    )
-                return
-
-        # Phase 2: proactive floor exit — predict floor crossing before it happens
-        if self._natural_vent_active:
-            thermal = self._thermal_model or {}
-            if thermal.get("confidence", "none") in ("medium", "high"):
-                k_passive = thermal.get("k_passive")
-                _indoor_now = self._get_indoor_temp_f()
-                if (
-                    k_passive is not None
-                    and k_passive < 0
-                    and _indoor_now is not None
-                    and outdoor is not None
-                    and outdoor < _indoor_now
-                ):
-                    passive_rate = k_passive * (_indoor_now - outdoor)  # °F/hr, negative
-                    if passive_rate < 0:
-                        comfort_heat_now = float(self.config.get("comfort_heat", 70))
-                        time_to_floor = (_indoor_now - comfort_heat_now) / abs(passive_rate)
-                        if time_to_floor < MIN_VIABLE_NAT_VENT_HOURS:
-                            self._natural_vent_active = False
-                            await self._deactivate_fan(
-                                reason=(f"nat vent proactive floor exit: floor in {time_to_floor:.2f} hr")
-                            )
-                            _LOGGER.info(
-                                "Natural vent proactive exit: floor predicted in %.2f hr"
-                                " < %.1f hr threshold — restoring heat",
-                                time_to_floor,
-                                MIN_VIABLE_NAT_VENT_HOURS,
-                            )
-                            if self._emit_event_callback:
-                                self._emit_event_callback(
-                                    "nat_vent_predicted_floor_exit",
-                                    {
-                                        "time_to_floor_hr": round(time_to_floor, 2),
-                                        "fan_mode_change": "on→auto",
-                                        "hvac_mode_restored": (
-                                            self._current_classification.hvac_mode
-                                            if self._current_classification
-                                            else "unknown"
-                                        ),
-                                    },
-                                )
-                            if self._current_classification:
-                                c = self._current_classification
-                                if c.hvac_mode in ("heat", "cool"):
-                                    await self._set_hvac_mode(
-                                        c.hvac_mode,
-                                        reason="nat vent proactive floor exit — restoring HVAC",
-                                    )
-                                    await self._set_temperature_for_mode(
-                                        c,
-                                        reason="nat vent proactive floor exit — restoring comfort",
-                                    )
-                                    self._start_grace_period("automation", trigger="nat_vent_exit_resume")
-                            return
-
-        # NEW (Issue #115): exit if outdoor > indoor — airflow now strictly heating
-        indoor = self._get_indoor_temp_f()
-        if self._natural_vent_active and outdoor is not None and indoor is not None and outdoor > indoor:
-            self._natural_vent_active = False
-            self._paused_by_door = True
-            self._nat_vent_outdoor_exit_time = dt_util.now()
-            await self._deactivate_fan(
-                reason=(
-                    f"nat vent exit: outdoor {outdoor:.1f}\u00b0F > indoor {indoor:.1f}\u00b0F \u2014 airflow reversed"
-                )
-            )
-            _LOGGER.info(
-                "Natural vent exit: outdoor %.1f\u00b0F > indoor %.1f\u00b0F \u2014 airflow reversed, entering pause",
-                outdoor,
-                indoor,
-            )
-            if self._emit_event_callback:
-                self._emit_event_callback("nat_vent_outdoor_rise_exit", {"outdoor": outdoor, "indoor": indoor})
-            return
-
-        if self._natural_vent_active and outdoor is not None and outdoor > threshold:
-            # Outdoor got too warm — exit nat vent, enter pause
-            self._natural_vent_active = False
-            self._paused_by_door = True
-            await self._deactivate_fan(
-                reason=f"natural vent exit: outdoor {outdoor:.1f}\u00b0F > threshold {threshold:.1f}\u00b0F"
-            )
-            _LOGGER.info(
-                "Natural vent exit: outdoor %.1f\u00b0F > threshold %.1f\u00b0F \u2014 entering pause",
-                outdoor,
-                threshold,
-            )
-            return
-
-        if self._paused_by_door and outdoor is not None and indoor is not None:
-            hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
-            lockout_s = float(self.config.get(CONF_NAT_VENT_REACTIVATION_LOCKOUT_S, NAT_VENT_REACTIVATION_LOCKOUT_S))
-            comfort_heat = float(self.config.get("comfort_heat", 70))
-
-            # Enforce lockout after outdoor-warm exit
-            if self._nat_vent_outdoor_exit_time is not None:
-                elapsed = (dt_util.now() - self._nat_vent_outdoor_exit_time).total_seconds()
-                if elapsed < lockout_s:
-                    _LOGGER.debug(
-                        "Nat vent paused-by-door: lockout active — %.0fs elapsed of %.0fs (%.0fs remaining)",
-                        elapsed,
-                        lockout_s,
-                        lockout_s - elapsed,
-                    )
+        async with self._decision_lock:
+            if not (self._paused_by_door or self._natural_vent_active):
+                # Comfort-ceiling override (Issue #134): if grace is active and indoor has
+                # risen above comfort_cool, allow re-evaluation so nat-vent can engage.
+                # Grace still blocks rapid door-open/close cycling below the comfort ceiling.
+                _indoor = self._get_indoor_temp_f()
+                _cool = float(self.config.get("comfort_cool", 75))
+                # Issue #244: a contact sensor open while HVAC is idle (door opened with
+                # nothing to pause) must still be re-evaluated so nat-vent can engage when
+                # outdoor later cools below indoor — otherwise the occupant misses free
+                # evening cooling. Restricted to HVAC-off so we never fight active heating/cooling.
+                _hvac_state_244 = self.hass.states.get(self.climate_entity)
+                _hvac_off_244 = (_hvac_state_244 is None) or (getattr(_hvac_state_244, "state", "off") == "off")
+                _idle_open = bool(self._sensor_check_callback and self._sensor_check_callback()) and _hvac_off_244
+                if not ((self._grace_active and _indoor is not None and _indoor > _cool) or _idle_open):
                     return
 
-            _delta_ok = outdoor < indoor - hysteresis
-            _floor_ok = indoor > comfort_heat
-            _ceiling_ok = outdoor < threshold
-            if _delta_ok and _floor_ok and _ceiling_ok:
-                # Outdoor cooled down — activate natural vent
-                await self._activate_fan(
+            outdoor = self._last_outdoor_temp
+            comfort_cool = float(self.config.get("comfort_cool", 75))
+            nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
+            threshold = comfort_cool + nat_vent_delta
+
+            # Issue #134: comfort-ceiling re-entry during grace — neither flag is True but
+            # indoor has risen above comfort_cool. Check nat-vent conditions directly.
+            if not (self._paused_by_door or self._natural_vent_active):
+                _indoor = self._get_indoor_temp_f()
+                _comfort_heat = float(self.config.get("comfort_heat", 70))
+                _hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
+                # Issue #392 Fix 1: mirror the ODE ceiling guard's dormancy condition.
+                _ceiling_threshold_gr = self._ceiling_threshold(comfort_cool)
+                _ceiling_ok_gr = _ceiling_threshold_gr is None or (
+                    _indoor is not None and _indoor <= _ceiling_threshold_gr
+                )
+                if (
+                    outdoor is not None
+                    and _indoor is not None
+                    and outdoor < _indoor - _hysteresis
+                    and _indoor > _comfort_heat
+                    and outdoor < threshold
+                    and _ceiling_ok_gr
+                ):
+                    # Band stays armed — just activate the fan; the compressor self-arbitrates.
+                    await self._activate_fan(
+                        reason=(
+                            f"nat vent grace re-entry: indoor {_indoor:.1f}°F"
+                            f" > comfort_cool {comfort_cool:.1f}°F,"
+                            f" outdoor {outdoor:.1f}°F cool"
+                        )
+                    )
+                    self._natural_vent_active = True
+                    await self._apply_nat_vent_hvac_state()
+                    # Issue #244: emit so the re-evaluation activation is visible in the
+                    # event log / timeline / AI report (previously this path was silent).
+                    if self._emit_event_callback:
+                        self._emit_event_callback(
+                            "sensor_opened",
+                            {
+                                "entity": "natural_vent_reeval",
+                                "result": "natural_ventilation",
+                                "trigger": "open_door_reeval",
+                            },
+                        )
+                return
+
+            # Issue #99: Comfort-floor exit — check BEFORE outdoor warmth to avoid conflicting
+            # transitions. If indoor drops to comfort_heat, stop fan and restore heat.
+            # Do NOT enter pause — the house needs to warm up, not wait for nat vent re-evaluation.
+            if self._natural_vent_active:
+                comfort_heat = float(self.config.get("comfort_heat", 70))
+                indoor = self._get_indoor_temp_f()
+                if (
+                    self._natural_vent_active
+                    and indoor is not None
+                    and comfort_cool is not None
+                    and indoor > comfort_cool
+                ):
+                    # Issue #247: the ODE ceiling guard now ESCALATES to AC on the classification cycle
+                    # when indoor breaches the ceiling under active nat-vent (its three-condition dormancy
+                    # lifts), so this is an informational heads-up, not a stuck state.
+                    _LOGGER.info(
+                        "Nat-vent active but indoor %.1fF > comfort_cool %.1fF --"
+                        " ceiling guard will escalate to AC this classification cycle",
+                        indoor,
+                        comfort_cool,
+                    )
+                # During sleep window, lower the hard exit floor to sleep_heat - hysteresis so the
+                # cycling logic can gracefully pause the fan at sleep_heat before the session terminates.
+                _hysteresis_cv = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
+                if _in_sleep_window(dt_util.now(), self.config):
+                    _sleep_heat_cv = float(self.config.get(CONF_SLEEP_HEAT, comfort_heat))
+                    _vent_floor = _sleep_heat_cv - _hysteresis_cv
+                else:
+                    _vent_floor = comfort_heat
+                if indoor is not None and indoor <= _vent_floor:
+                    self._natural_vent_active = False
+                    await self._deactivate_fan(
+                        reason=(
+                            f"natural vent exit: indoor {indoor:.1f}\u00b0F \u2264 comfort floor"
+                            f" {comfort_heat:.1f}\u00b0F"
+                        )
+                    )
+                    _LOGGER.info(
+                        "Natural vent exit (comfort floor): indoor %.1f\u00b0F"
+                        " \u2264 comfort_heat %.1f\u00b0F \u2014 restoring heat",
+                        indoor,
+                        comfort_heat,
+                    )
+                    if self._emit_event_callback:
+                        self._emit_event_callback(
+                            "nat_vent_comfort_floor_exit",
+                            {
+                                "indoor_temp": indoor,
+                                "comfort_heat": comfort_heat,
+                                "fan_mode_change": "on→auto",
+                                "hvac_mode_restored": (
+                                    self._current_classification.hvac_mode
+                                    if self._current_classification
+                                    else "unknown"
+                                ),
+                            },
+                        )
+                    if self._current_classification:
+                        c = self._current_classification
+                        if c.hvac_mode in ("heat", "cool"):
+                            await self._set_hvac_mode(
+                                c.hvac_mode,
+                                reason=f"natural vent comfort-floor exit \u2014 restoring {c.hvac_mode} mode",
+                            )
+                            await self._set_temperature_for_mode(
+                                c,
+                                reason="natural vent comfort-floor exit \u2014 restoring comfort",
+                            )
+                            self._start_grace_period("automation", trigger="nat_vent_exit_resume")
+                    return
+
+            # Priority 2b: Away mode ceiling exit — nat-vent exits at home comfort ceiling while away
+            # (away setback is higher than comfort_cool, but nat-vent only free-cools within home band)
+            if self._natural_vent_active and self._occupancy_mode == OCCUPANCY_AWAY:
+                _indoor_away = self._get_indoor_temp_f()
+                if _indoor_away is not None and comfort_cool is not None and _indoor_away >= comfort_cool:
+                    _LOGGER.info(
+                        "Nat-vent away-mode ceiling exit: indoor %.1fF >= comfort_cool %.1fF while away",
+                        _indoor_away,
+                        comfort_cool,
+                    )
+                    self._natural_vent_active = False
+                    await self._deactivate_fan(reason="nat-vent ceiling exit (away mode)")
+                    # Do NOT pause — just let away setback handle HVAC
+                    if self._emit_event_callback:
+                        self._emit_event_callback(
+                            "nat_vent_away_ceiling_exit",
+                            {"indoor": _indoor_away, "comfort_cool": comfort_cool},
+                        )
+                    return
+
+            # Phase 2: proactive floor exit — predict floor crossing before it happens
+            if self._natural_vent_active:
+                thermal = self._thermal_model or {}
+                if thermal.get("confidence", "none") in ("medium", "high"):
+                    k_passive = thermal.get("k_passive")
+                    _indoor_now = self._get_indoor_temp_f()
+                    if (
+                        k_passive is not None
+                        and k_passive < 0
+                        and _indoor_now is not None
+                        and outdoor is not None
+                        and outdoor < _indoor_now
+                    ):
+                        passive_rate = k_passive * (_indoor_now - outdoor)  # °F/hr, negative
+                        if passive_rate < 0:
+                            comfort_heat_now = float(self.config.get("comfort_heat", 70))
+                            time_to_floor = (_indoor_now - comfort_heat_now) / abs(passive_rate)
+                            if time_to_floor < MIN_VIABLE_NAT_VENT_HOURS:
+                                self._natural_vent_active = False
+                                await self._deactivate_fan(
+                                    reason=(f"nat vent proactive floor exit: floor in {time_to_floor:.2f} hr")
+                                )
+                                _LOGGER.info(
+                                    "Natural vent proactive exit: floor predicted in %.2f hr"
+                                    " < %.1f hr threshold — restoring heat",
+                                    time_to_floor,
+                                    MIN_VIABLE_NAT_VENT_HOURS,
+                                )
+                                if self._emit_event_callback:
+                                    self._emit_event_callback(
+                                        "nat_vent_predicted_floor_exit",
+                                        {
+                                            "time_to_floor_hr": round(time_to_floor, 2),
+                                            "fan_mode_change": "on→auto",
+                                            "hvac_mode_restored": (
+                                                self._current_classification.hvac_mode
+                                                if self._current_classification
+                                                else "unknown"
+                                            ),
+                                        },
+                                    )
+                                if self._current_classification:
+                                    c = self._current_classification
+                                    if c.hvac_mode in ("heat", "cool"):
+                                        await self._set_hvac_mode(
+                                            c.hvac_mode,
+                                            reason="nat vent proactive floor exit — restoring HVAC",
+                                        )
+                                        await self._set_temperature_for_mode(
+                                            c,
+                                            reason="nat vent proactive floor exit — restoring comfort",
+                                        )
+                                        self._start_grace_period("automation", trigger="nat_vent_exit_resume")
+                                return
+
+            # NEW (Issue #115): exit if outdoor > indoor — airflow now strictly heating
+            indoor = self._get_indoor_temp_f()
+            if self._natural_vent_active and outdoor is not None and indoor is not None and outdoor > indoor:
+                self._natural_vent_active = False
+                self._paused_by_door = True
+                self._nat_vent_outdoor_exit_time = dt_util.now()
+                await self._deactivate_fan(
                     reason=(
-                        f"natural vent activated: outdoor {outdoor:.1f}°F"
-                        f" < indoor {indoor:.1f}°F − {hysteresis:.1f}°F hysteresis,"
-                        f" outdoor ≤ threshold {threshold:.1f}°F"
+                        f"nat vent exit: outdoor {outdoor:.1f}\u00b0F > indoor {indoor:.1f}\u00b0F"
+                        " \u2014 airflow reversed"
                     )
                 )
-                self._natural_vent_active = True
-                self._paused_by_door = False
                 _LOGGER.info(
-                    "Natural vent activated: outdoor %.1f°F < indoor %.1f°F − %.1f°F hysteresis,"
-                    " outdoor ≤ threshold %.1f°F while paused",
+                    "Natural vent exit: outdoor %.1f\u00b0F > indoor %.1f\u00b0F \u2014 airflow reversed,"
+                    " entering pause",
                     outdoor,
                     indoor,
-                    hysteresis,
+                )
+                if self._emit_event_callback:
+                    self._emit_event_callback("nat_vent_outdoor_rise_exit", {"outdoor": outdoor, "indoor": indoor})
+                return
+
+            if self._natural_vent_active and outdoor is not None and outdoor > threshold:
+                # Outdoor got too warm — exit nat vent, enter pause
+                self._natural_vent_active = False
+                self._paused_by_door = True
+                await self._deactivate_fan(
+                    reason=f"natural vent exit: outdoor {outdoor:.1f}\u00b0F > threshold {threshold:.1f}\u00b0F"
+                )
+                _LOGGER.info(
+                    "Natural vent exit: outdoor %.1f\u00b0F > threshold %.1f\u00b0F \u2014 entering pause",
+                    outdoor,
                     threshold,
                 )
-                await self._apply_nat_vent_hvac_state()
-            else:
-                _LOGGER.debug(
-                    "Nat vent paused-by-door: conditions not met — "
-                    "outdoor=%.1f°F indoor=%.1f°F delta=%.1f°F (need>%.1f°F) "
-                    "floor_ok=%s ceiling_ok=%s",
-                    outdoor,
-                    indoor,
-                    indoor - outdoor,
-                    hysteresis,
-                    _floor_ok,
-                    _ceiling_ok,
+                return
+
+            if self._paused_by_door and outdoor is not None and indoor is not None:
+                hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
+                lockout_s = float(
+                    self.config.get(CONF_NAT_VENT_REACTIVATION_LOCKOUT_S, NAT_VENT_REACTIVATION_LOCKOUT_S)
                 )
+                comfort_heat = float(self.config.get("comfort_heat", 70))
+
+                # Enforce lockout after outdoor-warm exit
+                if self._nat_vent_outdoor_exit_time is not None:
+                    elapsed = (dt_util.now() - self._nat_vent_outdoor_exit_time).total_seconds()
+                    if elapsed < lockout_s:
+                        _LOGGER.debug(
+                            "Nat vent paused-by-door: lockout active — %.0fs elapsed of %.0fs (%.0fs remaining)",
+                            elapsed,
+                            lockout_s,
+                            lockout_s - elapsed,
+                        )
+                        return
+
+                _delta_ok = outdoor < indoor - hysteresis
+                _floor_ok = indoor > comfort_heat
+                _ceiling_ok = outdoor < threshold
+                # Issue #392 Fix 1: mirror the ODE ceiling guard's dormancy condition. Named
+                # distinctly from _ceiling_ok above (outdoor-vs-threshold direction check) — this
+                # is the comfort_cool-based handoff-to-AC condition instead.
+                _ceiling_threshold_pd = self._ceiling_threshold(comfort_cool)
+                _comfort_ceiling_ok = _ceiling_threshold_pd is None or indoor <= _ceiling_threshold_pd
+                if _delta_ok and _floor_ok and _ceiling_ok and _comfort_ceiling_ok:
+                    # Outdoor cooled down — activate natural vent
+                    await self._activate_fan(
+                        reason=(
+                            f"natural vent activated: outdoor {outdoor:.1f}°F"
+                            f" < indoor {indoor:.1f}°F − {hysteresis:.1f}°F hysteresis,"
+                            f" outdoor ≤ threshold {threshold:.1f}°F"
+                        )
+                    )
+                    self._natural_vent_active = True
+                    self._paused_by_door = False
+                    _LOGGER.info(
+                        "Natural vent activated: outdoor %.1f°F < indoor %.1f°F − %.1f°F hysteresis,"
+                        " outdoor ≤ threshold %.1f°F while paused",
+                        outdoor,
+                        indoor,
+                        hysteresis,
+                        threshold,
+                    )
+                    await self._apply_nat_vent_hvac_state()
+                else:
+                    _LOGGER.debug(
+                        "Nat vent paused-by-door: conditions not met — "
+                        "outdoor=%.1f°F indoor=%.1f°F delta=%.1f°F (need>%.1f°F) "
+                        "floor_ok=%s ceiling_ok=%s",
+                        outdoor,
+                        indoor,
+                        indoor - outdoor,
+                        hysteresis,
+                        _floor_ok,
+                        _ceiling_ok,
+                    )
 
     async def nat_vent_temperature_check(self, current_temp: float) -> None:
         """Thermostat-style cycling: keep indoor near the comfort midpoint during a nat-vent session.
@@ -2263,108 +2364,109 @@ class AutomationEngine:
         maintained (restore_hvac=False). When indoor warms back to (midpoint + hysteresis)
         the fan re-engages, subject to the outdoor-warm guard.
         """
-        if not self._natural_vent_active:
-            return
-
-        comfort_heat = float(self.config.get("comfort_heat", 70))
-        comfort_cool = float(self.config.get("comfort_cool", 75))
-        hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
-        if _in_sleep_window(dt_util.now(), self.config):
-            sleep_heat = float(self.config.get(CONF_SLEEP_HEAT, comfort_heat))
-            nat_vent_target = sleep_heat + hysteresis  # e.g. 65+1=66; off at 65, on at 67
-            # Hard exit floor is one hysteresis step below the cycling-off threshold so the
-            # fan can cycle off gracefully at sleep_heat before the session ends.
-            _hard_floor = sleep_heat - hysteresis  # e.g. 64°F
-            _context = "sleep"
-        else:
-            nat_vent_target = (comfort_heat + comfort_cool) / 2.0
-            _hard_floor = comfort_heat
-            _context = "daytime"
-        off_threshold = nat_vent_target - hysteresis
-        on_threshold = nat_vent_target + hysteresis
-
-        # Hard floor exit takes priority over cycling.
-        # Sleep window: _hard_floor = sleep_heat - hysteresis (one step below cycling-off threshold),
-        # allowing the fan to cycle off gracefully at sleep_heat before the session terminates.
-        # Daytime: _hard_floor = comfort_heat (unchanged behaviour).
-        if current_temp <= _hard_floor:
-            _LOGGER.info(
-                "Nat-vent hard exit [%s] via temp-check: indoor %.1f°F ≤ floor %.1f°F — ending session",
-                _context,
-                current_temp,
-                _hard_floor,
-            )
-            await self._deactivate_fan(reason="nat_vent_floor_exit", restore_hvac=True)
-            self._natural_vent_active = False
-            if self._emit_event_callback:
-                self._emit_event_callback(
-                    "nat_vent_comfort_floor_exit",
-                    {"indoor_temp": current_temp, "comfort_heat": _hard_floor, "source": "temp_check"},
-                )
-            return
-
-        if self._fan_active and current_temp <= off_threshold:
-            _LOGGER.info(
-                "Nat-vent cycling [%s]: target=%.1f°F, off=%.1f°F, on=%.1f°F (fan_device=%s)"
-                " — indoor %.1f°F ≤ off_threshold, cycling fan off, session remains active",
-                _context,
-                nat_vent_target,
-                off_threshold,
-                on_threshold,
-                _fan_device_label(self.config),
-                current_temp,
-            )
-            # Deactivate the fan without restoring HVAC — session stays alive.
-            # emit_event=False: this transition is reported via nat_vent_fan_off below.
-            await self._deactivate_fan(reason="nat_vent_cycling_off", restore_hvac=False, emit_event=False)
-            # _natural_vent_active intentionally left True — session continues
-            if self._emit_event_callback:
-                self._emit_event_callback(
-                    "nat_vent_fan_off",
-                    {
-                        "indoor_temp": current_temp,
-                        "off_threshold": off_threshold,
-                        "target": nat_vent_target,
-                        "fan_device": _fan_device_label(self.config),
-                    },
-                )
-            return
-
-        if not self._fan_active and current_temp >= on_threshold:
-            outdoor = self._last_outdoor_temp
-            if outdoor is not None and outdoor >= current_temp:
-                _LOGGER.info(
-                    "Nat-vent cycling: indoor %.1f°F ≥ on_threshold %.1f°F"
-                    " but outdoor %.1f°F ≥ indoor — skipping re-activation"
-                    " (outdoor-warm exit condition active)",
-                    current_temp,
-                    on_threshold,
-                    outdoor,
-                )
+        async with self._decision_lock:
+            if not self._natural_vent_active:
                 return
-            _LOGGER.info(
-                "Nat-vent cycling [%s]: target=%.1f°F, off=%.1f°F, on=%.1f°F (fan_device=%s)"
-                " — indoor %.1f°F ≥ on_threshold, outdoor=%.1f°F, cycling fan on",
-                _context,
-                nat_vent_target,
-                off_threshold,
-                on_threshold,
-                _fan_device_label(self.config),
-                current_temp,
-                outdoor if outdoor is not None else 0.0,
-            )
-            # emit_event=False: this transition is reported via nat_vent_fan_on below.
-            await self._activate_fan(reason="nat_vent_cycling_on", emit_event=False)
-            if self._emit_event_callback:
-                self._emit_event_callback(
-                    "nat_vent_fan_on",
-                    {
-                        "indoor_temp": current_temp,
-                        "on_threshold": on_threshold,
-                        "target": nat_vent_target,
-                        "fan_device": _fan_device_label(self.config),
-                    },
+
+            comfort_heat = float(self.config.get("comfort_heat", 70))
+            comfort_cool = float(self.config.get("comfort_cool", 75))
+            hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
+            if _in_sleep_window(dt_util.now(), self.config):
+                sleep_heat = float(self.config.get(CONF_SLEEP_HEAT, comfort_heat))
+                nat_vent_target = sleep_heat + hysteresis  # e.g. 65+1=66; off at 65, on at 67
+                # Hard exit floor is one hysteresis step below the cycling-off threshold so the
+                # fan can cycle off gracefully at sleep_heat before the session ends.
+                _hard_floor = sleep_heat - hysteresis  # e.g. 64°F
+                _context = "sleep"
+            else:
+                nat_vent_target = (comfort_heat + comfort_cool) / 2.0
+                _hard_floor = comfort_heat
+                _context = "daytime"
+            off_threshold = nat_vent_target - hysteresis
+            on_threshold = nat_vent_target + hysteresis
+
+            # Hard floor exit takes priority over cycling.
+            # Sleep window: _hard_floor = sleep_heat - hysteresis (one step below cycling-off threshold),
+            # allowing the fan to cycle off gracefully at sleep_heat before the session terminates.
+            # Daytime: _hard_floor = comfort_heat (unchanged behaviour).
+            if current_temp <= _hard_floor:
+                _LOGGER.info(
+                    "Nat-vent hard exit [%s] via temp-check: indoor %.1f°F ≤ floor %.1f°F — ending session",
+                    _context,
+                    current_temp,
+                    _hard_floor,
                 )
+                await self._deactivate_fan(reason="nat_vent_floor_exit", restore_hvac=True)
+                self._natural_vent_active = False
+                if self._emit_event_callback:
+                    self._emit_event_callback(
+                        "nat_vent_comfort_floor_exit",
+                        {"indoor_temp": current_temp, "comfort_heat": _hard_floor, "source": "temp_check"},
+                    )
+                return
+
+            if self._fan_active and current_temp <= off_threshold:
+                _LOGGER.info(
+                    "Nat-vent cycling [%s]: target=%.1f°F, off=%.1f°F, on=%.1f°F (fan_device=%s)"
+                    " — indoor %.1f°F ≤ off_threshold, cycling fan off, session remains active",
+                    _context,
+                    nat_vent_target,
+                    off_threshold,
+                    on_threshold,
+                    _fan_device_label(self.config),
+                    current_temp,
+                )
+                # Deactivate the fan without restoring HVAC — session stays alive.
+                # emit_event=False: this transition is reported via nat_vent_fan_off below.
+                await self._deactivate_fan(reason="nat_vent_cycling_off", restore_hvac=False, emit_event=False)
+                # _natural_vent_active intentionally left True — session continues
+                if self._emit_event_callback:
+                    self._emit_event_callback(
+                        "nat_vent_fan_off",
+                        {
+                            "indoor_temp": current_temp,
+                            "off_threshold": off_threshold,
+                            "target": nat_vent_target,
+                            "fan_device": _fan_device_label(self.config),
+                        },
+                    )
+                return
+
+            if not self._fan_active and current_temp >= on_threshold:
+                outdoor = self._last_outdoor_temp
+                if outdoor is not None and outdoor >= current_temp:
+                    _LOGGER.info(
+                        "Nat-vent cycling: indoor %.1f°F ≥ on_threshold %.1f°F"
+                        " but outdoor %.1f°F ≥ indoor — skipping re-activation"
+                        " (outdoor-warm exit condition active)",
+                        current_temp,
+                        on_threshold,
+                        outdoor,
+                    )
+                    return
+                _LOGGER.info(
+                    "Nat-vent cycling [%s]: target=%.1f°F, off=%.1f°F, on=%.1f°F (fan_device=%s)"
+                    " — indoor %.1f°F ≥ on_threshold, outdoor=%.1f°F, cycling fan on",
+                    _context,
+                    nat_vent_target,
+                    off_threshold,
+                    on_threshold,
+                    _fan_device_label(self.config),
+                    current_temp,
+                    outdoor if outdoor is not None else 0.0,
+                )
+                # emit_event=False: this transition is reported via nat_vent_fan_on below.
+                await self._activate_fan(reason="nat_vent_cycling_on", emit_event=False)
+                if self._emit_event_callback:
+                    self._emit_event_callback(
+                        "nat_vent_fan_on",
+                        {
+                            "indoor_temp": current_temp,
+                            "on_threshold": on_threshold,
+                            "target": nat_vent_target,
+                            "fan_device": _fan_device_label(self.config),
+                        },
+                    )
 
     async def fan_thermostat_check(
         self,
@@ -2387,7 +2489,7 @@ class AutomationEngine:
             outdoor: Current outdoor temperature in °F (None = unavailable).
             trigger: Caller label for the DEBUG log ("indoor", "outdoor", "timer", etc.).
         """
-        ca_fan_active = self._fan_active or self._natural_vent_active
+        ca_fan_active = self._fan_running
         if not ca_fan_active:
             _LOGGER.debug(
                 "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=keep",
@@ -2785,57 +2887,63 @@ class AutomationEngine:
 
     async def _re_pause_for_open_sensor(self) -> None:
         """Re-pause HVAC because a sensor is still open when grace expired."""
-        if self._is_within_planned_window_period():
-            _LOGGER.info(
-                "Skipping re-pause — within planned window period (windows recommended)",
-            )
-            return
-        # Check nat-vent conditions before blindly re-pausing
-        outdoor = self._last_outdoor_temp
-        comfort_cool = float(self.config.get("comfort_cool", 75))
-        nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
-        indoor = self._get_indoor_temp_f()
-        comfort_heat = float(self.config.get("comfort_heat", 70))
-        if (
-            outdoor is not None
-            and indoor is not None
-            and outdoor < indoor  # outdoor must be cooler than indoor
-            and indoor > comfort_heat  # indoor must be above comfort floor
-            and outdoor < comfort_cool + nat_vent_delta
-        ):
-            nat_vent_threshold = comfort_cool + nat_vent_delta
-            nat_vent_reason = (
-                f"grace expired — nat-vent: outdoor {outdoor:.1f}°F < indoor {indoor:.1f}°F,"
-                f" outdoor {outdoor:.1f}°F ≤ {nat_vent_threshold:.1f}°F"
-            )
-            await self._activate_fan(reason=nat_vent_reason)
-            self._natural_vent_active = True
-            _LOGGER.info(
-                "Re-check after grace: nat-vent conditions met — outdoor %.1f°F < indoor %.1f°F,"
-                " outdoor ≤ %.1f°F, band stays armed",
-                outdoor,
-                indoor,
-                nat_vent_threshold,
-            )
-            if self._emit_event_callback:
-                self._emit_event_callback("sensor_opened", {"entity": "re-check", "result": "natural_ventilation"})
-            return
-        state = self.hass.states.get(self.climate_entity)
-        if state and state.state not in ("off", "unavailable", "unknown"):
-            self._pre_pause_mode = state.state
-            self._paused_by_door = True
-            await self._set_hvac_mode(
-                "off",
-                reason="grace expired — door/window still open, re-pausing",
-            )
-            await self._notify(
-                "Grace period expired but a door/window is still open. HVAC has been paused again.",
-                "Climate Advisor",
-                notification_type="grace_repause",
-            )
-        elif state and state.state == "off":
-            # HVAC already off, just set the pause flag
-            self._paused_by_door = True
+        async with self._decision_lock:
+            if self._is_within_planned_window_period():
+                _LOGGER.info(
+                    "Skipping re-pause — within planned window period (windows recommended)",
+                )
+                return
+            # Check nat-vent conditions before blindly re-pausing
+            outdoor = self._last_outdoor_temp
+            comfort_cool = float(self.config.get("comfort_cool", 75))
+            nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
+            indoor = self._get_indoor_temp_f()
+            comfort_heat = float(self.config.get("comfort_heat", 70))
+            # Issue #392 Fix 1: mirror the ODE ceiling guard's dormancy condition.
+            _ceiling_threshold_rp = self._ceiling_threshold(comfort_cool)
+            _ceiling_ok_rp = _ceiling_threshold_rp is None or indoor <= _ceiling_threshold_rp
+            if (
+                outdoor is not None
+                and indoor is not None
+                and outdoor < indoor  # outdoor must be cooler than indoor
+                and indoor > comfort_heat  # indoor must be above comfort floor
+                and outdoor < comfort_cool + nat_vent_delta
+                and _ceiling_ok_rp
+            ):
+                nat_vent_threshold = comfort_cool + nat_vent_delta
+                nat_vent_reason = (
+                    f"grace expired — nat-vent: outdoor {outdoor:.1f}°F < indoor {indoor:.1f}°F,"
+                    f" outdoor {outdoor:.1f}°F ≤ {nat_vent_threshold:.1f}°F"
+                )
+                await self._activate_fan(reason=nat_vent_reason)
+                self._natural_vent_active = True
+                await self._apply_nat_vent_hvac_state()
+                _LOGGER.info(
+                    "Re-check after grace: nat-vent conditions met — outdoor %.1f°F < indoor %.1f°F,"
+                    " outdoor ≤ %.1f°F, band stays armed",
+                    outdoor,
+                    indoor,
+                    nat_vent_threshold,
+                )
+                if self._emit_event_callback:
+                    self._emit_event_callback("sensor_opened", {"entity": "re-check", "result": "natural_ventilation"})
+                return
+            state = self.hass.states.get(self.climate_entity)
+            if state and state.state not in ("off", "unavailable", "unknown"):
+                self._pre_pause_mode = state.state
+                self._paused_by_door = True
+                await self._set_hvac_mode(
+                    "off",
+                    reason="grace expired — door/window still open, re-pausing",
+                )
+                await self._notify(
+                    "Grace period expired but a door/window is still open. HVAC has been paused again.",
+                    "Climate Advisor",
+                    notification_type="grace_repause",
+                )
+            elif state and state.state == "off":
+                # HVAC already off, just set the pause flag
+                self._paused_by_door = True
 
     async def _apply_current_scheduled_state(self, reason: str = "grace_expired") -> None:
         """After override clears, converge to the scheduled automation state.
@@ -3307,6 +3415,38 @@ class AutomationEngine:
             reason=f"morning wake-up — comfort band [{_wakeup_band.floor:.0f}/{_wakeup_band.ceiling:.0f}]",
         )
 
+    def _ceiling_threshold(self, comfort_cool: float | None) -> float | None:
+        """Ceiling above which the compressor should take over from fan-assisted cooling.
+
+        Returns None for whole-house-fan mode (FAN_MODE_WHOLE_HOUSE / FAN_MODE_BOTH): a WHF
+        is guaranteed to keep converging toward outdoor temperature as long as outdoor stays
+        below indoor, so there is no ceiling-based handoff point — only the outdoor/indoor
+        direction matters (Issue #392 Fix 1). HVAC fan mode coexists with the compressor (band
+        stays armed per Issue #249), so the ceiling is a valid handoff signal there.
+        """
+        fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
+        if fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
+            return None
+        if comfort_cool is None:
+            return None
+        aggressive = bool(self.config.get("aggressive_savings", False))
+        return comfort_cool + CEILING_ESCALATION_SAVINGS_MARGIN_F if aggressive else comfort_cool
+
+    def _whf_owns_hvac(self) -> bool:
+        """Whether a whole-house-fan session currently owns (suppresses) the thermostat.
+
+        True when fan_mode is WHOLE_HOUSE/BOTH AND a suppression session is active
+        (``_pre_fan_hvac_mode is not None`` — the same flag ``_activate_fan``/
+        ``_deactivate_fan`` use to track an active suppression, not ``_natural_vent_active``,
+        which also covers HVAC-fan-mode nat-vent where HVAC is NOT suppressed).
+
+        Issue #392 Fix 1b: this is the seed of a future ``FanSession.may_run_hvac()`` object
+        (see Issue #392 shaping analysis) — a single choke-point check standing in for the
+        deferred `FanSession` extraction, not a permanent standalone guard.
+        """
+        fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
+        return fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH) and self._pre_fan_hvac_mode is not None
+
     async def _apply_nat_vent_hvac_state(self) -> None:
         """Apply the correct HVAC state when nat-vent is active.
 
@@ -3405,6 +3545,12 @@ class AutomationEngine:
 
         if self._fan_override_active:
             _LOGGER.info("Fan override active — skipping fan activation")
+            return
+
+        # Issue #392 Fix 1c: idempotency guard — collapse redundant re-decisions from
+        # multiple gate sites into a single real state transition.
+        if self._fan_active:
+            _LOGGER.debug("_activate_fan: already active — no-op (%s)", reason)
             return
 
         if self.dry_run:
@@ -3529,7 +3675,7 @@ class AutomationEngine:
         outdoor = self._last_outdoor_temp
         await self.fan_thermostat_check(indoor=indoor, outdoor=outdoor, trigger="timer")
         # Re-arm only if the fan is still active after the check
-        if self._fan_active or self._natural_vent_active:
+        if self._fan_running:
             self._start_fan_thermo_backstop()
 
     def _cancel_fan_thermo_backstop(self) -> None:
@@ -3560,6 +3706,12 @@ class AutomationEngine:
             _LOGGER.info("Fan override active — skipping fan deactivation")
             return
 
+        # Issue #392 Fix 1c: idempotency guard — collapse redundant re-decisions from
+        # multiple gate sites into a single real state transition.
+        if not self._fan_active:
+            _LOGGER.debug("_deactivate_fan: already inactive — no-op (%s)", reason)
+            return
+
         if self.dry_run:
             _LOGGER.info("[DRY RUN] Would deactivate fan — %s", reason)
             return
@@ -3579,11 +3731,18 @@ class AutomationEngine:
                 # Skipped during nat-vent cycling (restore_hvac=False) so HVAC stays
                 # suppressed between fan-on and fan-off cycles within the same session.
                 if restore_hvac and self._pre_fan_hvac_mode is not None:
-                    await self._set_hvac_mode(
-                        self._pre_fan_hvac_mode,
-                        reason=f"whole-house fan stopped — restoring HVAC mode ({self._pre_fan_hvac_mode})",
-                    )
+                    _restore_mode = self._pre_fan_hvac_mode
+                    # Issue #392: clear _pre_fan_hvac_mode BEFORE issuing the restore write, not
+                    # after. _whf_owns_hvac() (the Fix 1b choke-point guard in _set_hvac_mode())
+                    # treats "_pre_fan_hvac_mode is not None" as "WHF still owns the thermostat" —
+                    # the restore write itself ends the suppression session, so ownership must be
+                    # released before the write, or the guard self-blocks the very call that is
+                    # supposed to un-suppress HVAC.
                     self._pre_fan_hvac_mode = None
+                    await self._set_hvac_mode(
+                        _restore_mode,
+                        reason=f"whole-house fan stopped — restoring HVAC mode ({_restore_mode})",
+                    )
 
             if fan_mode in (FAN_MODE_HVAC, FAN_MODE_BOTH):
                 await self.hass.services.async_call(

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,22 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.55"
+VERSION = "0.4.56"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.56": [
+        "Fix #392: Whole-house fan (WHF) and AC could fight each other — the ODE ceiling guard"
+        " applied the same 'switch to AC once indoor crosses the ceiling' rule to both fan types,"
+        " but a WHF is mutually exclusive with AC and physically guaranteed to keep cooling the"
+        " house as long as outdoor air is cooler than indoor, so the ceiling number never applied"
+        " to it. This caused a repeating off→cool→off→cool flip roughly every 5 minutes. The"
+        " ceiling check is now archetype-aware, and HVAC writes are structurally blocked while a"
+        " WHF session owns the thermostat (previously only enforced by convention). Fan"
+        " activation/deactivation are now idempotent, and automation decisions are serialized so"
+        " independently-triggered handlers can no longer race on shared state. Activity Log lines"
+        " for fan events now show which fan (hvac_fan/whf/both) actually fired instead of a"
+        " generic 'fan' label.",
+    ],
     "0.4.55": [
         "Fix #390: Whole-house fan status could show 'off (manual override)' for up to 30 minutes"
         " after the fan was actually confirmed running — the coordinator listener that detects the"
@@ -634,6 +647,54 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    392: {
+        "version_fixed": "0.4.56",
+        "title": "Whole-house fan (WHF) and AC could fight each other — repeating off→cool→off→cool oscillation",
+        "scope_covered": (
+            "automation.py: (1) _ceiling_threshold() is now archetype-aware — returns None for"
+            " FAN_MODE_WHOLE_HOUSE/BOTH (a WHF is mutually exclusive with AC and physically"
+            " guaranteed to converge while outdoor < indoor, so the ceiling number is irrelevant"
+            " to it) and the existing comfort_cool-based value for FAN_MODE_HVAC (fan and"
+            " compressor coexist, ceiling is a valid handoff signal there). Refactored into the"
+            " ODE ceiling guard's dormancy check and mirrored across all 4 nat-vent reactivation"
+            " gate sites (handle_door_window_open(), check_natural_vent_conditions() grace"
+            " re-entry, nat_vent_temperature_check() paused reactivation, _re_pause_for_open_sensor()"
+            " — the last of which was also missing its _apply_nat_vent_hvac_state() call, fixed"
+            " alongside). (2) _whf_owns_hvac() choke-point guard added inside _set_hvac_mode() and"
+            " _set_temperature() — the two functions every HVAC write ultimately reaches — blocks"
+            " non-off writes while a WHF session owns the thermostat, making mutual exclusion"
+            " structural rather than a per-caller convention (previously only _activate_fan()/"
+            "_deactivate_fan() themselves enforced it; apply_classification()'s normal 30-min"
+            " cycle could silently re-arm HVAC to cool while a WHF was running whenever"
+            " aggressive_savings was off, the default). apply_classification() now short-circuits"
+            " for WHF right after arming the nat-vent state. Emits hvac_write_blocked_whf_active"
+            " when a write is blocked, and _re_deactivate_fan() clears _pre_fan_hvac_mode before"
+            " (not after) its restore write, fixing a self-blocking ordering bug found during"
+            " testing. (3) _activate_fan()/_deactivate_fan() are now idempotent (no-op with a"
+            " debug log if already in the target state), so independently-triggered handlers"
+            " reaching the same conclusion no longer each re-execute the full activation sequence."
+            " (4) self._decision_lock (asyncio.Lock) serializes the six automation entry-point"
+            " methods (apply_classification, handle_door_window_open,"
+            " handle_all_doors_windows_closed, check_natural_vent_conditions,"
+            " _re_pause_for_open_sensor, nat_vent_temperature_check) so triggers firing close"
+            " together can no longer interleave on shared engine state; verified no cross-calls"
+            " exist between the six, so a direct lock wrap was used (no _impl extraction needed)."
+            " (5) _fan_running property replaces scattered _fan_active or _natural_vent_active"
+            " OR-checks. ai_skills_activity.py: fan-related Activity Log renderers"
+            " (fan_activated/deactivated, fan_manual_override, fan_cancel, nat_vent_fan_on/off)"
+            " now show the fan archetype (hvac_fan/whf/both) instead of a generic 'fan' label."
+        ),
+        "scope_not_covered": (
+            "No runtime/safety timeout backstop was added for a WHF session that never converges"
+            " (e.g. outdoor stays just barely below indoor for hours) — WHF is governed purely by"
+            " outdoor/indoor direction by design decision, not a gap. The underlying"
+            " _natural_vent_active/_fan_active/_pre_fan_hvac_mode state is still tracked as loose"
+            " engine attributes rather than a single owning object — Issue #393 tracks the deferred"
+            " extraction of a FanSession abstraction that would own this state and its invariants;"
+            " _whf_owns_hvac() is written as the seed of that future object but the full extraction"
+            " was intentionally not done in this fix to keep it reviewable."
+        ),
+    },
     390: {
         "version_fixed": "0.4.55",
         "title": "WHF status showed 'off (manual override)' for up to 30 min while fan was physically running",

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.55"
+  "version": "0.4.56"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -819,6 +819,32 @@ If any condition fails, the guard **evaluates** (and fires if the breach scan co
 
 **`aggressive_savings` widens the ceiling threshold.** In normal mode the ceiling threshold is `comfort_cool`. In `aggressive_savings` mode it is `comfort_cool + CEILING_ESCALATION_SAVINGS_MARGIN_F` (2.0°F) — savings homes tolerate a small overshoot before paying for the compressor, but are still rescued from a real comfort failure once indoor exceeds that wider threshold.
 
+#### `_ceiling_threshold()` is archetype-aware (Issue #392 Fix 1)
+
+The ceiling threshold used in the dormancy check (condition 3 above) is computed by `_ceiling_threshold(comfort_cool)` in `automation.py`, not inlined. The helper returns a different answer depending on the configured fan archetype:
+
+```python
+def _ceiling_threshold(self, comfort_cool: float | None) -> float | None:
+    fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
+    if fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
+        return None
+    if comfort_cool is None:
+        return None
+    aggressive = bool(self.config.get("aggressive_savings", False))
+    return comfort_cool + CEILING_ESCALATION_SAVINGS_MARGIN_F if aggressive else comfort_cool
+```
+
+| fan_mode | Return value | Why |
+|---|---|---|
+| `FAN_MODE_HVAC` | `comfort_cool` (or `comfort_cool + CEILING_ESCALATION_SAVINGS_MARGIN_F` if `aggressive_savings`) | The HVAC blower and the compressor **coexist** — the comfort band stays armed the whole time nat-vent is active (§6e / Issue #249), so handing off to AC once indoor crosses the ceiling is safe and correct. Nothing fights: the thermostat itself decides whether the compressor needs to run. |
+| `FAN_MODE_WHOLE_HOUSE` / `FAN_MODE_BOTH` | `None` | A whole-house fan (WHF) is **mutually exclusive** with the compressor by construction (`_activate_fan()` forces HVAC to `off` while a WHF session is active; see §9). A WHF is also physically guaranteed to keep converging toward outdoor temperature for as long as `outdoor < indoor` — the ceiling number says nothing about whether the WHF *will* succeed, only about how long it will take. So there is no ceiling-based handoff point for WHF: convergence is governed purely by outdoor/indoor direction, not by how far indoor has drifted above `comfort_cool`. |
+
+The ODE ceiling guard's dormancy check (condition 3, above) treats `ceiling_threshold_val is None` as "ceiling condition satisfied" — i.e. for WHF, dormancy collapses to `outdoor <= indoor AND _natural_vent_active` (no ceiling term at all). For `FAN_MODE_HVAC`, dormancy still requires `indoor <= ceiling_threshold` exactly as before Issue #392.
+
+**Why this had to change (Root Cause of Issue #392):** before this fix, the guard applied the same ceiling-based dormancy rule to both archetypes. For `FAN_MODE_WHOLE_HOUSE`, this meant that once indoor ticked one degree past `comfort_cool`, the guard would escalate to `cool` — which deactivates the WHF and forces HVAC to `cool` (per the mutual-exclusion contract) — even though outdoor was still comfortably below indoor and the WHF would have converged on its own. The very next reactivation check (any of the four gate sites in §17) would then see `outdoor < indoor` still holds and turn the WHF back on, which forces HVAC back to `off`, undoing the guard's `cool` command. That produced the `off→cool→off→cool` oscillation reported in #392 (repeating roughly every 5 minutes between 18:53 and 18:58). Making `_ceiling_threshold()` archetype-aware removes the false ceiling trigger for WHF entirely — see §17 for the matching change to the four reactivation gate sites, and "Structural WHF/AC Mutual Exclusion" below (§9, Issue #392 Fix 1b) for the structural guard that also closes a related but separate gap (mutual exclusion not being enforced everywhere HVAC mode is written).
+
+**Test coverage (Issue #392):** `tests/test_nat_vent_activation.py`, `tests/test_fan_control.py`, `tests/test_whole_house_fan_hvac_suppression.py` — exact function names pending as of this doc pass; see those files directly for current coverage of archetype-aware ceiling behavior.
+
 **On escalation the guard clears nat-vent** (Issue #218 part 2): if `_natural_vent_active` is true when the guard fires, it deactivates the fan, sets `_natural_vent_active = False`, and emits `nat_vent_ceiling_escalation` before switching to `cool` — so free cooling does not fight the compressor.
 
 #### Guard conditions
@@ -1183,6 +1209,44 @@ The whole-house fan is a dedicated appliance (e.g., `fan.*` or `switch.*` entity
 
 Each component (HVAC fan + whole-house fan) follows its own archetype contract above. `_pre_fan_hvac_mode` is still set, because the whole-house fan component requires HVAC suppression.
 
+### Structural WHF/AC Mutual Exclusion — `_whf_owns_hvac()` Choke-Point Guard (Issue #392 Fix 1b)
+
+**Can the whole-house fan and the compressor ever both be commanded on at the same time? No — this is now a structural guarantee, not a per-caller convention.**
+
+Before Issue #392, mutual exclusion was enforced only by convention inside `_activate_fan()`/`_deactivate_fan()` themselves (see the behavioral contract table above). Nothing stopped any of the ~13 other `_set_hvac_mode()` call sites, or the several `_apply_comfort_band()` call sites, from writing an active HVAC mode while a WHF session owned the thermostat. This was a real, confirmed gap: `apply_classification()`'s normal (non-`aggressive_savings`) fall-through called `_apply_comfort_band()` → `_set_temperature(..., mode="cool")` on every 30-minute cycle even while `_natural_vent_active` was `True` under `FAN_MODE_WHOLE_HOUSE` — re-arming the thermostat to `cool` every cycle while the WHF was physically running, fighting the fan CA itself had just turned on.
+
+**The fix: one guard at the single choke point every HVAC write already passes through**, rather than patching each caller individually (per this project's "trust internal invariants, single choke point" philosophy).
+
+```python
+def _whf_owns_hvac(self) -> bool:
+    fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
+    return fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH) and self._pre_fan_hvac_mode is not None
+```
+
+`_whf_owns_hvac()` is `True` only when both hold: the configured archetype includes a whole-house fan, **and** a suppression session is currently active (`_pre_fan_hvac_mode is not None` — the same flag `_activate_fan()`/`_deactivate_fan()` already use to track an active suppression). It deliberately does not use `_natural_vent_active`, because that flag is also `True` for `FAN_MODE_HVAC` nat-vent sessions, where HVAC is *not* suppressed and writes must be allowed through.
+
+Both HVAC-writing functions check this at their very top, before any service call:
+
+```python
+# inside _set_hvac_mode(mode, *, reason) and _set_temperature(temperature, *, reason, mode)
+if mode != "off" and self._whf_owns_hvac():
+    _LOGGER.warning("HVAC write blocked — whole-house fan owns thermostat (%s)", reason)
+    if self._emit_event_callback:
+        self._emit_event_callback("hvac_write_blocked_whf_active", {"attempted_mode": mode, "reason": reason})
+    return
+```
+
+Key properties:
+- **`mode == "off"` is never blocked** — the guard only intercepts attempts to arm an *active* mode (`heat`, `cool`, `heat_cool`) while WHF owns the thermostat. Turning HVAC off is always allowed (it's what a WHF session wants anyway).
+- **Silent drops are made visible.** A blocked write logs a `WARNING` and emits `hvac_write_blocked_whf_active` (payload: `attempted_mode`, `reason`) so the Activity Log shows the interception rather than the write simply vanishing — per this project's Observability Requirements.
+- **`apply_classification()` also short-circuits before reaching the guard.** For `FAN_MODE_WHOLE_HOUSE`/`FAN_MODE_BOTH`, the nat-vent branch (`if self._natural_vent_active:`) returns immediately after `_apply_nat_vent_hvac_state()` — the same early-return pattern already used for `aggressive_savings=True` — so the classification cycle does not even attempt (and log) a band-arm the choke-point guard would silently drop, and does not waste a cycle computing `select_comfort_band()` or running the ODE ceiling guard while WHF owns the thermostat. `FAN_MODE_HVAC` keeps falling through to the comfort-band write exactly as before, because fan and compressor coexist for that archetype (see §6c).
+
+**This closes Root Cause #2 of Issue #392 directly.** Because both writer functions share this one choke point, no future caller — however it decides to call `_set_hvac_mode()` or `_set_temperature()` — can bypass WHF/AC mutual exclusion. The answer to "can WHF and AC ever both be on" is now enforced at exactly one place, not re-derived correctly (or incorrectly) at every call site.
+
+**Follow-up direction (not yet implemented):** `_whf_owns_hvac()` is deliberately named and doc-commented in the code as the seed of a future `FanSession.may_run_hvac()` method. The Issue #392 shaping analysis found that `_natural_vent_active`, `_fan_active`, `_pre_fan_hvac_mode`, and `_fan_override_active` are one concept ("a fan/HVAC-suppression session with an owner and rules") fractured across four loose attributes with no single owner. A `FanSession` class that owns this state and exposes `activate()`/`deactivate()` (idempotent by construction) and `may_run_hvac(mode) -> bool` is tracked as a **separate, deferred follow-up issue** — it is not implemented as part of Issue #392. `_whf_owns_hvac()` and the idempotency guards in §9f below are the small, safe cuts taken now that are consistent with that future direction, without taking on the risk of a full extraction in a bugfix PR.
+
+**Test coverage:** `tests/test_whole_house_fan_hvac_suppression.py`, `tests/test_fan_control.py` — exact function names pending as of this doc pass; both files carry the current coverage for this guard.
+
 ### 9a. Fan State Tracking
 
 The coordinator maintains six internal fields to manage fan state across activate/deactivate calls and detect user overrides:
@@ -1512,6 +1576,72 @@ The fan clean-slate introduced in (A) is consistent with §11: `_fan_override_ac
 | `_pre_fan_hvac_mode` | Yes | Still preserved — needed if coalesce decides to turn off a whole-house fan and restore the HVAC mode |
 | `_natural_vent_active` | No | Cleared on restart (was already the case); coalesce adopt-on re-sets it |
 
+### 9f. Idempotency Guards and the `_fan_running` Property (Issue #392 Fix 1c / Fix 1e)
+
+**Occupant-facing symptom this fixes:** during the 18:53–19:04 burst reported in Issue #392, the Activity Log showed what looked like several different automation decisions "fighting" every few minutes — the user could not tell whether the system was actually deliberating or just re-logging the same decision repeatedly.
+
+**Root cause:** `_activate_fan()` and `_deactivate_fan()` had no check for "is the fan already in the state I'm about to put it in." Four independent (re)activation gate sites (§17) can each independently conclude "conditions are met" within the same few seconds — a grace-expiry timer callback, a sensor-open debounce callback, the 30-minute classification cycle, and the ODE ceiling guard all evaluate their own trigger conditions with no coordination. Before this fix, every one of them that reached the same conclusion re-ran the *entire* activation/deactivation sequence: re-capturing `_pre_fan_hvac_mode` from whatever the thermostat showed at that instant (possibly already stale from a sibling handler's change moments earlier), reissuing the physical service call, and emitting a fresh `fan_activated`/`fan_deactivated` event — even when the fan was already in the target state from a decision made two seconds prior.
+
+**Fix — idempotency guard at the top of both functions**, after the existing `FAN_MODE_DISABLED` and `_fan_override_active` checks, before any state mutation:
+
+```python
+# in _activate_fan()
+if self._fan_active:
+    _LOGGER.debug("_activate_fan: already active — no-op (%s)", reason)
+    return
+```
+```python
+# in _deactivate_fan()
+if not self._fan_active:
+    _LOGGER.debug("_deactivate_fan: already inactive — no-op (%s)", reason)
+    return
+```
+
+Effect: the first caller to legitimately flip the fan state performs the work and logs the event (INFO/WARNING + Activity Log entry). Every other handler that reaches the same conclusion moments later finds nothing left to do and produces only a `DEBUG`-level line — traceable in the logs, but not a duplicate Activity Log row. Combined with the archetype-aware ceiling fix (§6c) and the choke-point guard (above), which make the *decision itself* stable, this makes the *execution* stable too: one real state transition per actual change, not one log line per handler that happened to fire in the same window.
+
+**`_fan_running` property (Fix 1e — shaping cut):** a related but separate smell was the recurring pattern `self._fan_active or self._natural_vent_active` appearing inline at multiple call sites (e.g. `nat_vent_temperature_check()`) to answer "is CA's fan on right now" — needing to OR two fields together to answer one question is evidence the two flags are one concept fractured into two names. Collapsed into a derived property:
+
+```python
+@property
+def _fan_running(self) -> bool:
+    return self._fan_active or self._natural_vent_active
+```
+
+Purely a readability/correctness-by-construction cut (no behavior change) — every inline `_fan_active or _natural_vent_active` OR was replaced with this property. Like `_whf_owns_hvac()`, it is a small stepping stone toward the deferred `FanSession` extraction (see the follow-up note in the Structural WHF/AC Mutual Exclusion subsection above), not the extraction itself.
+
+**Test coverage:** `tests/test_fan_control.py` — exact function names pending as of this doc pass.
+
+### 9g. `_decision_lock` — Serializing the Six Automation Entry Points (Issue #392 Fix 3)
+
+The `__init__` code comment for `self._decision_lock` in `automation.py` points readers here (§9g) for the deadlock-avoidance analysis below.
+
+**Occupant-facing symptom this fixes:** the same 18:53–19:04 burst also showed decisions from genuinely different trigger sources interleaving within the same few seconds. Fixes in §6c, above (choke-point guard), and §9f (idempotency) make each *individual* decision correct and stop *redundant* re-execution — but neither one, by itself, prevents two independently-triggered handlers from reading and writing shared engine state (`_natural_vent_active`, `_fan_active`, `_pre_fan_hvac_mode`, `_paused_by_door`) while the other is mid-flight. Python's `asyncio` is single-threaded but not atomic across `await` points, so handler B can start acting on state handler A is in the middle of changing.
+
+**The six automation decision-pass entry points**, each independently triggerable by a different event source (HA state-change listener, `async_call_later` timer callback, or the coordinator's periodic `_async_update_data()`):
+
+| # | Method | Trigger source |
+|---|---|---|
+| 1 | `apply_classification()` | Coordinator's 30-minute classification cycle |
+| 2 | `handle_door_window_open()` | Coordinator callback after sensor-open debounce |
+| 3 | `handle_all_doors_windows_closed()` | Coordinator callback after all sensors close |
+| 4 | `check_natural_vent_conditions()` | Called by the coordinator on every `_async_update_data()` |
+| 5 | `_re_pause_for_open_sensor()` | Triggered via `hass.async_create_task(...)` from the grace-expiry callback |
+| 6 | `nat_vent_temperature_check()` | Periodic re-evaluation while nat-vent is active or paused |
+
+**Fix:** `self._decision_lock = asyncio.Lock()` is created once in `__init__`. Each of the six methods above wraps its entire body in `async with self._decision_lock:` — a second trigger firing while a decision pass is already in progress waits for the lock instead of interleaving and racing on shared state:
+
+```python
+async def apply_classification(self, classification, predicted_indoor=None, indoor_temp=None) -> None:
+    async with self._decision_lock:
+        ...  # entire method body
+```
+
+**Deadlock-avoidance pre-check (required before wrapping):** `asyncio.Lock` is not reentrant — if any of the six methods called another of the six directly within the same call stack, wrapping both with the same lock would deadlock. Before implementing, the code was searched for direct cross-calls among the six; **none were found** — no method in this list calls another method in this list synchronously in its own body. Because of that, a plain `async with self._decision_lock:` wrap around each method's existing body was sufficient; no `_impl` extraction (splitting each method into a locked wrapper plus an unlocked `_impl` twin for internal cross-calls) was needed for this PR. If a future change introduces a direct call between any two of these six methods, that pre-check must be repeated and the `_impl` pattern applied before merging.
+
+**What this does NOT change:** this lock does not introduce new automation behavior. The semantic fixes (§6c archetype-aware ceiling, above choke-point guard, §9f idempotency) already make each individual decision correct and idempotent; the lock ensures those correct decisions are evaluated one at a time against a consistent snapshot of engine state, instead of several handlers reading/writing overlapping state concurrently. In a well-behaved system where the semantic fixes hold, the lock should rarely be contended — its purpose is to make the *absence* of interleaving-driven chaos structurally guaranteed rather than incidentally true.
+
+**Test coverage:** concurrency test using `asyncio.gather()` to invoke two of the six entry points "concurrently" against a shared engine instance instrumented to record enter/exit order, asserting non-overlapping execution. Located in `tests/test_nat_vent_activation.py` as of this doc pass (exact function name pending — Craftsman work in `tests/` is running in parallel with this docs pass).
+
 ---
 
 ## 10. Door/Window HVAC Pause
@@ -1831,6 +1961,23 @@ When nat vent has exited due to an outdoor-warm event (Priority 2 above), re-act
 
 If all three conditions are met, nat vent re-activates: HVAC remains off, fan turns on, `_natural_vent_active` is set back to `True`.
 
+#### Archetype-aware reactivation gate (Issue #392 Fix 1) — cross-reference §6c and §9
+
+The re-activation condition table above is the primary, direction/floor/ceiling-delta gate. As of Issue #392, all four call sites that (re)activate nat-vent additionally require the **archetype-aware ceiling condition** from §6c — `self._ceiling_threshold(comfort_cool) is None OR indoor <= ceiling_threshold` — before proceeding, mirroring the ODE ceiling guard's own dormancy check so the guard and the reactivation gates can no longer disagree with each other. For `FAN_MODE_HVAC`, this blocks reactivation once indoor is already past the ceiling (same behavior as before Issue #392). For `FAN_MODE_WHOLE_HOUSE`/`FAN_MODE_BOTH`, `_ceiling_threshold()` returns `None`, so this condition is always satisfied and reactivation is governed purely by the direction/floor/ceiling-delta gate above — a WHF keeps running (or resumes) whenever outdoor is still cooler than indoor, regardless of how far indoor has drifted above `comfort_cool`. See §9 (Structural WHF/AC Mutual Exclusion) for why this is safe: mutual exclusion with the compressor is enforced structurally, not by this gate.
+
+The four call sites, all in `automation.py`:
+
+| # | Function | Role |
+|---|---|---|
+| 1 | `handle_door_window_open()` | Sensor-open debounce callback — initial nat-vent activation |
+| 2 | `check_natural_vent_conditions()` | Grace re-entry branch — reactivation after a grace period |
+| 3 | `nat_vent_temperature_check()` | Paused-state reactivation (variable named `_comfort_ceiling_ok` here, distinct from an existing `_ceiling_ok` in the same function that means outdoor-vs-nat-vent-delta ceiling, not the comfort-cool ceiling) |
+| 4 | `_re_pause_for_open_sensor()` | Re-pause-time reactivation check after grace expires with a sensor still open. Also now calls `_apply_nat_vent_hvac_state()` after `_activate_fan()`, matching the other three sites — this was previously the one site that skipped that call, which was an inconsistency independent of the ceiling logic, fixed alongside it. |
+
+All four are wrapped in `self._decision_lock` (§9g) as part of Issue #392 Fix 3, so a reactivation decision from any one of them cannot interleave with a decision from `apply_classification()` or another of the six locked entry points.
+
+**`apply_classification()` short-circuits for WHF (Issue #392 Fix 1b)** — see §9 (Structural WHF/AC Mutual Exclusion) for the full mechanism. In summary: when `_natural_vent_active` is `True` and `aggressive_savings` is `False` (the default), `apply_classification()` used to fall through to `_apply_comfort_band()` regardless of fan archetype, re-arming `cool` on the thermostat every 30-minute cycle even while a WHF session was actively suppressing HVAC. It now returns immediately after `_apply_nat_vent_hvac_state()` when `fan_mode` is `FAN_MODE_WHOLE_HOUSE`/`FAN_MODE_BOTH`, so the classification cycle never attempts a comfort-band write that the choke-point guard would otherwise silently block. `FAN_MODE_HVAC` keeps falling through unchanged, since fan and compressor coexist for that archetype.
+
 ### `natural_vent_delta` Semantics
 
 `natural_vent_delta` is a ceiling tolerance: the number of degrees above `comfort_cool` that outdoor air is still considered acceptable for natural ventilation. The effective outdoor temperature ceiling is `comfort_cool + natural_vent_delta`.
@@ -1947,10 +2094,10 @@ This is the definitive reference for expected system behavior across all classif
 | | E1: Sensor Open | E2: All Closed | E3: Grace+Open | E4: Override | E5: Fan Change | E6: Class Change | E7: Resume | E8: Restart Reconcile |
 |---|---|---|---|---|---|---|---|---|
 | C1 (hot/cool) | Pause HVAC→off, notify | Resume to cool, auto grace | Re-pause, notify | Clear pause, manual grace | Fan override grace; thermostatic loop exits fan if `outdoor ≥ indoor` (§9e) | Re-apply classification | Resume cool, manual grace | Fan adopt-on (nat-vent eligible) or turn-off (not eligible); `Fan reconcile:` logged |
-| **C2 (warm/band/win=T/in)** | **No pause** (planned window) | No-op (not paused) | **No re-pause** (planned) | N/A (not paused) | Fan on, band stays armed; thermostatic loop monitors `outdoor vs indoor` | Re-apply band `[comfort_heat, comfort_cool]`; §6b backstop fires if indoor < comfort_heat | N/A (not paused) | Fan adopt-on (nat-vent eligible, sensors open) or turn-off; band re-armed by coalesce |
-| C3 (warm/band/win=T/out) | No pause (band armed, not paused) | No-op | N/A | N/A | Fan on, band stays armed; thermostatic loop monitors `outdoor vs indoor` | Re-apply band; §6b backstop fires if indoor < comfort_heat | N/A | Fan turn-off (outside window period → not nat-vent eligible) or no-fan |
+| **C2 (warm/band/win=T/in)** | **No pause** (planned window); reactivation gated by archetype-aware ceiling (§6c/§17 — WHF: direction-only; HVAC-fan: blocked once indoor > ceiling) | No-op (not paused) | **No re-pause** (planned); same archetype-aware ceiling gate applies | N/A (not paused) | Fan on, band stays armed for `FAN_MODE_HVAC`; for WHF, `apply_classification()` short-circuits before the band write (Issue #392 Fix 1b, §9) | Re-apply band `[comfort_heat, comfort_cool]` (`FAN_MODE_HVAC` only — WHF short-circuits per §9); §6b backstop fires if indoor < comfort_heat | N/A (not paused) | Fan adopt-on (nat-vent eligible) or turn-off; band re-armed by coalesce |
+| C3 (warm/band/win=T/out) | No pause (band armed, not paused); same archetype-aware ceiling gate | No-op | N/A | N/A | Fan on, band stays armed for `FAN_MODE_HVAC`; WHF short-circuits per §9 | Re-apply band (`FAN_MODE_HVAC` only); §6b backstop fires if indoor < comfort_heat | N/A | Fan turn-off (outside window period → not nat-vent eligible) or no-fan |
 | C4 (warm/band/win=F) | No pause (band armed, not paused) | No-op | N/A | N/A | Band stays armed | Re-apply band; §6b backstop fires if indoor < comfort_heat | N/A | Fan turn-off if physically running (no sensors open → not nat-vent eligible) |
-| **C5 (mild/band/win=T/in)** | **No pause** (planned window) | No-op | **No re-pause** (planned) | N/A | Fan on, band stays armed; thermostatic loop monitors `outdoor vs indoor` | Re-apply band `[comfort_heat, comfort_cool]` | N/A | Fan adopt-on (nat-vent eligible, sensors open) or turn-off; band re-armed |
+| **C5 (mild/band/win=T/in)** | **No pause** (planned window); same archetype-aware ceiling gate | No-op | **No re-pause** (planned); same gate | N/A | Fan on, band stays armed for `FAN_MODE_HVAC`; WHF short-circuits per §9 | Re-apply band `[comfort_heat, comfort_cool]` (`FAN_MODE_HVAC` only) | N/A | Fan adopt-on (nat-vent eligible) or turn-off; band re-armed |
 | C6 (cool/heat) | Pause HVAC→off, notify | Resume to heat, auto grace | Re-pause, notify | Clear pause, manual grace | Fan override grace; thermostatic loop exits fan if `outdoor ≥ indoor` | Re-apply | Resume heat, manual grace | Fan turn-off (heat day → not nat-vent eligible) or no-fan |
 | C7 (cold/heat) | Pause HVAC→off, notify | Resume to heat, auto grace | Re-pause, notify | Clear pause, manual grace | Fan override grace; thermostatic loop exits fan if `outdoor ≥ indoor` | Re-apply | Resume heat, manual grace | Fan turn-off (cold day → not nat-vent eligible) or no-fan |
 
@@ -1963,6 +2110,8 @@ This is the definitive reference for expected system behavior across all classif
 **Thermostatic fan loop (Issue #327, §9e):** In all C1–C7 contexts, once the fan is CA-owned and running, `fan_thermostat_check()` re-evaluates on every indoor or outdoor temperature change. The fan is turned off immediately when `outdoor ≥ indoor` — it does not wait for the next 30-minute coordinator poll. See §9e for the full exit hierarchy and trigger-source table.
 
 **Restart reconciliation (E8, Issue #327, §9e):** `_fan_override_active` is always cleared on restart; `_do_startup_coalesce` decides adopt-on, turn-off, or no-fan based on live thermostat state. E8 applies uniformly to all contexts — the decision depends on current physical conditions, not the day classification.
+
+**Archetype-aware nat-vent ceiling and structural WHF/AC exclusion (Issue #392):** In C2/C3/C5, E1/E3 (reactivation) now consistently apply the archetype-aware ceiling threshold from §6c/§17 across all four reactivation gate sites (`handle_door_window_open()`, `check_natural_vent_conditions()`, `nat_vent_temperature_check()`, `_re_pause_for_open_sensor()`) — `FAN_MODE_HVAC` blocks reactivation once indoor exceeds `comfort_cool` (unchanged from before #392); `FAN_MODE_WHOLE_HOUSE`/`FAN_MODE_BOTH` reactivates purely on outdoor/indoor direction. In E5/E6, `apply_classification()` now short-circuits before the comfort-band write when a WHF session owns the thermostat (§9), and the `_whf_owns_hvac()` choke-point guard in `_set_hvac_mode()`/`_set_temperature()` (§9) makes WHF/AC mutual exclusion structural for every cell in this table, not just the ones exercised by nat-vent. All six automation entry points relevant to this table (`apply_classification`, `handle_door_window_open`, `handle_all_doors_windows_closed`, `check_natural_vent_conditions`, `_re_pause_for_open_sensor`, `nat_vent_temperature_check`) are additionally serialized by `self._decision_lock` (§9g) so that concurrent E1/E3/E5/E6 triggers cannot interleave on shared engine state.
 
 This logic table MUST be kept current for any changes to automation behavior.
 
@@ -1985,6 +2134,12 @@ This logic table MUST be kept current for any changes to automation behavior.
 | All×E8 (coalesce: adopt-on) | _(test-ref pending)_ | coalesce adopts running fan as CA nat-vent when conditions hold; `_natural_vent_active=True` |
 | C1×E5 / C6×E5 / C7×E5 (thermostatic exit: `outdoor ≥ indoor`) | _(test-ref pending)_ | `fan_thermostat_check` turns fan off on `outdoor ≥ indoor` before next 30-min poll |
 | D×E5 (economizer: `outdoor ≥ indoor` blocked) | _(test-ref pending)_ | economizer `check_window_cooling_opportunity` rejects activation when `outdoor ≥ indoor` |
+| C2/C3/C5×E1/E3 (archetype-aware ceiling, `FAN_MODE_HVAC` blocks reactivation past ceiling) | test_nat_vent_activation.py, test_fan_control.py | Issue #392 Fix 1 — function names pending as of this doc pass; see files directly |
+| C2/C3/C5×E1/E3 (archetype-aware ceiling, `FAN_MODE_WHOLE_HOUSE` reactivates direction-only past ceiling, incl. #392 repro sequence) | test_nat_vent_activation.py, test_whole_house_fan_hvac_suppression.py | Issue #392 Fix 1 — function names pending as of this doc pass; see files directly |
+| C2/C3/C5×E5/E6 (`_whf_owns_hvac()` choke-point guard blocks active-mode writes; `apply_classification()` WHF short-circuit) | test_whole_house_fan_hvac_suppression.py, test_fan_control.py | Issue #392 Fix 1b — function names pending as of this doc pass |
+| All×E1/E2/E3/E5/E6 (idempotent `_activate_fan()`/`_deactivate_fan()`; no duplicate `fan_activated`/`fan_deactivated` on redundant calls) | test_fan_control.py | Issue #392 Fix 1c — function names pending as of this doc pass |
+| All×E1/E2/E3/E5/E6 (`_decision_lock` serializes the six entry points; no interleaved execution under `asyncio.gather()`) | test_nat_vent_activation.py | Issue #392 Fix 3 — function names pending as of this doc pass |
+| Fan archetype activity-log labels (`fan_activated`/`fan_deactivated`/`fan_manual_override`/`fan_cancel` render `fan_device`) | test_activity_renderers.py | Issue #392 Fix 2 — function names pending as of this doc pass |
 
 ---
 

--- a/tests/test_activity_renderers.py
+++ b/tests/test_activity_renderers.py
@@ -500,13 +500,45 @@ class TestFanEventRenderers:
     """Issue #331 follow-up: fan_activated / fan_deactivated / fan_running_untracked / cleared."""
 
     def test_fan_activated_shows_trigger(self):
+        """Issue #392 Fix 2: settings cell uses the archetype-specific fan_device label."""
         ev, st = _act_mod.EVENT_RENDERERS["fan_activated"](
-            {"reason": "min_runtime_cycle", "fan_mode": "hvac_fan"}, "fahrenheit"
+            {"reason": "min_runtime_cycle", "fan_device": "hvac_fan"}, "fahrenheit"
         )
+        assert "Fan activated" in ev and "min_runtime_cycle" in ev
+        assert st == "hvac_fan: off->on"
+
+    def test_fan_activated_shows_trigger_whf(self):
+        """Issue #392 Fix 2: whole-house-fan archetype renders 'whf', not the generic 'fan'."""
+        ev, st = _act_mod.EVENT_RENDERERS["fan_activated"](
+            {"reason": "natural ventilation", "fan_device": "whf"}, "fahrenheit"
+        )
+        assert "Fan activated" in ev and "natural ventilation" in ev
+        assert st == "whf: off->on"
+
+    def test_fan_activated_no_fan_device_falls_back(self):
+        """No fan_device in payload (legacy/pre-#392 event) -> generic 'fan' label, no crash."""
+        ev, st = _act_mod.EVENT_RENDERERS["fan_activated"]({"reason": "min_runtime_cycle"}, "fahrenheit")
         assert "Fan activated" in ev and "min_runtime_cycle" in ev
         assert st == "fan: off->on"
 
     def test_fan_deactivated_shows_trigger(self):
+        """Issue #392 Fix 2: settings cell uses the archetype-specific fan_device label."""
+        ev, st = _act_mod.EVENT_RENDERERS["fan_deactivated"](
+            {"reason": "economizer off -- fan no longer needed", "fan_device": "hvac_fan"}, "fahrenheit"
+        )
+        assert "Fan deactivated" in ev and "economizer off" in ev
+        assert st == "hvac_fan: on->off"
+
+    def test_fan_deactivated_shows_trigger_whf(self):
+        """Issue #392 Fix 2: whole-house-fan archetype renders 'whf', not the generic 'fan'."""
+        ev, st = _act_mod.EVENT_RENDERERS["fan_deactivated"](
+            {"reason": "door/window closed", "fan_device": "whf"}, "fahrenheit"
+        )
+        assert "Fan deactivated" in ev and "door/window closed" in ev
+        assert st == "whf: on->off"
+
+    def test_fan_deactivated_no_fan_device_falls_back(self):
+        """No fan_device in payload (legacy/pre-#392 event) -> generic 'fan' label, no crash."""
         ev, st = _act_mod.EVENT_RENDERERS["fan_deactivated"](
             {"reason": "economizer off -- fan no longer needed"}, "fahrenheit"
         )

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -228,6 +228,9 @@ class TestDeactivateFan:
                 CONF_FAN_ENTITY: "fan.attic",
             }
         )
+        # Fix 1c idempotency guard: _deactivate_fan() is now a no-op unless
+        # _fan_active is already True (mirrors _activate_fan()'s equivalent guard).
+        engine._fan_active = True
 
         asyncio.run(engine._deactivate_fan(reason="test"))
 
@@ -241,6 +244,8 @@ class TestDeactivateFan:
     def test_deactivate_hvac_fan(self):
         """fan_mode=hvac_fan → calls climate.set_fan_mode with 'auto'."""
         engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_HVAC})
+        # Fix 1c idempotency guard requires _fan_active=True before deactivate is real.
+        engine._fan_active = True
 
         asyncio.run(engine._deactivate_fan(reason="test"))
 
@@ -257,6 +262,8 @@ class TestDeactivateFan:
                 CONF_FAN_ENTITY: "fan.attic",
             }
         )
+        # Fix 1c idempotency guard requires _fan_active=True before deactivate is real.
+        engine._fan_active = True
 
         asyncio.run(engine._deactivate_fan(reason="test"))
 
@@ -308,6 +315,8 @@ class TestSwitchDomainFan:
                 CONF_FAN_ENTITY: "switch.attic_fan",
             }
         )
+        # Fix 1c idempotency guard requires _fan_active=True before deactivate is real.
+        engine._fan_active = True
 
         asyncio.run(engine._deactivate_fan(reason="test"))
 
@@ -421,6 +430,9 @@ class TestFanEconomizerIntegration:
         engine._current_classification = _make_hot_classification()
         engine._economizer_active = True
         engine._economizer_phase = "maintain"
+        # Fix 1c idempotency guard: fan must already be active for deactivate to be real
+        # (mirrors production — the economizer only ever stops a fan it previously started).
+        engine._fan_active = True
 
         # Trigger deactivation: outdoor too warm
         asyncio.run(
@@ -1507,25 +1519,50 @@ class TestCheckNatVentGraceComfortCeiling:
     _paused_by_door and _natural_vent_active were False — even if indoor was overheating.
     """
 
-    def test_grace_active_indoor_above_comfort_cool_allows_nat_vent(self):
-        """grace=True, indoor=76 > comfort_cool=75, outdoor cool → nat-vent activates.
+    def test_grace_active_indoor_above_comfort_cool_blocks_nat_vent_for_hvac_fan(self):
+        """grace=True, indoor=76 > comfort_cool=75, FAN_MODE_HVAC → nat-vent does NOT activate.
 
-        #249: nat-vent activation no longer calls set_hvac_mode("off") — the comfort
-        band stays armed; only the fan turns on. The "HVAC off first" step is removed.
+        Issue #392 Fix 1: for FAN_MODE_HVAC, the ceiling threshold (comfort_cool, since
+        aggressive_savings is off here) is still a valid handoff point to AC — fan and
+        compressor coexist safely for this archetype (band stays armed, Issue #249).
+        Once indoor exceeds the ceiling, reactivation must be BLOCKED so the compressor
+        (not the fan) handles the excess heat, matching the ODE ceiling guard's own
+        dormancy condition (`indoor <= ceiling_threshold`). This is the mirror image of
+        the FAN_MODE_WHOLE_HOUSE case (test_grace_active_whole_house_fan_ignores_ceiling
+        below), where the ceiling does not apply because WHF is direction-only.
+
+        Before Issue #392's archetype-aware ceiling fix, this test asserted the opposite
+        (nat-vent activates) — that was correct only for the (untested-for-archetype)
+        general case, but wrong once FAN_MODE_HVAC's ceiling-escalation contract is
+        applied to the four reactivation gates, not just the ODE guard.
         """
         engine = _make_grace_nat_vent_engine(indoor_temp=76.0, grace_active=True)
         with patch(_PATCH_CALL_LATER):
             asyncio.run(engine.check_natural_vent_conditions())
 
-        assert engine._natural_vent_active is True, (
-            "check_natural_vent_conditions() should fall through grace when indoor > comfort_cool"
+        assert engine._natural_vent_active is False, (
+            "FAN_MODE_HVAC: indoor (76) > ceiling_threshold (comfort_cool=75) must block "
+            "nat-vent reactivation — compressor should take over, not the fan"
         )
-        # #249: no set_hvac_mode("off") call — band stays armed, compressor self-arbitrates
-        hvac_calls = _get_service_calls(engine, "climate", "set_hvac_mode")
-        assert not any(c[0][2]["hvac_mode"] == "off" for c in hvac_calls)
-        # Fan must end up on (set_fan_mode=on from _activate_fan)
-        fan_calls = _get_service_calls(engine, "climate", "set_fan_mode")
-        assert fan_calls[-1][0][2]["fan_mode"] == "on"
+
+    def test_grace_active_whole_house_fan_ignores_ceiling(self):
+        """grace=True, indoor=76 > comfort_cool=75, FAN_MODE_WHOLE_HOUSE, outdoor cool → activates.
+
+        Issue #392 Fix 1: WHF's ceiling_threshold is always None (mutually exclusive with
+        AC, direction-only convergence) — the comfort ceiling never blocks WHF reactivation,
+        only the outdoor/indoor direction primary gate does. Outdoor (65) < indoor (76), so
+        nat-vent must activate despite indoor being well past the comfort ceiling.
+        """
+        engine = _make_grace_nat_vent_engine(indoor_temp=76.0, grace_active=True)
+        engine.config[CONF_FAN_MODE] = FAN_MODE_WHOLE_HOUSE
+
+        with patch(_PATCH_CALL_LATER):
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True, (
+            "FAN_MODE_WHOLE_HOUSE: ceiling_threshold is None, so indoor > comfort_cool must "
+            "NOT block reactivation as long as outdoor < indoor"
+        )
 
     def test_grace_active_outdoor_too_warm_no_nat_vent(self):
         """grace=True, indoor=76 > comfort_cool, but outdoor=74 is above threshold (75+3=78) — activates."""
@@ -1715,14 +1752,27 @@ class TestFanEventEmission:
         calls = {c.args[0]: c.args[1] for c in engine._emit_event_callback.call_args_list}
         assert "fan_activated" in calls
         assert calls["fan_activated"]["reason"] == "min_runtime_cycle"
+        # Issue #392 Fix 2: payload carries fan_device so the renderer can label the
+        # archetype (hvac_fan/whf/both) instead of a generic "fan" string.
+        assert calls["fan_activated"]["fan_device"] == "hvac_fan"
+
+    def test_activate_emits_fan_activated_with_whf_device_label(self):
+        """FAN_MODE_WHOLE_HOUSE -> fan_activated payload carries fan_device='whf'."""
+        engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE, CONF_FAN_ENTITY: "fan.attic"})
+        engine._emit_event_callback = MagicMock()
+        asyncio.run(engine._activate_fan(reason="natural ventilation"))
+        calls = {c.args[0]: c.args[1] for c in engine._emit_event_callback.call_args_list}
+        assert calls["fan_activated"]["fan_device"] == "whf"
 
     def test_deactivate_emits_fan_deactivated(self):
         engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_HVAC})
         engine._fan_active = True
         engine._emit_event_callback = MagicMock()
         asyncio.run(engine._deactivate_fan(reason="economizer off -- fan no longer needed"))
-        types = [c.args[0] for c in engine._emit_event_callback.call_args_list]
-        assert "fan_deactivated" in types
+        calls = {c.args[0]: c.args[1] for c in engine._emit_event_callback.call_args_list}
+        assert "fan_deactivated" in calls
+        # Issue #392 Fix 2: payload carries fan_device so the renderer can label the archetype.
+        assert calls["fan_deactivated"]["fan_device"] == "hvac_fan"
 
     def test_emit_event_false_suppresses_event(self):
         """nat-vent cycler passes emit_event=False so it does not double with nat_vent_fan_on."""

--- a/tests/test_nat_vent_activation.py
+++ b/tests/test_nat_vent_activation.py
@@ -22,6 +22,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from custom_components.climate_advisor.automation import AutomationEngine
 from custom_components.climate_advisor.classifier import DayClassification
 from custom_components.climate_advisor.const import (
+    CONF_FAN_ENTITY,
+    CONF_FAN_MODE,
+    FAN_MODE_WHOLE_HOUSE,
     MIN_VIABLE_NAT_VENT_HOURS,
     NAT_VENT_REACTIVATION_LOCKOUT_S,
 )
@@ -224,8 +227,15 @@ class TestNatVentActivation:
     """Row 3: all three conditions met → nat_vent activates."""
 
     def test_evening_cool_outdoor_activates_nat_vent(self):
-        """outdoor 70F < indoor 76F, indoor 76F > comfort_heat 70F, outdoor 70F < threshold 75F → nat_vent."""
-        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=76.0)
+        """outdoor 70F < indoor 76F, indoor 76F > comfort_heat 70F, outdoor 70F < threshold 79F → nat_vent.
+
+        Issue #392 Fix 1: reactivation gates now also require indoor <= ceiling_threshold
+        (comfort_cool, since fan_mode defaults to disabled/HVAC-fan archetype here — same
+        ceiling rule as FAN_MODE_HVAC). comfort_cool raised to 76 (== indoor) so this test
+        continues to exercise pure Row-3 directional activation without tripping the new
+        ceiling gate, which is covered separately by TestNatVentActivation ceiling tests.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
         engine._last_outdoor_temp = 70.0
 
         events: list[tuple] = []
@@ -239,18 +249,26 @@ class TestNatVentActivation:
         assert len(nat_events) == 1
 
     def test_outdoor_just_below_indoor_activates(self):
-        """outdoor 73.9F < indoor 74.0F — just below indoor — satisfies directional guard."""
-        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=74.0)
-        engine._last_outdoor_temp = 73.9  # just cooler than indoor, still under threshold 75
+        """outdoor 73.9F < indoor 74.0F — just below indoor — satisfies directional guard.
+
+        comfort_cool raised to 74 (== indoor) so the Issue #392 ceiling gate (default/
+        HVAC-fan archetype) does not block this pure directional-guard test.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0, indoor_f=74.0)
+        engine._last_outdoor_temp = 73.9  # just cooler than indoor, still under threshold 77
 
         asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
 
         assert engine._natural_vent_active is True
 
     def test_outdoor_near_threshold_still_activates(self):
-        """outdoor 74F < indoor 78F; threshold 75F — outdoor just inside ceiling → nat_vent."""
-        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=78.0)
-        engine._last_outdoor_temp = 74.0  # below indoor(78) and below threshold(75)
+        """outdoor 74F < indoor 78F; threshold 81F — outdoor just inside ceiling → nat_vent.
+
+        comfort_cool raised to 78 (== indoor) so the Issue #392 ceiling gate (default/
+        HVAC-fan archetype) does not block this pure directional-guard test.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=78.0, nat_vent_delta=3.0, indoor_f=78.0)
+        engine._last_outdoor_temp = 74.0  # below indoor(78) and below threshold(81)
 
         asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
 
@@ -367,11 +385,15 @@ class TestReactivationLockout:
         assert engine._natural_vent_active is False
 
     def test_reactivation_allowed_after_lockout(self):
-        """Re-activation attempt 301s after exit → lockout expired; re-activates if conditions met."""
-        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=76.0)
+        """Re-activation attempt 301s after exit → lockout expired; re-activates if conditions met.
+
+        comfort_cool raised to 76 (== indoor) so the Issue #392 ceiling gate (default/
+        HVAC-fan archetype) does not block this pure lockout-timing test.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
         engine._paused_by_door = True
         engine._natural_vent_active = False
-        # outdoor 68F: below indoor(76) by more than hysteresis(1F), below threshold(75)
+        # outdoor 68F: below indoor(76) by more than hysteresis(1F), below threshold(79)
         engine._last_outdoor_temp = 68.0
 
         exit_time = datetime(2026, 4, 20, 20, 0, 0)
@@ -386,8 +408,12 @@ class TestReactivationLockout:
         assert engine._paused_by_door is False
 
     def test_lockout_boundary_exactly_300s_still_blocked(self):
-        """At exactly 300s (not yet past lockout) → still blocked."""
-        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=76.0)
+        """At exactly 300s (not yet past lockout) → still blocked.
+
+        comfort_cool raised to 76 (== indoor) so the Issue #392 ceiling gate (default/
+        HVAC-fan archetype) does not block this pure lockout-timing test.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
         engine._paused_by_door = True
         engine._natural_vent_active = False
         engine._last_outdoor_temp = 68.0
@@ -413,14 +439,18 @@ class TestReactivationHysteresis:
     """Row 6: outdoor must be at least hysteresis(1F) below indoor to re-activate from pause."""
 
     def test_outdoor_just_at_hysteresis_boundary_activates(self):
-        """outdoor == indoor - 1.0F exactly → activates (boundary is inclusive with < in code)."""
+        """outdoor == indoor - 1.0F exactly → activates (boundary is inclusive with < in code).
+
+        comfort_cool raised to 76 (== indoor) so the Issue #392 ceiling gate (default/
+        HVAC-fan archetype) does not block this pure hysteresis-boundary test.
+        """
         # With hysteresis=1.0: condition is outdoor < indoor - 1.0
         # At outdoor = indoor - 1.0: condition is False (not strictly less)
-        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
         engine._paused_by_door = True
         engine._natural_vent_active = False
-        # outdoor exactly at boundary: 76.0 - 1.0 = 75.0 — but also equals threshold(75), so < threshold fails
-        # Use indoor=76.0, outdoor=74.9 → outdoor < 75.0 = 76.0 - 1.0 → True; below threshold(75)? 74.9 < 75 → True
+        # outdoor exactly at boundary: 76.0 - 1.0 = 75.0 — but also equals threshold(79), so < threshold holds
+        # Use indoor=76.0, outdoor=74.9 → outdoor < 75.0 = 76.0 - 1.0 → True; below threshold(79)? 74.9 < 79 → True
         engine._last_outdoor_temp = 74.9
 
         # No lockout
@@ -465,7 +495,9 @@ class TestReactivationHysteresis:
         This covers the normal case where pause came from manual or classification, not an
         outdoor-warm exit. The lockout is None so the lockout check is skipped.
         """
-        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=76.0)
+        # comfort_cool raised to 76 (== indoor) so the Issue #392 ceiling gate (default/
+        # HVAC-fan archetype) does not block this pure hysteresis test.
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
         engine._paused_by_door = True
         engine._natural_vent_active = False
         engine._last_outdoor_temp = 68.0  # well below indoor - hysteresis
@@ -555,8 +587,13 @@ class TestFullNatVentCycle:
     """Integration: open → nat_vent → outdoor rise exit → lockout → re-activate."""
 
     def test_open_to_nat_vent_to_rise_exit_to_reactivate(self):
-        """Full cycle: activate at 18:00; outdoor rises at 20:00; re-activate at 21:00 (post-lockout)."""
-        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=76.0)
+        """Full cycle: activate at 18:00; outdoor rises at 20:00; re-activate at 21:00 (post-lockout).
+
+        comfort_cool raised to 76 (== max indoor used across the sequence) so the Issue #392
+        ceiling gate (default/HVAC-fan archetype) does not block this pure directional/lockout
+        integration test — ceiling-specific behavior is covered separately.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
 
         events: list[tuple] = []
         engine._emit_event_callback = lambda name, payload: events.append((name, payload))
@@ -608,8 +645,15 @@ class TestForecastRisingOutdoorSkip:
         return {"datetime": dt_str, "temperature": temp_f}
 
     def test_forecast_peak_above_threshold_skips_nat_vent(self):
-        """Forecast peak > nat_vent_threshold within 2 hr -> falls through to pause, not nat vent."""
-        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=73.0)
+        """Forecast peak > nat_vent_threshold within 2 hr -> falls through to pause, not nat vent.
+
+        comfort_cool raised to 73 (== indoor) so the Issue #392 ceiling gate (default/
+        HVAC-fan archetype) does not short-circuit before the Phase-2 forecast guard runs —
+        this test is specifically about the forecast guard, not the ceiling gate.
+        nat_vent_delta lowered to 2.0 to keep nat_vent_threshold at 75F (73+2), preserving
+        the original docstring math for the forecast-peak comparison.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=73.0, nat_vent_delta=2.0, indoor_f=73.0)
         engine._last_outdoor_temp = 68.0
         engine._natural_vent_active = False
         engine._fan_override_active = False
@@ -630,8 +674,12 @@ class TestForecastRisingOutdoorSkip:
         assert any(e[0] == "nat_vent_forecast_skip" for e in events)
 
     def test_forecast_peak_below_threshold_allows_nat_vent(self):
-        """Forecast peak <= threshold -> Phase 2 guard passes -> nat vent activates."""
-        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=73.0)
+        """Forecast peak <= threshold -> Phase 2 guard passes -> nat vent activates.
+
+        comfort_cool raised to 73 (== indoor) so the Issue #392 ceiling gate (default/
+        HVAC-fan archetype) does not block this Phase-2-forecast-guard test.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=73.0, nat_vent_delta=3.0, indoor_f=73.0)
         engine._last_outdoor_temp = 68.0
         engine._natural_vent_active = False
         engine._fan_override_active = False
@@ -650,8 +698,12 @@ class TestForecastRisingOutdoorSkip:
         assert any(e[0] == "sensor_opened" and e[1].get("result") == "natural_ventilation" for e in events)
 
     def test_no_hourly_forecast_falls_back_to_phase1(self):
-        """Empty hourly forecast -> forecast guard skipped -> Phase 1 only -> nat vent activates."""
-        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=73.0)
+        """Empty hourly forecast -> forecast guard skipped -> Phase 1 only -> nat vent activates.
+
+        comfort_cool raised to 73 (== indoor) so the Issue #392 ceiling gate (default/
+        HVAC-fan archetype) does not block this Phase-1-fallback test.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=73.0, nat_vent_delta=3.0, indoor_f=73.0)
         engine._last_outdoor_temp = 68.0
         engine._natural_vent_active = False
         engine._fan_override_active = False
@@ -703,8 +755,11 @@ class TestThermalFloorImminentSkip:
         indoor=73.0, comfort_heat=70.0, delta=3.0
         k_passive=-0.1, outdoor=68.0 -> passive_rate = -0.1 * (73 - 68) = -0.5 F/hr
         time_to_floor = 3.0 / 0.5 = 6.0 hr > 1.0 -> proceed
+
+        comfort_cool raised to 73 (== indoor) so the Issue #392 ceiling gate (default/
+        HVAC-fan archetype) does not block this Phase-2-thermal-floor-guard test.
         """
-        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=73.0)
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=73.0, nat_vent_delta=3.0, indoor_f=73.0)
         engine._last_outdoor_temp = 68.0
         engine._natural_vent_active = False
         engine._fan_override_active = False
@@ -734,8 +789,12 @@ class TestThermalFloorImminentSkip:
         assert not any(e[0] == "nat_vent_floor_imminent_skip" for e in events)
 
     def test_no_thermal_model_fallback_to_phase1(self):
-        """Empty thermal model -> guard skipped -> nat vent activates."""
-        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=73.0)
+        """Empty thermal model -> guard skipped -> nat vent activates.
+
+        comfort_cool raised to 73 (== indoor) so the Issue #392 ceiling gate (default/
+        HVAC-fan archetype) does not block this fallback test.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=73.0, nat_vent_delta=3.0, indoor_f=73.0)
         engine._last_outdoor_temp = 68.0
         engine._natural_vent_active = False
         engine._fan_override_active = False
@@ -1135,14 +1194,22 @@ class TestNatVentAcAssist:
     # with savings OFF -> full comfort band re-armed
     # ------------------------------------------------------------------
     def test_path_b_rearm_full_band_savings_off(self):
-        """Engine in paused state, FAN_MODE_HVAC, savings=False.
+        """Engine in paused state, FAN_MODE_HVAC, savings=False, indoor already past ceiling.
 
-        check_natural_vent_conditions() re-activates -> _apply_nat_vent_hvac_state
-        -> _apply_comfort_band with ceiling band armed (cool at comfort_cool).
+        Issue #392 Fix 1: for FAN_MODE_HVAC, ceiling_threshold == comfort_cool when
+        aggressive_savings is off (no escalation margin). indoor=76 > ceiling=75, so
+        reactivation must now be BLOCKED — the compressor should take over rather than
+        the fan reactivating past the point where AC/fan can coexist and hold the
+        ceiling together. This mirrors the ODE ceiling guard's own dormancy condition
+        (`indoor <= ceiling_threshold`), now applied consistently at the reactivation
+        gate too, not just the guard.
 
-        Occupant experience: windows open, breeze plus AC compressor together hold
-        the comfort ceiling -- occupant stays comfortable without choosing between
-        free cooling and AC.
+        Before Issue #392, this test asserted the fan reactivates and re-arms the full
+        comfort band even with indoor past the ceiling — that was the exact asymmetry
+        (guard vs. reactivation gates disagreeing) that produced the off->cool->off->cool
+        oscillation described in the issue. See test_path_b_floor_only_savings_on below
+        (aggressive_savings=True) for the case where the +2°F savings margin keeps the
+        ceiling (77) above indoor (76) and reactivation still proceeds.
         """
         engine = _make_hvac_engine(fan_mode="hvac_fan", aggressive_savings=False, indoor_f=76.0)
         engine._paused_by_door = True
@@ -1151,7 +1218,31 @@ class TestNatVentAcAssist:
         engine._last_outdoor_temp = 68.0
         engine._nat_vent_outdoor_exit_time = None
 
-        # Stub _apply_comfort_band so we can assert it is called
+        # Stub _apply_comfort_band so we can assert it is NOT called (ceiling gate blocks first)
+        engine._apply_comfort_band = AsyncMock()
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False, (
+            "FAN_MODE_HVAC: indoor (76) > ceiling_threshold (comfort_cool=75, no savings "
+            "margin) must block reactivation — compressor should take over"
+        )
+        engine._apply_comfort_band.assert_not_called()
+
+    def test_path_b_rearm_full_band_savings_off_indoor_within_ceiling(self):
+        """Engine in paused state, FAN_MODE_HVAC, savings=False, indoor within ceiling.
+
+        Companion to the ceiling-blocked case above: with indoor (74) at or below
+        comfort_cool (75), the ceiling gate is satisfied and reactivation proceeds as
+        before Issue #392 — fan reactivates and the full comfort band (fan + compressor
+        coexisting) is re-armed.
+        """
+        engine = _make_hvac_engine(fan_mode="hvac_fan", aggressive_savings=False, indoor_f=74.0)
+        engine._paused_by_door = True
+        engine._natural_vent_active = False
+        engine._last_outdoor_temp = 68.0
+        engine._nat_vent_outdoor_exit_time = None
+
         engine._apply_comfort_band = AsyncMock()
 
         asyncio.run(engine.check_natural_vent_conditions())
@@ -1578,3 +1669,309 @@ class TestNatVentSleepCeilingExit:
         assert engine._natural_vent_active is True, (
             "_natural_vent_active must remain True outside sleep window when comfort is maintained"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #392 Fix 1: archetype-aware ceiling gate at all four reactivation sites
+# ---------------------------------------------------------------------------
+
+
+class TestCeilingGateArchetypeAllFourSites:
+    """Issue #392 Fix 1: each of the four (re)activation gate sites — the paused-by-door
+    branch and the grace re-entry branch (both inside check_natural_vent_conditions()),
+    handle_door_window_open(), and _re_pause_for_open_sensor() — must apply the SAME
+    archetype-aware ceiling rule as the ODE guard's own dormancy condition: FAN_MODE_HVAC blocks reactivation once
+    indoor exceeds the ceiling (comfort_cool, or comfort_cool+margin under
+    aggressive_savings); FAN_MODE_WHOLE_HOUSE/BOTH ignore the ceiling entirely
+    (direction-only: outdoor < indoor is sufficient).
+
+    Occupant impact: before this fix, a WHF session got prematurely escalated to AC
+    the moment indoor ticked past the ceiling even though outdoor was still much
+    cooler than indoor and the fan was working — forcing an unnecessary compressor
+    cycle and then immediately being undone by the next reactivation check (the
+    off->cool->off->cool flapping from the issue). After the fix, WHF just keeps
+    running until outdoor stops being cooler than indoor.
+    """
+
+    # -- Site 1: check_natural_vent_conditions() paused-by-door reactivation ---
+    # (a second, distinct ceiling-gated branch inside the same function as Site 2's
+    # grace re-entry branch — not a separate method)
+
+    def test_site1_paused_by_door_hvac_fan_blocked_past_ceiling(self):
+        """FAN_MODE_HVAC: paused by door, indoor > ceiling -> reactivation blocked."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine._paused_by_door = True
+        engine._natural_vent_active = False
+        engine._last_outdoor_temp = 68.0  # well below indoor, would otherwise reactivate
+        engine._nat_vent_outdoor_exit_time = None
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False, (
+            "FAN_MODE_HVAC: indoor (76) > ceiling (74) must block paused-by-door reactivation"
+        )
+
+    def test_site1_paused_by_door_whf_reactivates_past_ceiling(self):
+        """FAN_MODE_WHOLE_HOUSE: paused by door, indoor > ceiling but outdoor < indoor -> reactivates."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine.config[CONF_FAN_MODE] = FAN_MODE_WHOLE_HOUSE
+        engine._paused_by_door = True
+        engine._natural_vent_active = False
+        engine._last_outdoor_temp = 68.0
+        engine._nat_vent_outdoor_exit_time = None
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True, (
+            "FAN_MODE_WHOLE_HOUSE: ceiling must not block paused-by-door reactivation as long as outdoor < indoor"
+        )
+
+    # -- Site 2: check_natural_vent_conditions() grace re-entry ----------------
+
+    def test_site2_grace_reentry_hvac_fan_blocked_past_ceiling(self):
+        """FAN_MODE_HVAC: grace active, indoor > ceiling -> reactivation blocked."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine._paused_by_door = False
+        engine._natural_vent_active = False
+        engine._grace_active = True
+        engine._last_outdoor_temp = 68.0
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False, (
+            "FAN_MODE_HVAC: indoor (76) > ceiling (74) must block grace re-entry reactivation"
+        )
+
+    def test_site2_grace_reentry_whf_reactivates_past_ceiling(self):
+        """FAN_MODE_WHOLE_HOUSE: grace active, indoor > ceiling, outdoor < indoor -> reactivates."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine.config[CONF_FAN_MODE] = FAN_MODE_WHOLE_HOUSE
+        engine._paused_by_door = False
+        engine._natural_vent_active = False
+        engine._grace_active = True
+        engine._last_outdoor_temp = 68.0
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True, (
+            "FAN_MODE_WHOLE_HOUSE: ceiling must not block grace re-entry as long as outdoor < indoor"
+        )
+
+    # -- Site 3: handle_door_window_open() --------------------------------------
+
+    def test_site3_door_open_hvac_fan_blocked_past_ceiling(self):
+        """FAN_MODE_HVAC: sensor opens, indoor > ceiling -> activation blocked, falls to pause."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine._last_outdoor_temp = 68.0
+
+        asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+
+        assert engine._natural_vent_active is False, (
+            "FAN_MODE_HVAC: indoor (76) > ceiling (74) must block activation on sensor open"
+        )
+        assert engine._paused_by_door is True
+
+    def test_site3_door_open_whf_activates_past_ceiling(self):
+        """FAN_MODE_WHOLE_HOUSE: sensor opens, indoor > ceiling, outdoor < indoor -> activates."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine.config[CONF_FAN_MODE] = FAN_MODE_WHOLE_HOUSE
+        engine._last_outdoor_temp = 68.0
+
+        asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+
+        assert engine._natural_vent_active is True, (
+            "FAN_MODE_WHOLE_HOUSE: ceiling must not block activation as long as outdoor < indoor"
+        )
+
+    # -- Site 4: _re_pause_for_open_sensor() -------------------------------------
+
+    def test_site4_re_pause_hvac_fan_blocked_past_ceiling(self):
+        """FAN_MODE_HVAC: grace expires with sensor open, indoor > ceiling -> re-pauses (blocked)."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine._last_outdoor_temp = 68.0
+
+        asyncio.run(engine._re_pause_for_open_sensor())
+
+        assert engine._natural_vent_active is False, (
+            "FAN_MODE_HVAC: indoor (76) > ceiling (74) must block reactivation at _re_pause_for_open_sensor()"
+        )
+
+    def test_site4_re_pause_whf_activates_past_ceiling(self):
+        """FAN_MODE_WHOLE_HOUSE: grace expires with sensor open, indoor > ceiling, outdoor < indoor -> activates."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine.config[CONF_FAN_MODE] = FAN_MODE_WHOLE_HOUSE
+        engine.config[CONF_FAN_ENTITY] = "fan.attic"
+        engine._last_outdoor_temp = 68.0
+
+        asyncio.run(engine._re_pause_for_open_sensor())
+
+        assert engine._natural_vent_active is True, (
+            "FAN_MODE_WHOLE_HOUSE: ceiling must not block reactivation as long as outdoor < indoor"
+        )
+
+    # -- aggressive_savings margin test (FAN_MODE_HVAC) --------------------------
+
+    def test_aggressive_savings_widens_ceiling_margin_for_hvac_fan(self):
+        """FAN_MODE_HVAC + aggressive_savings=True -> ceiling = comfort_cool + 2.0F margin.
+
+        indoor=76 is past the plain comfort_cool=74 ceiling but within the
+        aggressive-savings-widened ceiling (74+2=76) -> reactivation proceeds.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine.config["aggressive_savings"] = True
+        engine._last_outdoor_temp = 68.0
+
+        asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+
+        assert engine._natural_vent_active is True, (
+            "aggressive_savings should widen the ceiling by CEILING_ESCALATION_SAVINGS_MARGIN_F "
+            "(2.0F), allowing reactivation at indoor=76 with comfort_cool=74"
+        )
+
+    def test_aggressive_savings_still_blocks_beyond_widened_margin(self):
+        """FAN_MODE_HVAC + aggressive_savings=True, indoor beyond even the widened ceiling -> blocked."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=5.0, indoor_f=77.0)
+        engine.config["aggressive_savings"] = True
+        engine._last_outdoor_temp = 68.0
+
+        asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+
+        assert engine._natural_vent_active is False, (
+            "indoor (77) exceeds even the widened ceiling (74+2=76) -- must still block"
+        )
+
+
+class TestIssue392ExactReproduction:
+    """Direct reproduction of the Issue #392 sequence: WHF mode, outdoor 72F, indoor 75F,
+    comfort_cool 74F. Before Fix 1, the ceiling guard would escalate to AC purely because
+    indoor(75) > comfort_cool(74), even though outdoor(72) is still comfortably below
+    indoor and the WHF is actively converging the house toward outdoor temperature.
+
+    Occupant impact: the user saw the fan deactivate, HVAC escalate to `cool`, and then
+    the very next sensor/grace re-check immediately reactivate the fan and force HVAC
+    back to `off` — an off->cool->off->cool fight repeating roughly every 5 minutes
+    (18:53-19:04 in the issue's activity log).
+    """
+
+    def test_whf_outdoor_72_indoor_75_comfort_cool_74_does_not_escalate_to_ac(self):
+        """WHF, outdoor=72, indoor=75, comfort_cool=74 -> nat-vent stays active, no AC escalation."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0, indoor_f=75.0)
+        engine.config[CONF_FAN_MODE] = FAN_MODE_WHOLE_HOUSE
+        engine.config[CONF_FAN_ENTITY] = "fan.whole_house"
+        engine._last_outdoor_temp = 72.0
+
+        # Sensor opens: outdoor(72) < indoor(75), indoor > comfort_heat(70), outdoor < threshold(77)
+        asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+
+        assert engine._natural_vent_active is True, (
+            "WHF must activate: outdoor(72) < indoor(75), well within direction-only gate "
+            "despite indoor(75) > comfort_cool(74)"
+        )
+
+        # HVAC must never have been commanded to an active mode (cool) — only "off" (suppression).
+        hvac_calls = [
+            c[0][2]["hvac_mode"]
+            for c in engine.hass.services.async_call.call_args_list
+            if c[0][0] == "climate" and c[0][1] == "set_hvac_mode"
+        ]
+        assert "cool" not in hvac_calls, (
+            f"HVAC must never escalate to 'cool' while WHF nat-vent is active and outdoor < indoor; got: {hvac_calls}"
+        )
+
+    def test_whf_outdoor_72_indoor_75_survives_grace_recheck_without_flapping(self):
+        """Simulates the observed sequence: activate, then grace re-check under the same
+        outdoor/indoor conditions must not flap (deactivate-then-reactivate).
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0, indoor_f=75.0)
+        engine.config[CONF_FAN_MODE] = FAN_MODE_WHOLE_HOUSE
+        engine.config[CONF_FAN_ENTITY] = "fan.whole_house"
+        engine._last_outdoor_temp = 72.0
+
+        asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+        assert engine._natural_vent_active is True
+
+        fan_calls_after_activate = len(
+            [c for c in engine.hass.services.async_call.call_args_list if c[0][0] == "fan" and c[0][1] == "turn_on"]
+        )
+
+        # Re-check under unchanged conditions (simulating the next coordinator cycle /
+        # grace-expiry re-evaluation) must be a no-op — nat-vent is already active and
+        # nothing about outdoor/indoor direction has changed.
+        engine._grace_active = False
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        fan_calls_after_recheck = len(
+            [c for c in engine.hass.services.async_call.call_args_list if c[0][0] == "fan" and c[0][1] == "turn_on"]
+        )
+        assert fan_calls_after_recheck == fan_calls_after_activate, (
+            "Re-check under unchanged conditions must not re-issue a redundant fan.turn_on call "
+            "(idempotency guard, Fix 1c)"
+        )
+        assert engine._natural_vent_active is True
+
+
+# ---------------------------------------------------------------------------
+# Issue #392 Fix 3: decision-lock concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionLockConcurrency:
+    """Issue #392 Fix 3: the six automation entry points share a single
+    asyncio.Lock() (_decision_lock) so concurrent triggers evaluate one at a time
+    against a consistent state snapshot instead of interleaving at await points.
+
+    Occupant impact: without serialization, two independently-triggered handlers
+    (e.g. a sensor-open debounce callback and a periodic nat-vent re-check) racing
+    on shared state (_natural_vent_active, _fan_active, _pre_fan_hvac_mode) is the
+    deeper mechanism behind the 18:53/18:58 burst of contradicting decisions in the
+    issue — several uncoordinated handlers each concluding something different
+    within the same few seconds.
+    """
+
+    def test_two_entry_points_do_not_interleave(self):
+        """asyncio.gather() on two locked entry points -> non-overlapping execution,
+        verified by recording enter/exit order around the lock acquisition.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine._last_outdoor_temp = 70.0
+
+        order: list[str] = []
+        real_lock = engine._decision_lock
+
+        class _TrackingLock:
+            """Wraps the real asyncio.Lock to record acquire/release order."""
+
+            def __init__(self, name_source: list[str]):
+                self._name_source = name_source
+
+            async def __aenter__(self):
+                await real_lock.acquire()
+                self._name_source.append(f"enter:{id(asyncio.current_task())}")
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                self._name_source.append(f"exit:{id(asyncio.current_task())}")
+                real_lock.release()
+
+        engine._decision_lock = _TrackingLock(order)
+
+        async def _run_both():
+            await asyncio.gather(
+                engine.handle_door_window_open("binary_sensor.front_door"),
+                engine.check_natural_vent_conditions(),
+            )
+
+        asyncio.run(_run_both())
+
+        # Non-overlapping: each task's enter must be immediately followed by its own
+        # exit before the other task's enter appears (strict enter/exit pairing).
+        assert len(order) == 4, f"Expected 4 lock events (2 enter + 2 exit); got: {order}"
+        first_task_id = order[0].split(":")[1]
+        assert order[1] == f"exit:{first_task_id}", (
+            f"First task's enter must be immediately followed by its own exit (no interleaving); got: {order}"
+        )
+        second_task_id = order[2].split(":")[1]
+        assert order[3] == f"exit:{second_task_id}", (
+            f"Second task's enter must be immediately followed by its own exit; got: {order}"
+        )
+        assert first_task_id != second_task_id, "The two tasks must be distinct"

--- a/tests/test_whole_house_fan_hvac_suppression.py
+++ b/tests/test_whole_house_fan_hvac_suppression.py
@@ -16,7 +16,7 @@ import asyncio
 import importlib
 import sys
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Patch dt_util.now before importing automation
 if "homeassistant.util.dt" in sys.modules:
@@ -441,3 +441,344 @@ class TestWindowCloseStopsWholehouseFan:
 
         fan_off_calls = _get_fan_entity_calls(engine, "turn_off", "fan.attic")
         assert len(fan_off_calls) == 0, f"Fix D must not call fan.turn_off when _fan_active=False; got: {fan_off_calls}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #392 Fix 1b: structural choke-point guard (_whf_owns_hvac in
+# _set_hvac_mode()/_set_temperature())
+# ---------------------------------------------------------------------------
+
+
+def _make_classification(day_type: str = "warm", hvac_mode: str = "cool"):
+    """Minimal DayClassification, bypassing __post_init__ validation."""
+    from custom_components.climate_advisor.classifier import DayClassification
+
+    c = object.__new__(DayClassification)
+    c.day_type = day_type
+    c.trend_direction = "stable"
+    c.trend_magnitude = 0.0
+    c.today_high = 85.0
+    c.today_low = 65.0
+    c.tomorrow_high = 85.0
+    c.tomorrow_low = 65.0
+    c.hvac_mode = hvac_mode
+    c.pre_condition = False
+    c.pre_condition_target = 0.0
+    c.windows_recommended = False
+    c.window_open_time = None
+    c.window_close_time = None
+    c.setback_modifier = 0.0
+    c.window_opportunity_morning = False
+    c.window_opportunity_evening = False
+    return c
+
+
+class TestChokePointGuardBlocksWhfWrites:
+    """Issue #392 Fix 1b: _set_hvac_mode()/_set_temperature() silently block active-mode
+    writes while a whole-house-fan session owns the thermostat (_whf_owns_hvac() == True),
+    making WHF/AC mutual exclusion a structural guarantee rather than a per-caller convention.
+
+    Occupant effect: without this guard, any of the ~13 call sites that write HVAC mode
+    (or the 7 _apply_comfort_band() call sites) could re-arm the compressor while the
+    whole-house fan is physically running, fighting the fan and wasting energy — even
+    though _activate_fan()/_deactivate_fan() already try to maintain exclusivity by
+    convention (Root Cause #2 in the #392 investigation).
+    """
+
+    def test_set_hvac_mode_blocked_when_whf_owns_hvac(self):
+        """mode='cool' write is silently dropped (no service call) while WHF suppresses HVAC."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        engine._pre_fan_hvac_mode = "cool"  # WHF session actively suppressing HVAC
+
+        asyncio.run(engine._set_hvac_mode("cool", reason="test: attempted re-arm"))
+
+        hvac_calls = _get_hvac_mode_calls(engine)
+        assert "cool" not in hvac_calls, f"Expected 'cool' write blocked while WHF owns HVAC; got: {hvac_calls}"
+
+    def test_set_hvac_mode_off_never_blocked(self):
+        """mode='off' writes are never blocked — the guard only blocks active modes."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="cool")
+        engine._pre_fan_hvac_mode = "cool"
+
+        asyncio.run(engine._set_hvac_mode("off", reason="test: suppress"))
+
+        hvac_calls = _get_hvac_mode_calls(engine)
+        assert "off" in hvac_calls, f"Expected 'off' write to always succeed; got: {hvac_calls}"
+
+    def test_set_hvac_mode_not_blocked_for_hvac_fan_mode(self):
+        """FAN_MODE_HVAC never sets _pre_fan_hvac_mode, so _whf_owns_hvac() is always False."""
+        engine = _make_engine(fan_mode=FAN_MODE_HVAC, current_hvac_mode="off")
+        engine._pre_fan_hvac_mode = None
+
+        asyncio.run(engine._set_hvac_mode("cool", reason="test"))
+
+        hvac_calls = _get_hvac_mode_calls(engine)
+        assert "cool" in hvac_calls, f"FAN_MODE_HVAC must not be blocked; got: {hvac_calls}"
+
+    def test_set_hvac_mode_not_blocked_when_no_whf_session_active(self):
+        """FAN_MODE_WHOLE_HOUSE but no active session (_pre_fan_hvac_mode=None) -> not blocked."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        engine._pre_fan_hvac_mode = None  # no suppression session in progress
+
+        asyncio.run(engine._set_hvac_mode("cool", reason="test"))
+
+        hvac_calls = _get_hvac_mode_calls(engine)
+        assert "cool" in hvac_calls, f"No active WHF session must not block writes; got: {hvac_calls}"
+
+    def test_set_temperature_blocked_when_whf_owns_hvac(self):
+        """_set_temperature(mode='cool') is silently dropped while WHF suppresses HVAC."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        engine._pre_fan_hvac_mode = "cool"
+
+        asyncio.run(engine._set_temperature(74.0, reason="test: attempted re-arm", mode="cool"))
+
+        temp_calls = [
+            c
+            for c in engine.hass.services.async_call.call_args_list
+            if c[0][0] == "climate" and c[0][1] == "set_temperature"
+        ]
+        assert len(temp_calls) == 0, f"Expected set_temperature blocked while WHF owns HVAC; got: {temp_calls}"
+
+    def test_set_temperature_not_blocked_for_hvac_fan_mode(self):
+        """FAN_MODE_HVAC: set_temperature succeeds normally (fan/compressor coexist)."""
+        engine = _make_engine(fan_mode=FAN_MODE_HVAC, current_hvac_mode="cool")
+        engine._pre_fan_hvac_mode = None
+
+        asyncio.run(engine._set_temperature(74.0, reason="test", mode="cool"))
+
+        temp_calls = [
+            c
+            for c in engine.hass.services.async_call.call_args_list
+            if c[0][0] == "climate" and c[0][1] == "set_temperature"
+        ]
+        assert len(temp_calls) == 1, f"FAN_MODE_HVAC set_temperature must succeed; got: {temp_calls}"
+
+    def test_hvac_write_blocked_event_fires_on_set_hvac_mode(self):
+        """A blocked _set_hvac_mode() write emits hvac_write_blocked_whf_active."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        engine._pre_fan_hvac_mode = "cool"
+        engine._emit_event_callback = MagicMock()
+
+        asyncio.run(engine._set_hvac_mode("cool", reason="test: attempted re-arm"))
+
+        events = [c.args[0] for c in engine._emit_event_callback.call_args_list]
+        assert "hvac_write_blocked_whf_active" in events, f"Expected block event; got: {events}"
+        payload = next(
+            c.args[1]
+            for c in engine._emit_event_callback.call_args_list
+            if c.args[0] == "hvac_write_blocked_whf_active"
+        )
+        assert payload["attempted_mode"] == "cool"
+
+    def test_hvac_write_blocked_event_fires_on_set_temperature(self):
+        """A blocked _set_temperature() write emits hvac_write_blocked_whf_active."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        engine._pre_fan_hvac_mode = "cool"
+        engine._emit_event_callback = MagicMock()
+
+        asyncio.run(engine._set_temperature(74.0, reason="test: attempted re-arm", mode="cool"))
+
+        events = [c.args[0] for c in engine._emit_event_callback.call_args_list]
+        assert "hvac_write_blocked_whf_active" in events, f"Expected block event; got: {events}"
+
+    def test_no_block_event_when_write_succeeds(self):
+        """A successful (non-blocked) write does not emit hvac_write_blocked_whf_active."""
+        engine = _make_engine(fan_mode=FAN_MODE_HVAC, current_hvac_mode="off")
+        engine._pre_fan_hvac_mode = None
+        engine._emit_event_callback = MagicMock()
+
+        asyncio.run(engine._set_hvac_mode("cool", reason="test"))
+
+        events = [c.args[0] for c in engine._emit_event_callback.call_args_list]
+        assert "hvac_write_blocked_whf_active" not in events
+
+
+class TestRePauseCallsApplyNatVentHvacState:
+    """Issue #392 Fix 1: _re_pause_for_open_sensor() now calls _apply_nat_vent_hvac_state()
+    after activating nat-vent, matching the other three reactivation gate sites
+    (handle_door_window_open, check_natural_vent_conditions grace re-entry,
+    nat_vent_temperature_check paused-state reactivation). Before this fix,
+    _re_pause_for_open_sensor() was the one site that skipped this call — an
+    inconsistency the plan calls out as "fix alongside" Root Cause #1.
+
+    Occupant effect: without this call, a WHF session reactivated via this specific
+    path would not have its no-op _apply_nat_vent_hvac_state() invariant applied
+    consistently (WHF: no-op since _activate_fan() already suppressed HVAC; HVAC-fan
+    mode: fails to re-arm the full comfort band), producing inconsistent state
+    depending on which of the four reactivation paths happened to fire.
+    """
+
+    def test_re_pause_calls_apply_nat_vent_hvac_state_when_reactivating(self):
+        """WHF: outdoor cool -> nat-vent reactivates -> _apply_nat_vent_hvac_state() called."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, fan_entity="fan.attic", current_hvac_mode="cool")
+        engine._get_indoor_temp_f = MagicMock(return_value=76.0)
+        engine._last_outdoor_temp = 68.0  # cool enough for nat-vent
+        engine._apply_nat_vent_hvac_state = AsyncMock()
+
+        asyncio.run(engine._re_pause_for_open_sensor())
+
+        assert engine._natural_vent_active is True
+        engine._apply_nat_vent_hvac_state.assert_awaited_once()
+
+    def test_re_pause_does_not_call_apply_nat_vent_hvac_state_when_not_reactivating(self):
+        """Outdoor too warm -> falls through to regular re-pause -> helper NOT called."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, fan_entity="fan.attic", current_hvac_mode="cool")
+        engine._get_indoor_temp_f = MagicMock(return_value=76.0)
+        engine._last_outdoor_temp = 90.0  # too warm — nat-vent conditions not met
+        engine._apply_nat_vent_hvac_state = AsyncMock()
+
+        asyncio.run(engine._re_pause_for_open_sensor())
+
+        assert engine._natural_vent_active is False
+        engine._apply_nat_vent_hvac_state.assert_not_awaited()
+
+
+class TestApplyClassificationWhfEarlyReturn:
+    """Issue #392 Fix 1b: apply_classification()'s nat-vent branch returns early for
+    FAN_MODE_WHOLE_HOUSE/BOTH right after _apply_nat_vent_hvac_state(), instead of falling
+    through to select_comfort_band()/_apply_comfort_band()/the ODE ceiling guard — all of
+    which would attempt (and have their writes silently dropped by) the choke-point guard
+    while WHF owns the thermostat. FAN_MODE_HVAC keeps falling through as before (band
+    stays armed; fan and compressor coexist per Issue #249).
+    """
+
+    def test_whf_nat_vent_active_skips_select_comfort_band(self):
+        """WHF + nat-vent active + savings off -> select_comfort_band() is NOT called."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        engine._natural_vent_active = True
+        engine._pre_fan_hvac_mode = "cool"
+        engine._apply_nat_vent_hvac_state = AsyncMock()
+
+        classification = _make_classification()
+
+        with patch("custom_components.climate_advisor.automation.select_comfort_band") as mock_select:
+            asyncio.run(engine.apply_classification(classification))
+            mock_select.assert_not_called()
+
+        engine._apply_nat_vent_hvac_state.assert_awaited_once()
+
+    def test_hvac_fan_nat_vent_active_still_calls_select_comfort_band(self):
+        """FAN_MODE_HVAC + nat-vent active + savings off -> select_comfort_band() IS called
+        (band stays armed; the guard is only for WHF's structural mutual-exclusion contract).
+        """
+        engine = _make_engine(fan_mode=FAN_MODE_HVAC, current_hvac_mode="cool")
+        engine._natural_vent_active = True
+        engine._apply_nat_vent_hvac_state = AsyncMock()
+
+        classification = _make_classification()
+
+        with patch("custom_components.climate_advisor.automation.select_comfort_band") as mock_select:
+            mock_select.return_value = MagicMock(active="ceiling", floor=70.0, ceiling=75.0, reason="test")
+            asyncio.run(engine.apply_classification(classification))
+            mock_select.assert_called_once()
+
+    def test_whf_aggressive_savings_still_returns_early_before_select_comfort_band(self):
+        """WHF + nat-vent + aggressive_savings=True -> already returned early for savings;
+        select_comfort_band() must still not be called (belt-and-suspenders for the WHF path).
+        """
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        engine.config["aggressive_savings"] = True
+        engine._natural_vent_active = True
+        engine._pre_fan_hvac_mode = "cool"
+        engine._apply_nat_vent_hvac_state = AsyncMock()
+
+        classification = _make_classification()
+
+        with patch("custom_components.climate_advisor.automation.select_comfort_band") as mock_select:
+            asyncio.run(engine.apply_classification(classification))
+            mock_select.assert_not_called()
+
+
+class TestFanActivateDeactivateIdempotency:
+    """Issue #392 Fix 1c: _activate_fan()/_deactivate_fan() are idempotent — a second call
+    while already in the target state is a no-op (debug log only), preventing the
+    18:53/18:58 burst pattern where multiple uncoordinated handlers each re-decide the
+    same already-satisfied condition and re-execute the full activation/deactivation
+    sequence (re-capturing _pre_fan_hvac_mode from a possibly-stale thermostat read,
+    reissuing the physical service call, emitting a duplicate event).
+    """
+
+    def test_activate_fan_twice_calls_service_once(self):
+        """Two _activate_fan() calls in a row -> physical turn_on called exactly once."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, fan_entity="fan.attic", current_hvac_mode="cool")
+        engine._emit_event_callback = MagicMock()
+
+        asyncio.run(engine._activate_fan(reason="first"))
+        asyncio.run(engine._activate_fan(reason="second"))
+
+        turn_on_calls = _get_fan_entity_calls(engine, "turn_on", "fan.attic")
+        assert len(turn_on_calls) == 1, f"Expected exactly 1 turn_on call; got {len(turn_on_calls)}"
+
+    def test_activate_fan_twice_emits_event_once(self):
+        """Two _activate_fan() calls -> fan_activated emitted exactly once."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, fan_entity="fan.attic", current_hvac_mode="cool")
+        engine._emit_event_callback = MagicMock()
+
+        asyncio.run(engine._activate_fan(reason="first"))
+        asyncio.run(engine._activate_fan(reason="second"))
+
+        activated_events = [c for c in engine._emit_event_callback.call_args_list if c.args[0] == "fan_activated"]
+        assert len(activated_events) == 1, f"Expected exactly 1 fan_activated event; got {len(activated_events)}"
+
+    def test_activate_fan_twice_does_not_recapture_pre_fan_hvac_mode(self):
+        """Second _activate_fan() call does not overwrite _pre_fan_hvac_mode from a
+        possibly-stale thermostat read — it should already equal the mode captured
+        by the first (real) activation.
+        """
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, fan_entity="fan.attic", current_hvac_mode="cool")
+
+        asyncio.run(engine._activate_fan(reason="first"))
+        assert engine._pre_fan_hvac_mode == "cool"
+
+        # Simulate the thermostat now reading "off" (already suppressed) — if the second
+        # call incorrectly re-captured, _pre_fan_hvac_mode would become "off" (wrong).
+        engine.hass.states.get = MagicMock(return_value=_make_thermostat_state("off"))
+        asyncio.run(engine._activate_fan(reason="second"))
+
+        assert engine._pre_fan_hvac_mode == "cool", (
+            f"Idempotency guard must prevent re-capture on the redundant call; got {engine._pre_fan_hvac_mode!r}"
+        )
+
+    def test_deactivate_fan_twice_calls_service_once(self):
+        """Two _deactivate_fan() calls in a row -> physical turn_off called exactly once."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, fan_entity="fan.attic", current_hvac_mode="off")
+        engine._fan_active = True
+        engine._pre_fan_hvac_mode = "cool"
+        engine._emit_event_callback = MagicMock()
+
+        asyncio.run(engine._deactivate_fan(reason="first"))
+        asyncio.run(engine._deactivate_fan(reason="second"))
+
+        turn_off_calls = _get_fan_entity_calls(engine, "turn_off", "fan.attic")
+        assert len(turn_off_calls) == 1, f"Expected exactly 1 turn_off call; got {len(turn_off_calls)}"
+
+    def test_deactivate_fan_twice_emits_event_once(self):
+        """Two _deactivate_fan() calls -> fan_deactivated emitted exactly once."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, fan_entity="fan.attic", current_hvac_mode="off")
+        engine._fan_active = True
+        engine._pre_fan_hvac_mode = "cool"
+        engine._emit_event_callback = MagicMock()
+
+        asyncio.run(engine._deactivate_fan(reason="first"))
+        asyncio.run(engine._deactivate_fan(reason="second"))
+
+        deactivated_events = [c for c in engine._emit_event_callback.call_args_list if c.args[0] == "fan_deactivated"]
+        assert len(deactivated_events) == 1, f"Expected exactly 1 fan_deactivated event; got {len(deactivated_events)}"
+
+    def test_deactivate_fan_twice_does_not_double_restore_hvac(self):
+        """Second _deactivate_fan() call does not re-issue the HVAC restore write —
+        _pre_fan_hvac_mode is already None after the first (real) deactivation.
+        """
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, fan_entity="fan.attic", current_hvac_mode="off")
+        engine._fan_active = True
+        engine._pre_fan_hvac_mode = "cool"
+
+        asyncio.run(engine._deactivate_fan(reason="first"))
+        hvac_calls_after_first = _get_hvac_mode_calls(engine)
+        assert "cool" in hvac_calls_after_first
+
+        asyncio.run(engine._deactivate_fan(reason="second"))
+        hvac_calls_after_second = _get_hvac_mode_calls(engine)
+        assert hvac_calls_after_second.count("cool") == 1, (
+            f"Expected exactly 1 HVAC restore write across both calls; got {hvac_calls_after_second}"
+        )

--- a/tests/test_window_hvac_interaction.py
+++ b/tests/test_window_hvac_interaction.py
@@ -107,6 +107,7 @@ def _make_ae_stub(**overrides) -> AutomationEngine:
     ae._request_refresh_callback = None
     ae._post_grace_fan_check_callback = None
     ae.dry_run = False
+    ae._decision_lock = asyncio.Lock()
 
     # Mock async service calls
     ae._set_hvac_mode = AsyncMock()

--- a/tools/simulations/golden/2026-03-28-overnight.json
+++ b/tools/simulations/golden/2026-03-28-overnight.json
@@ -10,11 +10,12 @@
     "At 23:30 indoor drops to comfort_heat=70F \u00e2\u20ac\u201d Issue #99 comfort-floor exit fires, heat restores.",
     "The outdoor temp (53F) is still below the nat vent threshold, but the indoor comfort floor takes priority.",
     "06:00 assertion updated for Issue #115: outdoor >= indoor -> paused (directional guard).",
-    "Promote to golden/ once all assertions pass in production."
+    "Promote to golden/ once all assertions pass in production.",
+    "Issue #392: comfort_cool raised from 72 to 76 so the archetype-aware ceiling gate (indoor <= ceiling_threshold, applied to the default/HVAC-fan archetype used here) does not block the 20:00 re-activation (indoor 76F) — this scenario tests directional/threshold/comfort-floor behavior, not the ceiling gate."
   ],
   "config": {
     "comfort_heat": 70,
-    "comfort_cool": 72,
+    "comfort_cool": 76,
     "natural_vent_delta": 3.0
   },
   "verdict": {

--- a/tools/simulations/golden/MANIFEST.json
+++ b/tools/simulations/golden/MANIFEST.json
@@ -14,8 +14,8 @@
     "issue": 95
   },
   "2026-03-28-overnight": {
-    "sha256": "65deb17e5237191cefdda5468694f11539456d0c540f765a1b590b13594d1566",
-    "signed": "2026-06-13",
+    "sha256": "0a888340544f632afdde84b823688e6a82f7c322a1d603c0131c54d9b3d29faf",
+    "signed": "2026-07-02",
     "issue": 69
   },
   "away-mode-classification-cycle": {
@@ -29,18 +29,18 @@
     "issue": 115
   },
   "nat-vent-evening-activation": {
-    "sha256": "20c90ee48bce399afa0949a63b1af280a168e197db7130450cc3941a3a4a9f3f",
-    "signed": "2026-06-13",
+    "sha256": "9114cf34c3501d8884b11e39a6ae6728121a50ee04b83a839b85c25a8dae1471",
+    "signed": "2026-07-02",
     "issue": 115
   },
   "nat-vent-indoor-hot-outdoor-near-comfort": {
-    "sha256": "92d8fe0a3479c6f9b9b4c201c6e5394fd488d3dc062478cf8dfff4d01c624230",
-    "signed": "2026-06-13",
+    "sha256": "d1d8b2d815d4c855da2f7187ef182aa1600e9ab3d752957b63b00a104be9ab24",
+    "signed": "2026-07-02",
     "issue": 115
   },
   "nat-vent-outdoor-rises-above-indoor-exit": {
-    "sha256": "2faf2ba3e7ae0b6787253d8d5039bdaa7873cfc1e2ad61deb8ed772ff77dce1b",
-    "signed": "2026-06-13",
+    "sha256": "93414d8a93af51fe660d5c2a28715d27bb48d16d79ba7cabcce9406702c09b5a",
+    "signed": "2026-07-02",
     "issue": 115
   },
   "nat-vent-outdoor-warmer-no-activate": {
@@ -99,8 +99,8 @@
     "issue": 218
   },
   "startup_indoor_above_cool_nat_vent_not_running": {
-    "sha256": "a9b7c2a7b3a7fc4892c27ea9047629a41da7bf4745ceea4458e83c4a890d7162",
-    "signed": "2026-06-13",
+    "sha256": "894a9ac68a0e79cf79c6d896a9a453fc92f9ad75eb34fc8863479c831c2f92c8",
+    "signed": "2026-07-02",
     "issue": 218
   },
   "startup_indoor_above_cool_sensors_closed": {

--- a/tools/simulations/golden/nat-vent-evening-activation.json
+++ b/tools/simulations/golden/nat-vent-evening-activation.json
@@ -11,7 +11,7 @@
   },
   "config": {
     "comfort_heat": 70,
-    "comfort_cool": 72,
+    "comfort_cool": 76,
     "natural_vent_delta": 3.0
   },
   "events": [
@@ -20,7 +20,7 @@
       "type": "temp_update",
       "indoor_f": 76.0,
       "outdoor_f": 70.0,
-      "note": "evening: indoor above comfort_cool, outdoor 6F cooler — nat vent eligible"
+      "note": "evening: indoor at comfort_cool ceiling, outdoor 6F cooler — nat vent eligible. comfort_cool raised to 76 (Issue #392: reactivation gates now also require indoor <= ceiling_threshold for the default/HVAC-fan archetype used here — this scenario tests directional activation, not the ceiling gate)"
     },
     {
       "time": "2026-04-20T18:00:00",
@@ -33,7 +33,7 @@
     {
       "at": "2026-04-20T18:00:00",
       "expect": "natural_ventilation",
-      "reason": "outdoor 70F < indoor 76F (beneficial direction); outdoor 70F < threshold 75F; indoor 76F > comfort_heat 70F — nat vent activates"
+      "reason": "outdoor 70F < indoor 76F (beneficial direction); outdoor 70F < threshold 79F; indoor 76F > comfort_heat 70F; indoor 76F <= ceiling_threshold 76F — nat vent activates"
     }
   ]
 }

--- a/tools/simulations/golden/nat-vent-indoor-hot-outdoor-near-comfort.json
+++ b/tools/simulations/golden/nat-vent-indoor-hot-outdoor-near-comfort.json
@@ -5,13 +5,13 @@
   "issue": 115,
   "verdict": {
     "type": "positive",
-    "summary": "When indoor is above comfort_cool and outdoor is below both indoor and threshold, nat vent activates",
-    "observed_behavior": "natural_ventilation: outdoor(74) < indoor(78), outdoor(74) < threshold(75)",
-    "expected_behavior": "natural_ventilation: outdoor(74) < indoor(78), outdoor(74) < threshold(75)"
+    "summary": "When indoor is at or below the ceiling and outdoor is below both indoor and threshold, nat vent activates",
+    "observed_behavior": "natural_ventilation: outdoor(74) < indoor(78), outdoor(74) < threshold(81), indoor(78) <= ceiling(78)",
+    "expected_behavior": "natural_ventilation: outdoor(74) < indoor(78), outdoor(74) < threshold(81), indoor(78) <= ceiling(78)"
   },
   "config": {
     "comfort_heat": 70,
-    "comfort_cool": 72,
+    "comfort_cool": 78,
     "natural_vent_delta": 3.0
   },
   "events": [
@@ -20,7 +20,7 @@
       "type": "temp_update",
       "indoor_f": 78.0,
       "outdoor_f": 74.0,
-      "note": "hot interior; outdoor 74F is above comfort_cool(72) but below indoor(78) and below threshold(75)"
+      "note": "hot interior; outdoor 74F is below indoor(78) and below threshold(81). comfort_cool raised to 78 (== indoor) so Issue #392's archetype-aware ceiling gate (default/HVAC-fan archetype) does not block this directional-activation scenario."
     },
     {
       "time": "2026-04-20T17:00:00",
@@ -33,7 +33,7 @@
     {
       "at": "2026-04-20T17:00:00",
       "expect": "natural_ventilation",
-      "reason": "outdoor 74F < indoor 78F (beneficial); outdoor 74F < threshold 75F (within ceiling); indoor 78F > comfort_heat 70F — nat vent activates for hot-day free cooling"
+      "reason": "outdoor 74F < indoor 78F (beneficial); outdoor 74F < threshold 81F; indoor 78F > comfort_heat 70F; indoor 78F <= ceiling_threshold 78F — nat vent activates for hot-day free cooling"
     }
   ]
 }

--- a/tools/simulations/golden/nat-vent-outdoor-rises-above-indoor-exit.json
+++ b/tools/simulations/golden/nat-vent-outdoor-rises-above-indoor-exit.json
@@ -11,7 +11,7 @@
   },
   "config": {
     "comfort_heat": 70,
-    "comfort_cool": 72,
+    "comfort_cool": 76,
     "natural_vent_delta": 3.0
   },
   "events": [
@@ -20,7 +20,7 @@
       "type": "temp_update",
       "indoor_f": 76.0,
       "outdoor_f": 70.0,
-      "note": "evening: outdoor well below indoor — nat vent eligible"
+      "note": "evening: outdoor well below indoor — nat vent eligible. comfort_cool raised to 76 (Issue #392: reactivation gates now also require indoor <= ceiling_threshold for the default/HVAC-fan archetype used here — this scenario tests the directional outdoor-rise exit, not the ceiling gate)"
     },
     {
       "time": "2026-04-20T18:00:00",
@@ -40,12 +40,12 @@
     {
       "at": "2026-04-20T18:00:00",
       "expect": "natural_ventilation",
-      "reason": "outdoor 70F < indoor 76F and below threshold 75F — nat vent activates"
+      "reason": "outdoor 70F < indoor 76F and below threshold 79F; indoor 76F <= ceiling_threshold 76F — nat vent activates"
     },
     {
       "at": "2026-04-20T20:00:00",
       "expect": "nat_vent_outdoor_rise_exit",
-      "reason": "outdoor 74.5F >= indoor 74.0F — directional exit fires; outdoor still below threshold 75F but airflow no longer beneficial"
+      "reason": "outdoor 74.5F >= indoor 74.0F — directional exit fires; outdoor still below threshold 79F but airflow no longer beneficial"
     }
   ]
 }

--- a/tools/simulations/golden/startup_indoor_above_cool_nat_vent_not_running.json
+++ b/tools/simulations/golden/startup_indoor_above_cool_nat_vent_not_running.json
@@ -1,13 +1,13 @@
 {
   "name": "startup_indoor_above_cool_nat_vent_not_running",
-  "description": "Startup: ceiling guard fires before nat-vent can activate",
+  "description": "Startup: reactivation ceiling gate blocks nat-vent when indoor already exceeds comfort_cool (Issue #392)",
   "source": "synthetic",
   "issue": 218,
   "verdict": {
     "type": "positive",
-    "summary": "When startup has indoor exceeding comfort_cool, ceiling guard in production blocks nat-vent activation. Simulator lacks ceiling guard logic.",
-    "observed_behavior": "startup with indoor 76F > comfort_cool 74F, sensors open — simulator activates nat vent",
-    "expected_behavior": "In production: ceiling guard would block nat vent. In simulator: gap in logic means nat vent activates even with breached ceiling."
+    "summary": "When startup has indoor exceeding comfort_cool, the archetype-aware ceiling gate (Issue #392 Fix 1) blocks nat-vent (re)activation for the default/HVAC-fan archetype used here — the single-engine harness now exercises this directly since the gate lives in production's reactivation gates, not a separate simulator-only check.",
+    "observed_behavior": "startup with indoor 76F > comfort_cool 74F, sensors open — nat-vent activation is blocked; HVAC pauses instead",
+    "expected_behavior": "Ceiling gate blocks nat-vent activation because indoor 76F > ceiling_threshold 74F; door/window pause path applies instead."
   },
   "config": {
     "comfort_heat": 70,
@@ -34,20 +34,19 @@
       "time": "2026-05-23T08:05:00",
       "type": "sensor_open",
       "entity": "binary_sensor.living_room_window",
-      "note": "Sensor opens: outdoor 68F < indoor 76F, indoor > comfort_heat 70F. In production, ceiling breach would block nat vent. Simulator activates it (gap in ceiling guard)."
+      "note": "Sensor opens: outdoor 68F < indoor 76F, indoor > comfort_heat 70F, but indoor 76F > ceiling_threshold 74F. Issue #392 Fix 1: the reactivation gate now blocks nat-vent activation in this case for the default/HVAC-fan archetype — production pauses instead."
     }
   ],
   "assertions": [
     {
       "at": "2026-05-23T08:01:00",
       "expect": "classification_applied",
-      "reason": "Classification applied. In production, comfort ceiling guard would override."
+      "reason": "Classification applied. Ceiling gate governs the subsequent sensor-open event."
     },
     {
       "at": "2026-05-23T08:05:00",
-      "expect": "natural_ventilation",
-      "simulator_support": false,
-      "reason": "Simulator activates nat vent (no ceiling guard logic). In production: ceiling guard would block because indoor 76F > comfort_cool 74F. Documents gap: simulator needs ceiling guard to block nat vent activation when indoor exceeds comfort_cool."
+      "expect": "paused",
+      "reason": "Indoor 76F > ceiling_threshold 74F blocks nat-vent (re)activation (Issue #392 Fix 1) — HVAC pauses for the open sensor instead. This closes the gap this scenario originally documented: pre-#392, no reactivation gate checked the ceiling, so production and simulator would have diverged. Now production's own gate blocks it, verifiable directly through the single-engine harness."
     }
   ]
 }

--- a/tools/simulations/pending/issue-392-natvent-ceiling-oscillation.json
+++ b/tools/simulations/pending/issue-392-natvent-ceiling-oscillation.json
@@ -1,0 +1,120 @@
+{
+  "name": "issue-392-natvent-ceiling-oscillation",
+  "description": "Reproduces the Issue #392 18:53->19:04 off->cool->off->cool oscillation: WHF nat-vent active, indoor rises above the comfort ceiling while outdoor stays below indoor. A real window close/reopen (18:55/18:56, matching the issue's repeated sensor-open pattern) forces the reactivation gate to re-evaluate while indoor is still past the ceiling -- this is the exact condition that used to trip the old ceiling-based AC escalation. After Fix 1, FAN_MODE_WHOLE_HOUSE ignores the ceiling entirely (direction-only: outdoor < indoor is sufficient) and reactivates cleanly with no cool-mode escalation.",
+  "source": "activity-report",
+  "issue": 392,
+  "notes": [
+    "Occupant impact: without Fix 1, the whole-house fan repeatedly deactivated, HVAC escalated to cool, and the very next sensor-open/grace-recheck immediately reactivated the fan and forced HVAC back to off -- an off->cool->off->cool fight roughly every 5 minutes. The occupant saw contradicting Activity Log entries and the AC cycling for no thermal benefit while a free breeze was already handling the load.",
+    "Config: fan_mode=whole_house_fan, comfort_cool=74F -- matches the issue's real config.",
+    "VERIFIED SCENARIO EFFECTIVENESS (three-exercise protocol, CLAUDE.md): the 18:53/18:58 temp_update assertions alone are NOT sufficient to catch a regression -- check_natural_vent_conditions()'s while-active exit checks (outdoor>indoor direction, outdoor>threshold) never consult _ceiling_threshold() while nat-vent is already running, so those two points pass identically whether or not Fix 1 is present. The REAL teeth of this scenario is the 18:56 assertion: it follows a real sensor_close (18:55, ends the session) then sensor_open (18:56, forces a fresh reactivation-gate evaluation) while indoor (75F) is still above comfort_cool (74F). Verified directly against tools/sim_harness/run_production.py with _ceiling_threshold() monkey-patched back to the pre-#392 blanket rule (comfort_cool with no archetype check): under the bug, the decision at 18:56 is 'paused' (reactivation blocked by the ceiling) and stays 'paused' through 19:00, only reactivating at 19:04 once indoor cooled back to exactly the ceiling value -- under the fix, 18:56 is 'natural_ventilation' immediately. This confirms the scenario would fail if Fix 1 were deleted.",
+    "The 18:55 sensor_close is a REAL window close, not a grace-timer artifact -- production correctly runs the normal Fix C restore path here (fan off, HVAC mode restored to cool), which is expected, intentional behavior distinct from the Issue #392 bug (the bug is the ceiling gate blocking/escalating while the window is OPEN and nat-vent is trying to run, not the normal restore-on-close path).",
+    "Two fan_activated events occur across the run (18:10 initial open, 18:56 after the real close/reopen) -- both are genuine new activations following a real sensor transition, not duplicates within the same tick (which Fix 1c's idempotency guard would collapse if a scenario triggered redundant same-tick reactivation attempts).",
+    "Single-engine harness (Issue #236): this scenario drives tools/sim_harness/ against the REAL production AutomationEngine -- it directly exercises the Issue #392 Fix 1 (_ceiling_threshold archetype awareness at the reactivation gate) and Fix 1b (_whf_owns_hvac choke-point guard preventing any stray 'cool' write while the WHF session is active and the window is open), not a parallel simulator model.",
+    "Two-way alignment check (docs vs production, per CLAUDE.md three-exercise protocol): docs/08-COMPUTATION-REFERENCE.md SS6c/SS9/SS17 (Scribe-owned, updated in the same PR) document _ceiling_threshold()'s archetype-aware behavior and the four reactivation gate sites; this scenario's 18:56 assertion exercises exactly the paused-by-door reactivation gate site documented there.",
+    "User outcome if this scenario fails to catch a regression: the WHF occupant would again see the fan needlessly stop and the AC cycle on while a free breeze was already handling the cooling load, and would see contradicting off->cool->off->cool entries in the Activity Log during any real close/reopen sequence while indoor is above the comfort ceiling.",
+    "Promote to golden/ once reviewed and confirmed by the user per the Golden Simulation Test Policy."
+  ],
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 74,
+    "setback_heat": 60,
+    "setback_cool": 80,
+    "natural_vent_delta": 3.0,
+    "fan_mode": "whole_house_fan",
+    "fan_entity": "fan.whole_house"
+  },
+  "events": [
+    {
+      "time": "2026-07-02T18:00:00",
+      "type": "temp_update",
+      "indoor_f": 72.0,
+      "outdoor_f": 68.0,
+      "note": "Evening: indoor 72F, outdoor 68F -- below comfort_cool ceiling, outdoor well below indoor."
+    },
+    {
+      "time": "2026-07-02T18:01:00",
+      "type": "classification",
+      "day_type": "warm",
+      "hvac_mode": "cool",
+      "windows_recommended": false,
+      "note": "Warm-day classification: hvac_mode=cool (normal daytime baseline before nat-vent takes over)."
+    },
+    {
+      "time": "2026-07-02T18:10:00",
+      "type": "sensor_open",
+      "entity": "binary_sensor.living_room_window",
+      "note": "Window opens. outdoor=68F < indoor=72F, indoor > comfort_heat=68F, outdoor <= threshold 77F. Nat-vent activates, whole-house fan turns on, HVAC suppressed to off (Fix 1b)."
+    },
+    {
+      "time": "2026-07-02T18:53:00",
+      "type": "temp_update",
+      "indoor_f": 75.0,
+      "outdoor_f": 72.0,
+      "note": "Indoor has drifted up to 75F -- ABOVE comfort_cool=74F ceiling -- while outdoor (72F) is still below indoor and the window stays open. Nat-vent must stay active; the while-active exit checks in check_natural_vent_conditions() are direction/threshold-only and do not consult the ceiling, so this point is a baseline sanity check, not the scenario's primary regression-catching assertion (see notes)."
+    },
+    {
+      "time": "2026-07-02T18:55:00",
+      "type": "sensor_close",
+      "entity": "binary_sensor.living_room_window",
+      "note": "Occupant briefly closes the window. This is a REAL close, not a grace-timer artifact -- production correctly runs the normal Fix C restore path here (fan off, HVAC mode restored to cool), which is expected, intentional behavior distinct from the Issue #392 bug."
+    },
+    {
+      "time": "2026-07-02T18:56:00",
+      "type": "sensor_open",
+      "entity": "binary_sensor.living_room_window",
+      "note": "Window re-opens moments later (matching the issue's repeated sensor-open pattern) -- forces a FRESH reactivation-gate evaluation at indoor=75F > ceiling=74F, outdoor=72F < indoor. This is the scenario's primary regression-catching assertion: under the pre-#392 ceiling rule this reactivation is blocked (falls to 'paused'); under Fix 1 it must reactivate immediately via the direction-only WHF gate."
+    },
+    {
+      "time": "2026-07-02T18:58:00",
+      "type": "temp_update",
+      "indoor_f": 75.0,
+      "outdoor_f": 72.0,
+      "note": "Indoor holds at 75F, outdoor holds at 72F -- still past the ceiling but outdoor still below indoor and window still open. Second oscillation point from the issue's activity log (18:58); confirms the session remains stable after the 18:56 reactivation."
+    },
+    {
+      "time": "2026-07-02T19:04:00",
+      "type": "temp_update",
+      "indoor_f": 74.0,
+      "outdoor_f": 72.0,
+      "note": "Indoor has converged back to the ceiling value; outdoor (72F) still below indoor (74F). Matches the issue's real HA log timestamp (19:03:59-19:04:10 in production, where the AC was incorrectly commanded to cool before the fix). WHF must remain active throughout."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-07-02T18:01:00",
+      "expect": "classification_applied",
+      "reason": "Warm-day classification applied before nat-vent takes over."
+    },
+    {
+      "at": "2026-07-02T18:10:00",
+      "expect": "natural_ventilation",
+      "reason": "Sensor opened with outdoor=68F < indoor=72F and outdoor <= threshold 77F -- nat-vent activates, WHF turns on, HVAC suppressed to off (Fix 1b choke-point guard)."
+    },
+    {
+      "at": "2026-07-02T18:53:00",
+      "expect": "natural_ventilation",
+      "reason": "Baseline sanity check: indoor (75F) above comfort_cool (74F) but window still open and outdoor (72F) still below indoor -- the while-active session must not have exited. (Does not by itself distinguish the archetype-aware ceiling fix -- see 18:56 for the scenario's primary regression-catching assertion.)"
+    },
+    {
+      "at": "2026-07-02T18:56:00",
+      "expect": "natural_ventilation",
+      "reason": "PRIMARY REGRESSION-CATCHING ASSERTION (Issue #392 Fix 1). Window closed then reopened with indoor (75F) still above comfort_cool (74F) -- forces a fresh reactivation-gate evaluation. FAN_MODE_WHOLE_HOUSE's ceiling_threshold is None (direction-only, outdoor 72F < indoor 75F) so reactivation must succeed immediately. Verified: with the pre-#392 blanket ceiling rule, this same event produces 'paused' instead (reactivation blocked until indoor drops back to the ceiling at 19:04) -- confirming this assertion fails if Fix 1 is reverted."
+    },
+    {
+      "at": "2026-07-02T18:58:00",
+      "expect": "natural_ventilation",
+      "reason": "Session remains stable after the 18:56 reactivation -- no flapping back to paused/cool."
+    },
+    {
+      "at": "2026-07-02T19:04:00",
+      "expect": "natural_ventilation",
+      "reason": "Matches the issue's real HA log timestamp where production previously commanded climate.set_hvac_mode('cool') right after a fan reactivation. After the fix, outdoor (72F) is still below indoor (74F) so nat-vent must still be active with no AC escalation."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "WHF nat-vent reactivates cleanly after a real window close/reopen even while indoor exceeds the comfort ceiling, as long as outdoor stays below indoor -- no ceiling-triggered blocking, no cool-mode escalation, no flapping",
+    "observed_behavior": "classification_applied -> natural_ventilation on window open -> natural_ventilation sustained through the 18:53 indoor-above-ceiling condition -> natural_ventilation immediately on the 18:56 reactivation (indoor still above ceiling) -> natural_ventilation sustained through 18:58 and 19:04",
+    "expected_behavior": "FAN_MODE_WHOLE_HOUSE ceiling_threshold is None (Issue #392 Fix 1) -- the ceiling never blocks WHF reactivation while outdoor stays below indoor, even immediately after a real window close/reopen. HVAC must never be commanded to 'cool' while the WHF session is active and the window is open (Fix 1b structural choke-point guarantee) -- a real window close still correctly restores HVAC via the normal Fix C path, which is separate, intentional behavior."
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #392 — a whole-house fan (WHF) and AC could fight each other in a repeating `off→cool→off→cool` loop every ~5 minutes. Also addresses a follow-on request from the same issue: Activity Log fan events now show which fan archetype (`hvac_fan`/`whf`/`both`) actually fired instead of a generic "fan" label.

### Root cause

The ODE ceiling guard applied one blanket "switch to AC once indoor crosses the ceiling" rule to both fan archetypes. That's correct for `FAN_MODE_HVAC` (the blower fan coexists with the compressor — band stays armed). It's wrong for `FAN_MODE_WHOLE_HOUSE`/`both`: a WHF is **mutually exclusive** with AC by construction (`_activate_fan()` forces HVAC off while it runs) and is *physically guaranteed* to keep cooling the house as long as outdoor air stays cooler than indoor — the comfort-ceiling number says nothing about whether it will succeed, only how long it takes. Escalating a WHF session to AC purely because indoor ticked one degree past the ceiling deactivated the fan and forced HVAC to `cool`; the very next reactivation check saw outdoor was still cooler than indoor, turned the WHF back on, and forced HVAC back to `off` — undoing the escalation. Repeat every cycle.

A deeper review (prompted by asking "is WHF/AC exclusion actually guaranteed anywhere, or just by convention?") found it was **not** structurally guaranteed: `apply_classification()`'s normal 30-minute cycle could re-arm HVAC to `cool` while a WHF was actively running, whenever `aggressive_savings` was off (the default) — completely independent of the ceiling guard.

### Changes

- **`_ceiling_threshold()`** is now archetype-aware — returns `None` for `FAN_MODE_WHOLE_HOUSE`/`BOTH` (no ceiling override; governed purely by outdoor/indoor direction) and the existing `comfort_cool`-based value for `FAN_MODE_HVAC`. Mirrored across all 4 nat-vent reactivation gate sites (`handle_door_window_open()`, `check_natural_vent_conditions()` grace re-entry, `nat_vent_temperature_check()` paused reactivation, `_re_pause_for_open_sensor()` — the last of which was also missing its `_apply_nat_vent_hvac_state()` call, fixed alongside).
- **`_whf_owns_hvac()` choke-point guard** inside `_set_hvac_mode()`/`_set_temperature()` — the two functions every HVAC write ultimately reaches — blocks non-`off` writes while a WHF session owns the thermostat, making mutual exclusion structural instead of a per-caller convention. `apply_classification()` now short-circuits for WHF right after arming nat-vent state. Emits `hvac_write_blocked_whf_active` when a write is blocked (visible in the Activity Log).
- **Idempotency guards** on `_activate_fan()`/`_deactivate_fan()` — no-op with a debug log if already in the target state, so independently-triggered handlers reaching the same conclusion moments apart no longer each re-execute the full activation sequence (this was the literal source of the "multiple decisions, last one wins" appearance in the original log).
- **`self._decision_lock`** (asyncio.Lock) serializes the six automation entry-point methods (`apply_classification`, `handle_door_window_open`, `handle_all_doors_windows_closed`, `check_natural_vent_conditions`, `_re_pause_for_open_sensor`, `nat_vent_temperature_check`) so independently-triggered handlers can no longer interleave on shared engine state. Verified no cross-calls exist between the six (no deadlock risk), so a direct lock wrap was used — no `_impl` extraction needed.
- **`_fan_running` property** replaces scattered `_fan_active or _natural_vent_active` OR-checks (small readability cut identified during an ontology/shaping review — see "Deferred work" below).
- **Fan-archetype Activity Log labels**: `fan_activated`/`fan_deactivated`/`fan_manual_override`/`fan_cancel`/`nat_vent_fan_on`/`nat_vent_fan_off` renderers now show `hvac_fan`/`whf`/`both` instead of generic `fan`.
- **Regression found and fixed during testing** (not part of the original design): `_deactivate_fan()` was clearing `_pre_fan_hvac_mode` *after* calling `_set_hvac_mode()` to restore it, so the new choke-point guard saw the WHF session as still "owning" the thermostat and silently blocked its own restore write. Fixed by reordering — clear before the write, not after.

### Golden scenario changes (explicit user review, not unilateral)

5 locked golden scenarios needed updates, all reviewed and confirmed by the maintainer before editing, per this repo's Golden Simulation Test Policy:
- 4 scenarios (`nat-vent-evening-activation`, `2026-03-28-overnight`, `nat-vent-indoor-hot-outdoor-near-comfort`, `nat-vent-outdoor-rises-above-indoor-exit`) incidentally set `indoor > comfort_cool` while testing unrelated directional/hysteresis/exit behavior — `comfort_cool` was raised in each config to preserve original test intent now that the ceiling gate applies.
- 1 scenario (`startup_indoor_above_cool_nat_vent_not_running`) documented a known pre-#392 gap in its own text (`simulator_support: false`, "production would block this, simulator can't verify"). This fix closes that gap — updated to assert `paused` and dropped the now-stale flag.

All 5 re-signed via `python tools/simulate.py --sign`, `--check-integrity` clean.

New scenario `tools/simulations/pending/issue-392-natvent-ceiling-oscillation.json` reproduces the original oscillation directly and was mutation-tested (temporarily reverting `_ceiling_threshold()`'s archetype-awareness) to confirm it's a real regression-catcher, not a tautology. Left in `pending/`, not promoted to `golden/` — that's a separate future decision.

### Deferred (tracked separately)

An ontology review during planning surfaced that fan/HVAC-suppression state (`_natural_vent_active`, `_fan_active`, `_pre_fan_hvac_mode`, etc.) is scattered across 20+ mutation sites as loose engine attributes rather than owned by a single object — the repeated pattern of "is this invariant actually enforced anywhere?" → "no, only by convention" across this issue's four root causes is the signature of a missing `FanSession` type. Extracting that is real surgery best done as its own reviewable change, not bundled into this bugfix — tracked in #393. `_whf_owns_hvac()` and `_fan_running` are left as explicit seeds of that future object.

## Test plan

- [x] `pytest tests/ -q` — 2952 passed, 0 failures
- [x] `ruff check` / `ruff format` — clean
- [x] `python tools/simulate.py` — 50/50 golden scenarios pass
- [x] `python tools/simulate.py --check-integrity` — clean
- [x] `python tools/simulate.py --pending -v` — 5/5 pass, including the new #392 scenario
- [x] Independent Opus verification pass: re-read the full diff, independently re-traced the deadlock-safety claim across all 6 lock-wrapped methods, independently verified the `_deactivate_fan()` regression fix, empirically re-ran the mutation test on the new golden scenario, re-ran the entire verification suite from scratch — recommendation: **GO**
- [x] `pytest tests/test_version_sync.py` — passes (0.4.56)