### PR TITLE
Fix #396: add diagnostics for startup-coalescing hang after #392

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.4.57] — 2026-07-02
+
+- Fix #396: Added diagnostics to pinpoint a startup-coalescing regression introduced by #392's automation decision lock — after that fix, the status card could show "waiting for coalescing" indefinitely after a restart, with no way to tell what was stuck. The decision lock now tracks and logs which method holds it and for how long, with checkpoint logging through the coalesce call chain and a new `decision_lock_holder` / `decision_lock_held_seconds` status field. This is diagnostics only — the underlying hang itself is not yet confirmed fixed; the next occurrence will name the exact stuck step.
+
 ## [0.4.56] — 2026-07-02
 
 - Fix #392: Whole-house fan (WHF) and AC could fight each other in a repeating off→cool→off→cool loop roughly every 5 minutes — the ODE ceiling guard applied the same "switch to AC once indoor crosses the ceiling" rule to both fan archetypes, but a WHF is mutually exclusive with AC and physically guaranteed to keep cooling the house as long as outdoor air is cooler than indoor, so the ceiling number never applied to it. The ceiling check is now archetype-aware, HVAC writes are structurally blocked while a WHF session owns the thermostat (previously only enforced by convention), fan activation/deactivation are now idempotent, and automation decisions are serialized so independently-triggered handlers can no longer race on shared state.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -398,6 +398,13 @@ class AutomationEngine:
         # six methods calls another of the six directly in the same stack, so a plain
         # `async with self._decision_lock:` wrap is safe — no `_impl` extraction needed).
         self._decision_lock = asyncio.Lock()
+        # Issue #396: holder tracking so a stuck/slow lock is diagnosable from logs alone —
+        # the #392 lock shipped with WARNING-level logging for the contended-and-blocked case
+        # (hvac_write_blocked_whf_active) but nothing for "a method is waiting on this lock and
+        # it isn't coming back," which is the failure mode that actually occurred. Set
+        # immediately after acquiring, cleared in a finally immediately before release.
+        self._decision_lock_holder: str | None = None
+        self._decision_lock_held_since: datetime | None = None
 
         # Dry-run mode: when True, all service calls are logged but skipped
         self.dry_run: bool = False
@@ -1018,6 +1025,44 @@ class AutomationEngine:
         )
         self._start_grace_period("manual", trigger="override_confirmed")
 
+    @contextlib.asynccontextmanager
+    async def _decision_pass(self, method_name: str):
+        """Acquire ``self._decision_lock`` with wait/hold instrumentation (Issue #396).
+
+        Logs when a method starts waiting on the lock and how long it waited once
+        acquired, and tracks who currently holds it (`_decision_lock_holder` /
+        `_decision_lock_held_since`) so a stuck or slow lock is diagnosable from logs
+        alone instead of requiring another multi-hour investigation.
+        """
+        _wait_start = dt_util.now()
+        if self._decision_lock.locked():
+            _LOGGER.debug(
+                "[decision-lock] %s: waiting — currently held by %s since %s",
+                method_name,
+                self._decision_lock_holder,
+                self._decision_lock_held_since,
+            )
+        async with self._decision_lock:
+            _wait_seconds = (dt_util.now() - _wait_start).total_seconds()
+            self._decision_lock_holder = method_name
+            self._decision_lock_held_since = dt_util.now()
+            _LOGGER.debug(
+                "[decision-lock] %s: acquired (waited %.3fs)",
+                method_name,
+                _wait_seconds,
+            )
+            try:
+                yield
+            finally:
+                _held_seconds = (dt_util.now() - self._decision_lock_held_since).total_seconds()
+                _LOGGER.debug(
+                    "[decision-lock] %s: releasing (held %.3fs)",
+                    method_name,
+                    _held_seconds,
+                )
+                self._decision_lock_holder = None
+                self._decision_lock_held_since = None
+
     async def apply_classification(
         self,
         classification: DayClassification,
@@ -1039,7 +1084,7 @@ class AutomationEngine:
                 to evaluate the pre-cool achievement gate (Issue #295). When
                 None the achievement check is skipped for this cycle.
         """
-        async with self._decision_lock:
+        async with self._decision_pass("apply_classification"):
             self._current_classification = classification
 
             if self._manual_override_active:
@@ -1767,7 +1812,7 @@ class AutomationEngine:
 
         Called by the coordinator after the debounce period.
         """
-        async with self._decision_lock:
+        async with self._decision_pass("handle_door_window_open"):
             if self._paused_by_door:
                 return  # Already paused
 
@@ -1960,7 +2005,7 @@ class AutomationEngine:
 
     async def handle_all_doors_windows_closed(self) -> None:
         """Resume HVAC after all monitored doors/windows are closed."""
-        async with self._decision_lock:
+        async with self._decision_pass("handle_all_doors_windows_closed"):
             was_nat_vent = self._natural_vent_active
             was_paused = self._paused_by_door
             if self._emit_event_callback:
@@ -2047,7 +2092,7 @@ class AutomationEngine:
         Called by coordinator on each _async_update_data when sensors are open.
         Mirrors the monitoring logic in tools/simulate.py ClimateSimulator.
         """
-        async with self._decision_lock:
+        async with self._decision_pass("check_natural_vent_conditions"):
             if not (self._paused_by_door or self._natural_vent_active):
                 # Comfort-ceiling override (Issue #134): if grace is active and indoor has
                 # risen above comfort_cool, allow re-evaluation so nat-vent can engage.
@@ -2364,7 +2409,7 @@ class AutomationEngine:
         maintained (restore_hvac=False). When indoor warms back to (midpoint + hysteresis)
         the fan re-engages, subject to the outdoor-warm guard.
         """
-        async with self._decision_lock:
+        async with self._decision_pass("nat_vent_temperature_check"):
             if not self._natural_vent_active:
                 return
 
@@ -2887,7 +2932,7 @@ class AutomationEngine:
 
     async def _re_pause_for_open_sensor(self) -> None:
         """Re-pause HVAC because a sensor is still open when grace expired."""
-        async with self._decision_lock:
+        async with self._decision_pass("_re_pause_for_open_sensor"):
             if self._is_within_planned_window_period():
                 _LOGGER.info(
                     "Skipping re-pause — within planned window period (windows recommended)",

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,19 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.56"
+VERSION = "0.4.57"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.57": [
+        "Fix #396: Added diagnostics to pinpoint a startup-coalescing regression introduced by"
+        " #392's automation decision lock — after that fix, the status card could show 'waiting"
+        " for coalescing' indefinitely after a restart, with no way to tell what was stuck. The"
+        " decision lock now tracks and logs which method holds it and for how long, with"
+        " checkpoint logging through the coalesce call chain and a new decision_lock_holder /"
+        " decision_lock_held_seconds status field — the next occurrence will name the exact stuck"
+        " step in the logs and dashboard instead of another blind investigation. This is"
+        " diagnostics only; the underlying hang itself is not yet confirmed fixed.",
+    ],
     "0.4.56": [
         "Fix #392: Whole-house fan (WHF) and AC could fight each other — the ODE ceiling guard"
         " applied the same 'switch to AC once indoor crosses the ceiling' rule to both fan types,"
@@ -647,6 +657,34 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    396: {
+        "version_fixed": "0.4.57",
+        "title": (
+            "Startup coalescing hangs indefinitely after #392's decision lock"
+            " — diagnostics only, root cause not yet confirmed"
+        ),
+        "scope_covered": (
+            "automation.py: added _decision_pass(), an async context manager wrapping all 6"
+            " decision-lock entry points (apply_classification, handle_door_window_open,"
+            " handle_all_doors_windows_closed, check_natural_vent_conditions,"
+            " _re_pause_for_open_sensor, nat_vent_temperature_check). Tracks"
+            " _decision_lock_holder (method name) and _decision_lock_held_since (timestamp),"
+            " logs DEBUG on wait-start/acquire/release with wait and hold durations."
+            " coordinator.py: added '[coalesce-diag]' DEBUG checkpoint logging through the full"
+            " suspect call chain in _async_update_data() and _do_startup_coalesce() — before/after"
+            " every automation_engine call and the coalesce condition check's actual boolean"
+            " values — plus new decision_lock_holder / decision_lock_held_seconds fields on the"
+            " status API alongside startup_coalesce_active, so a stuck lock is visible on the"
+            " dashboard, not just in backend logs."
+        ),
+        "scope_not_covered": (
+            "This is diagnostics only — no behavior change, and the actual root cause of the"
+            " coalescing hang is NOT yet confirmed or fixed. The next occurrence (deliberately"
+            " reproduced by restarting HA after this deploys) will show, via the new checkpoint"
+            " logs and decision_lock_holder status field, exactly which await never returns. The"
+            " real fix is a follow-up once that evidence is in hand — see Issue #396."
+        ),
+    },
     392: {
         "version_fixed": "0.4.56",
         "title": "Whole-house fan (WHF) and AC could fight each other — repeating off→cool→off→cool oscillation",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1285,7 +1285,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     nat_vent_threshold,
                 )
                 first_sensor = open_sensors[0]
+                _LOGGER.debug("[coalesce-diag] before handle_door_window_open(%s)", first_sensor)
                 await self.automation_engine.handle_door_window_open(first_sensor)
+                _LOGGER.debug("[coalesce-diag] after handle_door_window_open(%s)", first_sensor)
                 nat_vent_activated = True
             else:
                 _LOGGER.info(
@@ -1306,11 +1308,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 c.hvac_mode,
             )
             indoor_temp = self._get_indoor_temp()
+            _LOGGER.debug("[coalesce-diag] before apply_classification() [coalesce path]")
             await self.automation_engine.apply_classification(
                 c,
                 predicted_indoor=self._last_predicted_indoor,
                 indoor_temp=indoor_temp,
             )
+            _LOGGER.debug("[coalesce-diag] after apply_classification() [coalesce path]")
             hvac_commanded = True
 
         # Issue #327: Startup fan reconciliation.
@@ -1329,12 +1333,14 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             _fan_mode_reconcile = "unknown"
             _hvac_action_reconcile = "unknown"
             _thermostat_fan_running = False
+        _LOGGER.debug("[coalesce-diag] before reconcile_fan_on_startup()")
         await self.automation_engine.reconcile_fan_on_startup(
             indoor=indoor,
             outdoor=outdoor,
             thermostat_fan_running=_thermostat_fan_running,
             any_sensor_open=self._any_sensor_open(),
         )
+        _LOGGER.debug("[coalesce-diag] after reconcile_fan_on_startup()")
 
         self._emit_event(
             "startup_coalesced",
@@ -1351,6 +1357,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch forecast and update classification (runs every 30 min)."""
         # Re-resolve group membership in case it changed
+        _LOGGER.debug("[coalesce-diag] _async_update_data: enter")
         new_resolved = self._resolve_monitored_sensors()
         if set(new_resolved) != set(self._resolved_sensors):
             _LOGGER.info("Door/window sensor membership changed; updating listeners")
@@ -1358,7 +1365,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             self._resolved_sensors = new_resolved
             self._subscribe_door_window_listeners()
 
+        _LOGGER.debug("[coalesce-diag] _async_update_data: before _get_forecast()")
         forecast = await self._get_forecast()
+        _LOGGER.debug("[coalesce-diag] _async_update_data: after _get_forecast() — forecast=%s", forecast is not None)
         self._hourly_forecast_temps = await self._get_hourly_forecast_data()
         self.automation_engine._hourly_forecast_temps = self._hourly_forecast_temps
         if forecast:
@@ -1477,8 +1486,17 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                         # Flag is set inside the method after completion
 
             # Bug 1 (Issue #321): Startup coalescing — evaluate state at t+5min instead of detecting override at t+30s
+            _LOGGER.debug(
+                "[coalesce-diag] coalesce condition check: startup_timer_fired=%s"
+                " startup_coalesce_active=%s current_classification=%s",
+                self._startup_timer_fired,
+                self._startup_coalesce_active,
+                self._current_classification is not None,
+            )
             if self._startup_timer_fired and self._startup_coalesce_active and self._current_classification:
+                _LOGGER.debug("[coalesce-diag] before _do_startup_coalesce()")
                 await self._do_startup_coalesce()
+                _LOGGER.debug("[coalesce-diag] after _do_startup_coalesce()")
 
             # Periodic daily solar phase re-fit (Issue #310): run once per calendar day
             # using only the last 2 days of chart_log (backfill=False). Stamping
@@ -1558,11 +1576,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     _ae.clear_manual_override(reason="stuck_grace_recovery")
                     self._emit_event("stuck_grace_recovered", {"grace_end_time": _ae._grace_end_time})
 
+            _LOGGER.debug("[coalesce-diag] before apply_classification() [regular cycle path]")
             await self.automation_engine.apply_classification(
                 self._current_classification,
                 predicted_indoor=self._last_predicted_indoor,
                 indoor_temp=self._get_indoor_temp(),
             )
+            _LOGGER.debug("[coalesce-diag] after apply_classification() [regular cycle path]")
 
             # If the day type changed since the briefing was generated,
             # regenerate the briefing text without re-sending notifications (Issue #78).
@@ -1624,10 +1644,14 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
             # Re-evaluate natural vent conditions while any sensor is open
             if self._any_sensor_open():
+                _LOGGER.debug("[coalesce-diag] before check_natural_vent_conditions()")
                 await self.automation_engine.check_natural_vent_conditions()
+                _LOGGER.debug("[coalesce-diag] after check_natural_vent_conditions()")
 
             # Save state after classification update
+            _LOGGER.debug("[coalesce-diag] before _async_save_state()")
             await self._async_save_state()
+            _LOGGER.debug("[coalesce-diag] after _async_save_state() — _async_update_data exiting normally")
         else:
             # Weather entity not ready yet (common after HA restart).
             # Retry with gentle backoff: 30s → 60s → 120s → 240s → 480s
@@ -6116,6 +6140,15 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     (dt_util.parse_datetime(self._startup_coalesce_expiry) - dt_util.now()).total_seconds(),
                 )
                 if self._startup_coalesce_expiry and self._startup_coalesce_active
+                else None
+            ),
+            # Issue #396: surface decision-lock holder so a stuck coalesce/decision pass is
+            # diagnosable from the dashboard, not just backend logs — "waiting on X since Y"
+            # instead of a generic "waiting for coalescing" with no further detail.
+            "decision_lock_holder": ae._decision_lock_holder,
+            "decision_lock_held_seconds": (
+                (dt_util.now() - ae._decision_lock_held_since).total_seconds()
+                if ae._decision_lock_held_since is not None
                 else None
             ),
             # Bug 2 (Issue #321): stuck-grace detection for debug pane

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.56"
+  "version": "0.4.57"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -1640,7 +1640,40 @@ async def apply_classification(self, classification, predicted_indoor=None, indo
 
 **What this does NOT change:** this lock does not introduce new automation behavior. The semantic fixes (§6c archetype-aware ceiling, above choke-point guard, §9f idempotency) already make each individual decision correct and idempotent; the lock ensures those correct decisions are evaluated one at a time against a consistent snapshot of engine state, instead of several handlers reading/writing overlapping state concurrently. In a well-behaved system where the semantic fixes hold, the lock should rarely be contended — its purpose is to make the *absence* of interleaving-driven chaos structurally guaranteed rather than incidentally true.
 
-**Test coverage:** concurrency test using `asyncio.gather()` to invoke two of the six entry points "concurrently" against a shared engine instance instrumented to record enter/exit order, asserting non-overlapping execution. Located in `tests/test_nat_vent_activation.py` as of this doc pass (exact function name pending — Craftsman work in `tests/` is running in parallel with this docs pass).
+**Test coverage:** `tests/test_nat_vent_activation.py::TestDecisionLockConcurrency::test_two_entry_points_do_not_interleave` — `asyncio.gather()` invokes two of the six entry points "concurrently" against a shared engine instance instrumented to record enter/exit order, asserting non-overlapping execution.
+
+#### Holder tracking — diagnosing a stuck lock (Issue #396)
+
+This lock shipped with WARNING-level logging for the *contended-and-blocked* case
+(`hvac_write_blocked_whf_active`, §9 above) but nothing for "a method is waiting on this lock and
+it isn't coming back" — the exact failure mode that caused startup coalescing to hang indefinitely
+in production shortly after this lock was deployed (root cause not yet confirmed as of this doc
+pass; see Issue #396). That gap is closed by `_decision_pass()`, an async context manager every one
+of the six entry points now goes through instead of a bare `async with self._decision_lock:`:
+
+```python
+async def apply_classification(self, ...) -> None:
+    async with self._decision_pass("apply_classification"):
+        ...  # entire method body, unchanged
+```
+
+`_decision_pass()`:
+- Logs (DEBUG) when a method starts waiting on an already-held lock, naming the current holder.
+- Sets `self._decision_lock_holder` (method name) and `self._decision_lock_held_since` (timestamp)
+  immediately after acquiring — cleared in a `finally` immediately before release, so this is
+  accurate even on exception paths.
+- Logs (DEBUG) the wait duration on acquire and the hold duration on release.
+
+`_decision_lock_holder` / `_decision_lock_held_since` are also surfaced on the coordinator status
+API (`coordinator.py`, alongside `startup_coalesce_active`) as `decision_lock_holder` /
+`decision_lock_held_seconds`, so a stuck lock is visible from the dashboard — "waiting on
+`check_natural_vent_conditions`, held 340s" — instead of a generic "waiting for coalescing" with no
+further detail. This is purely additive observability; it does not change which method acquires the
+lock or when.
+
+**Test coverage:** `tests/test_nat_vent_activation.py::TestDecisionLockHolderTracking` — holder set
+during a pass and cleared after, cleared even when the pass body raises, and a second (waiting) pass
+can see the first pass's holder name while blocked.
 
 ---
 

--- a/tests/test_nat_vent_activation.py
+++ b/tests/test_nat_vent_activation.py
@@ -19,6 +19,8 @@ import sys
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from custom_components.climate_advisor.automation import AutomationEngine
 from custom_components.climate_advisor.classifier import DayClassification
 from custom_components.climate_advisor.const import (
@@ -1953,6 +1955,10 @@ class TestDecisionLockConcurrency:
                 self._name_source.append(f"exit:{id(asyncio.current_task())}")
                 real_lock.release()
 
+            def locked(self) -> bool:
+                """Proxy to the real lock — Issue #396's _decision_pass() diagnostic checks this."""
+                return real_lock.locked()
+
         engine._decision_lock = _TrackingLock(order)
 
         async def _run_both():
@@ -1975,3 +1981,70 @@ class TestDecisionLockConcurrency:
             f"Second task's enter must be immediately followed by its own exit; got: {order}"
         )
         assert first_task_id != second_task_id, "The two tasks must be distinct"
+
+
+class TestDecisionLockHolderTracking:
+    """Issue #396: the #392 decision lock shipped with no observability for the
+    "something is holding this lock and it isn't coming back" failure mode — the
+    exact case that caused startup coalescing to hang indefinitely in production.
+    _decision_lock_holder / _decision_lock_held_since must be set while a decision
+    pass owns the lock and cleared afterward, including on exception paths, so a
+    stuck lock is diagnosable from logs/status API alone next time.
+    """
+
+    def test_holder_set_during_pass_and_cleared_after(self):
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
+        assert engine._decision_lock_holder is None
+        assert engine._decision_lock_held_since is None
+
+        observed_holder = {}
+
+        async def _run():
+            async with engine._decision_pass("test_method"):
+                observed_holder["holder"] = engine._decision_lock_holder
+                observed_holder["held_since"] = engine._decision_lock_held_since
+
+        asyncio.run(_run())
+
+        assert observed_holder["holder"] == "test_method"
+        assert observed_holder["held_since"] is not None
+        # Cleared after the pass completes.
+        assert engine._decision_lock_holder is None
+        assert engine._decision_lock_held_since is None
+
+    def test_holder_cleared_even_when_pass_body_raises(self):
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
+
+        async def _run():
+            with pytest.raises(ValueError):
+                async with engine._decision_pass("test_method_raises"):
+                    raise ValueError("boom")
+
+        asyncio.run(_run())
+
+        assert engine._decision_lock_holder is None
+        assert engine._decision_lock_held_since is None
+
+    def test_second_pass_reports_first_as_holder_while_waiting(self):
+        """Regression guard for the exact log line #396's diagnostics rely on: a
+        method waiting on an already-held lock must be able to see who holds it.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
+        seen_holder_while_waiting = {}
+
+        async def _first_pass_holds_briefly():
+            async with engine._decision_pass("first_method"):
+                await asyncio.sleep(0.05)
+
+        async def _second_pass_checks_holder():
+            await asyncio.sleep(0.01)  # ensure first pass has acquired by now
+            seen_holder_while_waiting["holder"] = engine._decision_lock_holder
+            async with engine._decision_pass("second_method"):
+                pass
+
+        async def _run_both():
+            await asyncio.gather(_first_pass_holds_briefly(), _second_pass_checks_holder())
+
+        asyncio.run(_run_both())
+
+        assert seen_holder_while_waiting["holder"] == "first_method"


### PR DESCRIPTION
## Summary

After deploying #392's decision lock, the status card could show "waiting for coalescing" indefinitely after an HA restart with no way to tell why. Live logs confirmed `_do_startup_coalesce()` never completes a second time (its own first, unconditional log line never reappears), but static reading of the six lock-wrapped methods and the coordinator's call chain could not pinpoint with certainty which specific `await` never returns.

**This is diagnostics only, not a behavior fix.** Shipping a fix without knowing the actual cause would be a guess dressed up as a fix — the right move is to add enough observability to know for certain, then fix the confirmed cause in a follow-up.

## Changes

- `automation.py`: `_decision_pass()`, an async context manager wrapping all 6 decision-lock entry points (`apply_classification`, `handle_door_window_open`, `handle_all_doors_windows_closed`, `check_natural_vent_conditions`, `_re_pause_for_open_sensor`, `nat_vent_temperature_check`). Tracks `_decision_lock_holder` (method name) and `_decision_lock_held_since` (timestamp), logs wait-start/acquire/release with durations.
- `coordinator.py`: `"[coalesce-diag]"` checkpoint DEBUG logging through the full suspect call chain in `_async_update_data()` and `_do_startup_coalesce()` — before/after every `automation_engine` call, plus the coalesce condition's actual boolean values (`_startup_timer_fired`, `_startup_coalesce_active`, `_current_classification is not None`).
- New `decision_lock_holder` / `decision_lock_held_seconds` fields on the coordinator status API, alongside the existing `startup_coalesce_active`, so a stuck lock is visible on the dashboard, not just in backend logs.
- This closes a standing observability gap, not just today's incident: the #392 lock shipped with WARNING-level logging for the *contended-and-blocked* case (`hvac_write_blocked_whf_active`) but nothing for "a method is waiting on this lock and it isn't coming back," which is exactly the silent-hang case that occurred.

## Next step

Deploy this, restart HA, and read the new `[coalesce-diag]` / `decision-lock` logs — they will name the exact stuck step with certainty. The real fix follows in #396 once that evidence is in hand.

## Test plan

- [x] `pytest tests/ -q` — 2955 passed (3 new tests for `_decision_pass()` holder tracking: set-during-pass, cleared-on-exception, visible-while-waiting)
- [x] `ruff check` / `ruff format` — clean
- [x] `python tools/simulate.py` — 50/50 golden scenarios pass, `--check-integrity` clean (no behavior change, as expected — this is pure instrumentation)
- [x] `pytest tests/test_version_sync.py` — passes (0.4.57)