### PR TITLE
Fix #415: Status card nat-vent target reappears (71°F) desynced from cycling band

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.66"
+VERSION = "0.4.67"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.67": [
+        "Fix #415: the Status card no longer shows a stale nat-vent target temperature"
+        " (e.g. 'nat-vent (target 71°F)') that could disagree with the correct cycling"
+        " band shown right below it (e.g. '64°F–66°F'). The status string is cached for"
+        " up to 30 minutes while the cycling band is recomputed live on every dashboard"
+        " load, so the two could drift apart across a sleep-window transition. The status"
+        " string now just says 'nat-vent' — the live cycling band is the only place the"
+        " temperature is shown.",
+    ],
     "0.4.66": [
         "Fix #413: restart-cause diagnostics (added in #403) now correctly classify real HA"
         " restarts and deploys as 'version_changed' or 'user_restart' instead of always"
@@ -740,6 +749,29 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    415: {
+        "version_fixed": "0.4.67",
+        "title": "Status card nat-vent target reappears (71°F) desynced from cycling band",
+        "scope_covered": (
+            "coordinator.py: _compute_automation_status()'s nat-vent branch no longer embeds"
+            " a numeric target — it returns the plain string 'nat-vent'. Root cause: that"
+            " string is cached for up to update_interval (30 min) while api.py independently"
+            " recomputes compute_nat_vent_cycling_band() live on every dashboard poll to"
+            " populate the cycling-band line, so the two could diverge whenever a sleep-window"
+            " boundary fell between the last coordinator refresh and the current poll. Every"
+            " prior fix (#374, #400, #402, #407, #409) corrected which formula each call site"
+            " used but left both independently-timed call sites in place, so the divergence was"
+            " structurally guaranteed to recur. Removing the number from automation_status"
+            " means there is nothing left to desync — the live cycling-band line is now the"
+            " sole place this temperature is shown."
+        ),
+        "scope_not_covered": (
+            "compute_nat_vent_cycling_band() itself and the 30-minute coordinator update_interval"
+            " are unchanged — this fix removes the redundant, cache-timing-vulnerable display of"
+            " the same number, it does not change how or how often the underlying value is"
+            " computed."
+        ),
+    },
     413: {
         "version_fixed": "0.4.66",
         "title": "Restart-cause classification (#403) always showed 'unknown' on real HA restarts/deploys",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -5510,18 +5510,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         if self.automation_engine._is_within_planned_window_period() and self._any_sensor_open():
             return "windows open (as planned)"
         if self.automation_engine.natural_vent_active:
-            # Bug 3 (Issue #321): surface cycling target in status for at-a-glance visibility.
-            # Issue #407: was hardcoded to the flat daytime comfort-band midpoint, ignoring the
-            # sleep window, and never migrated to compute_nat_vent_cycling_band() (the Issue #402
-            # follow-up single source of truth for this exact value) — see that method's docstring
-            # for the fix-one-duplicate-miss-the-sibling history this repeats (#374, #400, #402).
-            # Issue #409: dropped the "windows open · " prefix — natural_vent_active does not
-            # imply a sensor is open (it can activate on temperature/idle-HVAC conditions alone,
-            # see automation.py's idle-reeval path, and door/window sensors are optional config),
-            # and real window state is already shown by the dedicated Doors/Windows status card.
-            # Restating it here was both potentially inaccurate and duplicative.
-            _nt = self.compute_nat_vent_cycling_band()["nat_vent_target"]
-            return f"nat-vent (target {_nt:.0f}°F)"
+            # Issue #415: no numeric target here. This string is cached for up to
+            # update_interval (30 min), but api.py recomputes compute_nat_vent_cycling_band()
+            # live on every dashboard poll for the cycling-band line — so a number embedded
+            # here can silently drift from the live band across a sleep-window boundary
+            # (e.g. cached "71°F" vs. live "64°F–66°F"). The live band is the only place
+            # this temperature is shown now; don't reintroduce it here.
+            return "nat-vent"
         if self.automation_engine.is_paused_by_door:
             if self._occupancy_mode == OCCUPANCY_AWAY:
                 return "paused — away (setback deferred: windows open)"

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.66"
+  "version": "0.4.67"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -2064,6 +2064,8 @@ Once `_natural_vent_active = True`, the fan does not simply stay on until the se
 
 *Sleep-window note:* The sleep target is the sleep floor plus one hysteresis step, so the fan cools the home to `sleep_heat` (cycling off there) and then maintains it by re-activating at `sleep_heat + 2 × hysteresis`. The hard-exit threshold (`sleep_heat − hysteresis`) sits one step below the cycling-off point, so the session ends only if indoor temperature falls past `sleep_heat` — i.e., after the fan has already paused.
 
+*Dashboard display note (Issue #415):* `nat_vent_target` is used to compute the cycling band shown on the Status card, but is never embedded as a number in the `automation_status` string itself. `automation_status` is cached for up to `update_interval` (30 min), while `api.py` recomputes `compute_nat_vent_cycling_band()` live on every dashboard poll — so a number embedded in the cached string can drift from the live band across a sleep-window boundary. Do not reintroduce a numeric target into `automation_status`; the live cycling-band line is the sole place this temperature is displayed.
+
 **Fan cycles off (indoor ≤ off_threshold):**
 - `_fan_active` is set to `False`; fan deactivated.
 - `_natural_vent_active` remains `True` — the session is still active.

--- a/tests/test_door_window.py
+++ b/tests/test_door_window.py
@@ -987,7 +987,7 @@ class TestAutomationStatusPausedWithOccupancy:
         if within_planned_window and any_sensor_open:
             return "windows open (as planned)"
         if natural_vent_active:
-            return "windows open · nat-vent (target 73°F)"
+            return "nat-vent"
         if is_paused_by_door:
             if occupancy_mode == OCCUPANCY_AWAY:
                 return "paused — away (setback deferred: windows open)"

--- a/tests/test_nat_vent_dashboard_target.py
+++ b/tests/test_nat_vent_dashboard_target.py
@@ -188,15 +188,15 @@ class TestComputeNatVentCyclingBand:
 
 
 class TestComputeAutomationStatusNatVentTarget:
-    """Issue #407: _compute_automation_status()'s nat-vent branch must call
+    """Issue #415: _compute_automation_status()'s nat-vent branch must never embed a
 
-    compute_nat_vent_cycling_band() — the same single source of truth used by the
-    "Natural Vent" status card — instead of independently recomputing the flat
-    daytime comfort-band midpoint. Before this fix, the main Status card always
-    showed the daytime midpoint (e.g. 71°F) even overnight during the sleep window,
-    contradicting the already-correct Natural Vent card (e.g. 65-66°F), repeating the
-    exact "fix one duplicate implementation, miss the sibling" pattern documented on
-    compute_nat_vent_cycling_band() from #374/#400/#402.
+    numeric target. It is cached for up to update_interval (30 min) while api.py
+    recomputes compute_nat_vent_cycling_band() live on every dashboard poll for the
+    cycling-band line — so a number embedded here can silently drift from the live
+    band across a sleep-window boundary (e.g. cached "71°F" vs. live "64°F–66°F").
+    This repeated the "fix one duplicate implementation, miss the sibling" pattern
+    from #374/#400/#402 because every prior fix (#407, #409) corrected which formula
+    to use rather than removing the second, independently-timed computation.
 
     Issue #409: the "windows open · " prefix was dropped — natural_vent_active does
     not imply a sensor is open, and real window state is already shown by the
@@ -213,22 +213,22 @@ class TestComputeAutomationStatusNatVentTarget:
             "wake_time": "07:00",
         }
 
-    def test_daytime_status_uses_comfort_midpoint(self):
-        """Outside the sleep window, the status string shows the daytime midpoint target."""
+    def test_daytime_status_has_no_numeric_target(self):
+        """Outside the sleep window, the status string is plain "nat-vent"."""
         coord = _make_nat_vent_coord_stub(config=self._config())
 
         # 14:00 — outside the 22:00-07:00 sleep window
         with patch(_PATCH_DT_NOW, return_value=datetime(2026, 7, 2, 14, 0, 0)):
             status = coord._compute_automation_status()
 
-        assert status == "nat-vent (target 71°F)"
+        assert status == "nat-vent"
 
-    def test_sleep_window_status_uses_sleep_heat_not_daytime_midpoint(self):
-        """During the sleep window, the status string must show the sleep-window target
-        (sleep_heat + hysteresis), NOT the daytime comfort-band midpoint.
+    def test_sleep_window_status_has_no_numeric_target(self):
+        """During the sleep window, the status string is also plain "nat-vent" —
 
-        This is the exact regression this bug produced: the Status card previously showed
-        71°F (the daytime midpoint) overnight instead of 66°F (sleep_heat(65) + hysteresis(1)).
+        no number is embedded here at all, so it can never disagree with the live
+        cycling-band line regardless of which side of the sleep-window boundary the
+        coordinator's cached status was last computed on.
         """
         coord = _make_nat_vent_coord_stub(config=self._config())
 
@@ -236,23 +236,30 @@ class TestComputeAutomationStatusNatVentTarget:
         with patch(_PATCH_DT_NOW, return_value=datetime(2026, 7, 2, 2, 0, 0)):
             status = coord._compute_automation_status()
 
-        assert status == "nat-vent (target 66°F)"
+        assert status == "nat-vent"
         assert "71" not in status
+        assert "°F" not in status
 
-    def test_status_and_cycling_band_agree(self):
-        """The target embedded in the status string must equal
+    def test_stale_cached_status_cannot_disagree_with_live_band(self):
+        """Regression guard for the recurring bug: simulate a coordinator whose
 
-        compute_nat_vent_cycling_band()["nat_vent_target"], formatted the same way — a
-        guard against the two ever drifting apart again.
+        automation_status was cached during the daytime (stale, up to 30 min old)
+        while compute_nat_vent_cycling_band() is queried live during the sleep
+        window (as api.py does on every poll). Since automation_status embeds no
+        number, the two can never visibly disagree, no matter how stale the cache is.
         """
         coord = _make_nat_vent_coord_stub(config=self._config())
 
-        with patch(_PATCH_DT_NOW, return_value=datetime(2026, 7, 2, 2, 0, 0)):
-            status = coord._compute_automation_status()
-            band = coord.compute_nat_vent_cycling_band()
+        # Cache automation_status as of 21:59 (still daytime).
+        with patch(_PATCH_DT_NOW, return_value=datetime(2026, 7, 2, 21, 59, 0)):
+            cached_status = coord._compute_automation_status()
 
-        expected = f"nat-vent (target {band['nat_vent_target']:.0f}°F)"
-        assert status == expected
+        # api.py queries the live band 2 minutes later, now inside the sleep window.
+        with patch(_PATCH_DT_NOW, return_value=datetime(2026, 7, 2, 22, 1, 0)):
+            live_band = coord.compute_nat_vent_cycling_band()
+
+        assert cached_status == "nat-vent"
+        assert f"{live_band['nat_vent_target']:.0f}" not in cached_status
 
     def test_status_does_not_claim_windows_open(self):
         """Issue #409: natural_vent_active does not imply a window/door sensor is open

--- a/tests/ui/status-divergence.spec.js
+++ b/tests/ui/status-divergence.spec.js
@@ -99,7 +99,7 @@ test.describe('Natural Vent info merged into Status card (Issue #407, #409)', ()
           outdoor_temp: 65,
           automation_enabled: true,
           occupancy_mode: 'home',
-          automation_status: 'nat-vent (target 71°F)',
+          automation_status: 'nat-vent',
           compliance_score: 1.0,
           nat_vent_active: true,
           nat_vent_ac_assist: false,
@@ -121,7 +121,10 @@ test.describe('Natural Vent info merged into Status card (Issue #407, #409)', ()
     const html = await statusItem.innerHTML();
     expect(html).toContain('70');
     expect(html).toContain('72');
-    expect(html).toContain('71');
+    // Issue #415: automation_status must never embed a numeric target (it's cached for
+    // up to 30 min while the cycling band is recomputed live on every poll, so a number
+    // here can silently drift from the live band across a sleep-window boundary).
+    expect(html).not.toContain('71');
     expect(html).toContain('savings mode');
     // Issue #409: no duplicate naming — "Natural ventilation" must not appear
     // (the concept is named once, as "nat-vent", in automation_status).


### PR DESCRIPTION
## Summary
- `automation_status`'s nat-vent branch was cached for up to 30 min (coordinator `update_interval`) while `api.py` recomputed the cycling band live on every dashboard poll, so the two could disagree across a sleep-window boundary (e.g. cached "71°F" vs. live "64°F–66°F").
- Every prior fix (#374, #400, #402, #407, #409) corrected the formula at one call site but left both independently-timed call sites in place, so the divergence was structurally guaranteed to recur.
- Fix: remove the numeric target from `automation_status` entirely — it now returns plain `"nat-vent"`. The live cycling-band line is the sole place the temperature is shown, so there's nothing left to desync.

## Test plan
- [x] `pytest tests/test_nat_vent_dashboard_target.py tests/test_door_window.py -v` — includes a new regression test simulating a stale (daytime) cached status alongside a live sleep-window band query
- [x] Full suite: `pytest tests/` — 3059 passed
- [x] `python tools/simulate.py` — 51/51 golden scenarios passed
- [x] `pytest tests/test_version_sync.py` — versions in sync (0.4.67)
- [x] ruff check/format clean