### PR TITLE
Fix #505: vacation deep setback armed once at mode-entry, never reapplied

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -1510,9 +1510,13 @@ class AutomationEngine:
             )
 
             # Issue #85: respect occupancy mode — don't overwrite setback with comfort
+            # Issue #505: vacation must actively reapply the deep setback the same way away
+            # does — "deep setback preserved" was never actually guaranteed once a manual
+            # override (or anything else) has moved the thermostat off the setback value.
             if _gate == ScheduledBandGate.DEFER_OCCUPANCY:
                 if self._occupancy_mode == OCCUPANCY_VACATION:
-                    _LOGGER.info("Vacation mode — skipping classification temp change (deep setback preserved)")
+                    _LOGGER.info("Vacation mode — reapplying deep setback instead of comfort temps")
+                    await self.handle_occupancy_vacation()
                     return
                 _LOGGER.info("Away mode — reapplying setback instead of comfort temps")
                 await self.handle_occupancy_away()
@@ -4026,8 +4030,15 @@ class AutomationEngine:
         )
 
         # Issue #85: vacation/away already has a setback — don't override it with sleep temps.
+        # Issue #505: bedtime-specific sleep temps are still skipped, but the setback itself
+        # must be actively reapplied here too — grace expiry landing inside the sleep window
+        # routes here instead of apply_classification(), and the same "already active"
+        # assumption can be false (e.g. a manual override cleared moments earlier).
         if _gate == ScheduledBandGate.DEFER_OCCUPANCY:
-            _LOGGER.info("Bedtime skipped — %s mode (setback already active)", self._occupancy_mode)
+            _LOGGER.info(
+                "Bedtime skipped — %s mode (reapplying setback instead of sleep temps)",
+                self._occupancy_mode,
+            )
             if self._emit_event_callback:
                 self._emit_event_callback(
                     "bedtime_setback_skipped",
@@ -4035,6 +4046,10 @@ class AutomationEngine:
                 )
             if self._today_record is not None:
                 self._today_record.setback_skipped_reason = "occupancy"
+            if self._occupancy_mode == OCCUPANCY_VACATION:
+                await self.handle_occupancy_vacation()
+            else:
+                await self.handle_occupancy_away()
             return
 
         if _gate == ScheduledBandGate.DEFER_OVERRIDE:
@@ -4181,8 +4196,17 @@ class AutomationEngine:
             whf_owns_hvac=self._whf_owns_hvac(),
         )
 
+        # Issue #505: reapply the setback here too, same rationale as apply_classification()/
+        # handle_bedtime() — "already active" is not guaranteed once an override has cleared.
         if _gate == ScheduledBandGate.DEFER_OCCUPANCY:
-            _LOGGER.info("Pre-cool skipped — %s mode (setback already active)", self._occupancy_mode)
+            _LOGGER.info(
+                "Pre-cool skipped — %s mode (reapplying setback instead of pre-cool)",
+                self._occupancy_mode,
+            )
+            if self._occupancy_mode == OCCUPANCY_VACATION:
+                await self.handle_occupancy_vacation()
+            else:
+                await self.handle_occupancy_away()
             return f"skipped: {self._occupancy_mode}"
 
         if _gate == ScheduledBandGate.DEFER_OVERRIDE:

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.26"
+VERSION = "0.5.27"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.27": [
+        "Fix #505: vacation mode's deep energy-saving setback was armed once when you"
+        " turned vacation mode on, and never enforced again for the rest of the trip —"
+        " confirmed against real logs from a 5-day vacation where the home ran at normal"
+        " comfort temperature almost the entire time. A temporary override (e.g. for"
+        " cleaners) that was later cancelled left the thermostat at the override's"
+        " setpoint indefinitely instead of returning to the deep setback, the same way"
+        " away mode already correctly does. Away mode itself, home mode, and guest mode"
+        " were not affected. Also fixed the same gap for the bedtime and pre-cool"
+        " triggers, which had the identical assumption.",
+    ],
     "0.5.26": [
         "Fix #504: a monitored door/window sensor bouncing open/closed rapidly (flaky"
         " contact hardware, or a quick open-close-open) could snap the whole-house fan on"
@@ -1186,6 +1197,65 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    505: {
+        "version_fixed": "0.5.27",
+        "title": "Vacation deep setback armed once at mode-entry, never re-applied for the rest of the trip",
+        "scope_covered": (
+            "apply_classification()'s ScheduledBandGate.DEFER_OCCUPANCY branch"
+            " (automation.py) special-cased VACATION to log 'deep setback preserved' and"
+            " return, never calling handle_occupancy_vacation() — unlike the AWAY branch,"
+            " which already called handle_occupancy_away() to actively re-arm the setback"
+            " every 30-minute cycle. Confirmed via live production logs from a real"
+            " 5-day vacation (2026-07-14 to 2026-07-19): the 82F deep setback"
+            " (Set temperature to 82F — vacation mode — deep setback band) fired exactly"
+            " once, at mode entry, and never again — indoor temp sampled throughout the"
+            " trip held at 73-75F (normal comfort), not the setback ceiling, the entire"
+            " time. A manual override (e.g. for cleaners) that later cleared left the"
+            " thermostat at the override's setpoint indefinitely rather than restoring"
+            " the vacation setback. Original design gap from Issue #85 (commit 0959140),"
+            " unaffected by the #498 gate-sharing refactor. Fix calls the existing,"
+            " already-correct handle_occupancy_vacation() from the same branch, mirroring"
+            " AWAY exactly — net reduction in special-cased logic, no new functions."
+            " Same fix applied to two sibling gaps with the identical shape:"
+            " handle_bedtime() and handle_pre_cool()'s own DEFER_OCCUPANCY branches"
+            " previously skipped for both AWAY and VACATION with no re-push at all,"
+            " relying on apply_classification()'s 30-min cycle as an implicit backstop —"
+            " a grace-period expiry landing inside the sleep window routes to"
+            " handle_bedtime() instead, so that backstop didn't apply there (affecting"
+            " AWAY too, not just vacation, in that narrower window). Home and guest mode"
+            " were never affected — decide_scheduled_band_gate() only routes AWAY/"
+            "VACATION through DEFER_OCCUPANCY; guest has no handle_occupancy_guest() at"
+            " all and flows through the normal comfort-band path every cycle like home."
+            " Two existing golden simulation scenarios"
+            " (away_morning_wakeup_skipped_assertion.json,"
+            " morning_wakeup_skipped_away_occupancy.json) had their bedtime-cycle"
+            " assertion updated from bedtime_setback_skipped to setback_applied(79F) to"
+            " reflect the bedtime sibling fix genuinely re-confirming the away setback"
+            " at bedtime now, not just skipping. vacation_mode_full_lifecycle.json's"
+            " mid-vacation assertion reason text was corrected: it was worded as if it"
+            " proved active reapplication, but the harness's most-recent-decision-at-or-"
+            "before lookup semantics meant it could only ever prove no-drift, which is"
+            " why this scenario didn't catch the bug despite its name — the new"
+            " vacation_occupancy_override_cleared.json pending scenario is what actually"
+            " proves active reapplication, by perturbing the setpoint with a manual"
+            " override before asserting the setback returns."
+        ),
+        "scope_not_covered": (
+            "The status card's simultaneous display of contradictory values during the"
+            " stale window (reported alongside the setpoint bug) was not independently"
+            " investigated as a separate display bug — it is expected to self-resolve as"
+            " a consequence of the automation converging within one 30-minute cycle (or"
+            " ~10s via the dashboard cancel-override button) instead of staying stale for"
+            " hours or days, matching the margin AWAY mode already operates within."
+            " handle_pre_cool()'s reapply path has unit-test coverage"
+            " (test_grace_convergence.py) but no dedicated golden simulation scenario —"
+            " it is a single optional pre-dawn trigger backstopped by the same"
+            " apply_classification() cycle as everything else. incident-classes.md was"
+            " not given a new detection-code-backed incident class for this failure"
+            " pattern; doing so accurately would require new coordinator.py detection"
+            " logic (a distinct feature), not just a documentation row."
+        ),
+    },
     504: {
         "version_fixed": "0.5.26",
         "title": "Rapid door/window sensor bounce instantly re-triggered nat-vent/WHF reactivation with no settle time",

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.26"
+  "version": "0.5.27"
 }

--- a/docs/occupancy-dispatch-spec.md
+++ b/docs/occupancy-dispatch-spec.md
@@ -25,7 +25,7 @@ This spec covers the occupancy toggle listener, mode priority resolution, state-
 - **Approximate line ranges:**
   - `coordinator.py`: L763–L896 (toggle listener + priority resolver + away timer)
   - `coordinator.py`: L287–L290 (instance variables), L525–L532 (state restore), L600–L601 (state persist)
-  - `automation.py`: L281 (default mode), L306–L315 (`set_occupancy_mode`), L653–L684 (`apply_classification` guards), L925–L939 (`_set_temperature_for_mode` safety net), L1615–L1648 (`handle_occupancy_away`), L1650–L1694 (`handle_occupancy_home`), L1696–L1725 (`handle_occupancy_vacation`), L1727–L1732 (`handle_bedtime` guard), L1768–L1776 (`handle_morning_wakeup` guard)
+  - `automation.py`: L1432 (`apply_classification`, DEFER_OCCUPANCY guard ~L1513), L2249 (`_set_temperature_for_mode` safety net), L3852 (`handle_occupancy_away`), L3899 (`handle_occupancy_home`), L3951 (`handle_occupancy_vacation`), L4001 (`handle_bedtime`, DEFER_OCCUPANCY guard ~L4033), L4149 (`handle_pre_cool`, DEFER_OCCUPANCY guard ~L4199), L4324 (`handle_morning_wakeup`). Line numbers drift with unrelated commits — treat as approximate; verify with `grep -n "async def " automation.py` before citing.
   - `const.py`: L130, L155–L161 (constants)
 
 **Out of scope:**
@@ -150,7 +150,7 @@ Invoked after the 15-minute grace timer expires, and also called by `apply_class
    - Any other HVAC mode (off, fan only): log info, no temperature change
 4. **No notification sent.**
 
-### `handle_occupancy_vacation()` (`automation.py:L1696`)
+### `handle_occupancy_vacation()` (`automation.py:3951`)
 
 Invoked immediately (no grace) when VACATION mode is detected.
 
@@ -177,33 +177,36 @@ Invoked immediately (no grace) when VACATION mode is detected.
 
 ## 30-Minute Poll Guards (`apply_classification`)
 
-`apply_classification()` runs every 30 minutes when the coordinator refreshes. Occupancy guards execute **after** the manual override check and **after** the override-confirm-pending check (`automation.py:L653–L684`).
+`apply_classification()` (`automation.py:1432`) runs every 30 minutes when the coordinator refreshes, and also on grace-period expiry outside the sleep window (via `_apply_current_scheduled_state()`) and on manual-override cancellation (via the dashboard's Cancel Override button, ~10s delayed). Occupancy guards execute **after** the manual override check and **after** the override-confirm-pending check, then route through the shared `desired_state.decide_scheduled_band_gate()` (Issue #498).
 
 **Evaluation order inside `apply_classification()`:**
 
-1. **Manual override active** (L661) → log and return. Override wins; occupancy is not evaluated.
-2. **Override confirm pending** (L669) → log and return.
-3. **VACATION mode** (L678) → log and return. Deep setback is preserved; no temperature change.
-4. **AWAY mode** (L681) → call `handle_occupancy_away()` to reapply setback, then return.
-5. **HOME or GUEST** → proceed to normal comfort application.
+1. **Manual override active** → log and return. Override wins; occupancy is not evaluated.
+2. **Override confirm pending** → log and return.
+3. **Gate resolves `DEFER_OCCUPANCY`** (occupancy is AWAY or VACATION):
+   - **AWAY** → call `handle_occupancy_away()` to actively reapply the setback band, then return.
+   - **VACATION** → call `handle_occupancy_vacation()` to actively reapply the deep setback band, then return. *(Issue #505: prior to this fix, VACATION just logged "deep setback preserved" and returned without ever re-arming the band — this was an original design gap from Issue #85, not caught by any existing test, that let vacation's setback go unenforced for the rest of a real trip once anything — most commonly a manual override — moved the thermostat off it. `handle_occupancy_vacation()` already existed and already did the correct thing; it was simply never called from this path.)*
+4. **HOME or GUEST** → proceed to normal comfort application (never reaches the occupancy gate — `decide_scheduled_band_gate()` only routes AWAY/VACATION through `DEFER_OCCUPANCY`).
 
-The manual-override-first ordering means: if both `_manual_override_active` and `_occupancy_mode == VACATION` are true, the override check fires first and the function returns before the vacation guard is ever evaluated. The effect is the same (no temperature change), but the log message differs.
+The manual-override-first ordering means: if both `_manual_override_active` and `_occupancy_mode == VACATION` are true, the override check fires first and the function returns before the occupancy gate is ever evaluated. Once the override later clears (confirm or cancel), the next `apply_classification()` pass reaches the gate and actively reapplies the correct setback — it does not merely assume it's already there.
 
 ## Bedtime and Wakeup Guards
 
-**`handle_bedtime()` (`automation.py:L1727`):**
+**`handle_bedtime()` (`automation.py:4001`):**
 
-- If `_occupancy_mode` is `OCCUPANCY_VACATION` or `OCCUPANCY_AWAY`: log info and return. Setback is already active; applying sleep temps would move the thermostat in the wrong direction.
+- If the gate resolves `DEFER_OCCUPANCY` (VACATION or AWAY): bedtime-specific sleep temps are still skipped (applying them would move the thermostat in the wrong direction), but as of Issue #505 the away/vacation setback is now **actively reapplied** here too — `handle_occupancy_vacation()`/`handle_occupancy_away()` is called before returning, exactly mirroring `apply_classification()`'s branch above. This matters because grace-period expiry landing *inside* the sleep window routes here instead of to `apply_classification()` (see `_apply_current_scheduled_state()`), so the same "setback already active" assumption would otherwise be exposed to the same staleness bug on a narrower (≤30 min, until the next backstop cycle) but still real window.
 - For HOME/GUEST: clears manual override, deactivates fan if running, applies adaptive bedtime setback via `compute_bedtime_setback()`.
 
-**`handle_morning_wakeup()` (`automation.py:L1768`):**
+**`handle_morning_wakeup()` (`automation.py:4324`):**
 
-- If `_occupancy_mode` is NOT `OCCUPANCY_HOME` or `OCCUPANCY_GUEST`: log info and return. No comfort restore while away.
+- If `_occupancy_mode` is NOT `OCCUPANCY_HOME` or `OCCUPANCY_GUEST`: log info and return. No comfort restore while away — this path is unaffected by Issue #505 (a silent no-op here is correct; the away/vacation setback is the intended active state and gets actively reconfirmed elsewhere, not restored to comfort).
 - For HOME/GUEST: clears manual override, deactivates fan if still running, restores comfort temperatures.
+
+**`handle_pre_cool()`:** has the same `DEFER_OCCUPANCY` shape as `handle_bedtime()` and received the identical Issue #505 fix — reapplies the away/vacation setback before returning "skipped" rather than assuming it's already active.
 
 ## `_set_temperature_for_mode()` Safety Net
 
-`_set_temperature_for_mode()` (`automation.py:L925`) is the common comfort-application path called by most HVAC-setting code within the engine. It acts as a last-resort occupancy guard:
+`_set_temperature_for_mode()` (`automation.py:2249`) is the common comfort-application path called by most HVAC-setting code within the engine. It acts as a last-resort occupancy guard:
 
 1. If `_occupancy_mode == OCCUPANCY_AWAY`: log info, `await handle_occupancy_away()`, return.
 2. If `_occupancy_mode == OCCUPANCY_VACATION`: log info, `await handle_occupancy_vacation()`, return.
@@ -258,7 +261,7 @@ The manual-override-first ordering means: if both `_manual_override_active` and 
 2. The coordinator's `self._occupancy_mode` and the engine's `_occupancy_mode` are always in sync at the end of any transition. `set_occupancy_mode()` is called in the same transaction as the coordinator's own assignment (`coordinator.py:L864–L867`).
 3. At most one away timer is pending at any time. `_cancel_occupancy_away_timer()` is always called before starting a new timer, and before dispatching VACATION, HOME, or GUEST handlers.
 4. `handle_occupancy_away()` is never called directly by the coordinator — it is always routed through either the timer callback or `apply_classification()`. This preserves the 15-minute grace guarantee.
-5. `handle_occupancy_vacation()` is always called immediately (no grace). There is no equivalent grace timer for vacation mode.
+5. `handle_occupancy_vacation()` is always called immediately on the vacation toggle (no grace). There is no equivalent grace timer for vacation mode. As of Issue #505, it is also called from `apply_classification()`/`handle_bedtime()`/`handle_pre_cool()`'s `DEFER_OCCUPANCY` branches on every subsequent cycle while vacation mode is active — not just once at toggle time.
 6. GUEST mode is functionally identical to HOME at the automation handler level. The distinction is tracked in `_occupancy_mode` for reporting and briefing, but `handle_occupancy_home()` is the only handler invoked for both.
 7. Away duration (`_today_record.occupancy_away_minutes`) is only incremented on return from a non-home mode. If HA restarts mid-departure, the duration from `_occupancy_away_since` to restart is not counted (timer is not re-armed, so the next toggle change that returns to HOME accumulates from `_occupancy_away_since` which was persisted).
 8. The `_set_temperature_for_mode()` safety net cannot recurse: away and vacation handlers call `_set_temperature()` directly, not `_set_temperature_for_mode()`.
@@ -281,7 +284,7 @@ The manual-override-first ordering means: if both `_manual_override_active` and 
 - [`_set_temperature_for_mode`](../custom_components/climate_advisor/automation.py#L925) — comfort-application safety net
 - [`handle_occupancy_away`](../custom_components/climate_advisor/automation.py#L1615) — away setback handler
 - [`handle_occupancy_home`](../custom_components/climate_advisor/automation.py#L1650) — home/guest comfort restore + notification
-- [`handle_occupancy_vacation`](../custom_components/climate_advisor/automation.py#L1696) — deep vacation setback handler
+- [`handle_occupancy_vacation`](../custom_components/climate_advisor/automation.py#L3951) — deep vacation setback handler
 - [`handle_bedtime` (occupancy guard)](../custom_components/climate_advisor/automation.py#L1727) — skips sleep setback when away/vacation
 - [`handle_morning_wakeup` (occupancy guard)](../custom_components/climate_advisor/automation.py#L1768) — skips comfort restore when not home/guest
 - [`_is_toggle_on`](../custom_components/climate_advisor/coordinator.py#L763) — reads toggle entity state with unavailable=OFF and XOR invert

--- a/tests/test_grace_convergence.py
+++ b/tests/test_grace_convergence.py
@@ -21,6 +21,8 @@ from custom_components.climate_advisor.classifier import DayClassification
 from custom_components.climate_advisor.const import (
     CONF_MANUAL_GRACE_NOTIFY,
     CONF_MANUAL_GRACE_PERIOD,
+    OCCUPANCY_AWAY,
+    OCCUPANCY_VACATION,
 )
 
 # Provide a base dt_util.now — individual tests override this via patch
@@ -37,6 +39,24 @@ _PATCH_DT_NOW = "custom_components.climate_advisor.automation.dt_util.now"
 # ---------------------------------------------------------------------------
 
 
+def _make_thermostat_state(mode: str = "cool") -> MagicMock:
+    """Return a mock thermostat state with heat+cool capabilities.
+
+    Issue #505: apply_classification()/handle_bedtime()/handle_pre_cool() now call
+    _apply_comfort_band() (via handle_occupancy_vacation()/handle_occupancy_away())
+    on the DEFER_OCCUPANCY path — that reads hvac_modes/supported_features to decide
+    whether it can arm the band. Without these the band no-ops and no service call
+    is emitted.
+    """
+    s = MagicMock()
+    s.state = mode
+    s.attributes = {
+        "hvac_modes": ["off", "heat", "cool"],
+        "supported_features": 1,
+    }
+    return s
+
+
 def _make_automation_engine(config_overrides: dict | None = None) -> AutomationEngine:
     """Create an AutomationEngine with mocked HA dependencies."""
     hass = MagicMock()
@@ -49,6 +69,7 @@ def _make_automation_engine(config_overrides: dict | None = None) -> AutomationE
 
     hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
     hass.states = MagicMock()
+    hass.states.get.return_value = _make_thermostat_state("cool")
 
     config = {
         "comfort_heat": 70,
@@ -232,6 +253,85 @@ class TestGraceConvergence:
         assert apply_classification_called, "apply_classification() should be called when no sleep/wake config"
         assert apply_classification_called[0] is classification
 
+
+class TestOccupancyReapplyOnDeferOccupancy:
+    """Issue #505: vacation mode never re-armed its deep setback after the initial
+    mode-entry — apply_classification()/handle_bedtime()/handle_pre_cool() must all
+    actively reapply the away/vacation setback on DEFER_OCCUPANCY, not just log and
+    return on the (sometimes false) assumption that it's "already active"."""
+
+    def test_apply_classification_vacation_reapplies_setback(self):
+        """A vacation-mode classification cycle must re-arm the 83°F deep setback
+        (setback_cool=80 + VACATION_SETBACK_EXTRA=3), matching the live-log evidence
+        that this never happened for issue #505's real 5-day vacation."""
+        engine = _make_automation_engine()
+        engine._occupancy_mode = OCCUPANCY_VACATION
+        classification = _make_classification(hvac_mode="cool")
+
+        asyncio.run(engine.apply_classification(classification))
+
+        engine.hass.services.async_call.assert_called()
+        args, _ = engine.hass.services.async_call.call_args
+        assert args[0] == "climate"
+        assert args[1] == "set_temperature"
+        assert args[2]["temperature"] == 83.0
+        assert args[2]["hvac_mode"] == "cool"
+
+    def test_apply_classification_away_still_reapplies_setback(self):
+        """Regression guard: away mode's existing correct reapply behavior (via
+        handle_occupancy_away()) must be unchanged by the vacation fix."""
+        engine = _make_automation_engine()
+        engine._occupancy_mode = OCCUPANCY_AWAY
+        classification = _make_classification(hvac_mode="cool")
+
+        asyncio.run(engine.apply_classification(classification))
+
+        engine.hass.services.async_call.assert_called()
+        args, _ = engine.hass.services.async_call.call_args
+        assert args[2]["temperature"] == 80.0
+
+    def test_handle_bedtime_vacation_reapplies_setback_in_sleep_window(self):
+        """Grace expiry landing inside the sleep window routes to handle_bedtime()
+        instead of apply_classification() — that path must also reapply vacation's
+        setback rather than silently assuming it's already active."""
+        engine = _make_automation_engine({"sleep_time": "22:30", "wake_time": "07:00"})
+        engine._occupancy_mode = OCCUPANCY_VACATION
+        engine._current_classification = _make_classification(hvac_mode="cool")
+
+        asyncio.run(engine.handle_bedtime())
+
+        engine.hass.services.async_call.assert_called()
+        args, _ = engine.hass.services.async_call.call_args
+        assert args[2]["temperature"] == 83.0
+
+    def test_handle_bedtime_away_reapplies_setback_in_sleep_window(self):
+        """Same sibling gap, away mode: grace expiry inside the sleep window must
+        also reapply away's setback, not just vacation's."""
+        engine = _make_automation_engine({"sleep_time": "22:30", "wake_time": "07:00"})
+        engine._occupancy_mode = OCCUPANCY_AWAY
+        engine._current_classification = _make_classification(hvac_mode="cool")
+
+        asyncio.run(engine.handle_bedtime())
+
+        engine.hass.services.async_call.assert_called()
+        args, _ = engine.hass.services.async_call.call_args
+        assert args[2]["temperature"] == 80.0
+
+    def test_handle_pre_cool_vacation_reapplies_setback(self):
+        """handle_pre_cool()'s DEFER_OCCUPANCY branch must also reapply the setback."""
+        engine = _make_automation_engine()
+        engine._occupancy_mode = OCCUPANCY_VACATION
+        classification = _make_classification(hvac_mode="cool", setback_modifier=-2.0)
+        engine._current_classification = classification
+
+        asyncio.run(engine.handle_pre_cool(indoor_temp=78.0, nat_vent_just_closed=False))
+
+        engine.hass.services.async_call.assert_called()
+        args, _ = engine.hass.services.async_call.call_args
+        assert args[2]["temperature"] == 83.0
+
+
+class TestGraceNormalExpirySchedulesConvergence:
     def test_grace_normal_expiry_schedules_convergence_task(self):
         """Normal grace expiry (sensors closed) schedules _apply_current_scheduled_state via async_create_task."""
         engine = _make_automation_engine(

--- a/tests/test_occupancy_automation.py
+++ b/tests/test_occupancy_automation.py
@@ -162,8 +162,15 @@ class TestApplyClassificationOccupancy:
         # Away band active='ceiling'; thermostat has cool → set_temperature(setback_cool=80).
         assert set_temp == 80  # setback_cool (away ceiling), not setback_heat (60)
 
-    def test_vacation_skips_classification_entirely(self):
-        """When on vacation, classification should not change temperature at all."""
+    def test_vacation_reapplies_deep_setback_not_comfort(self):
+        """Issue #505: on vacation, classification must reapply the deep vacation
+        setback (setback_cool=80 + VACATION_SETBACK_EXTRA=3 = 83), not comfort temps
+        and not a no-op. Previously this asserted NO service call at all — that
+        encoded the exact bug (the deep setback was armed once at vacation entry and
+        never re-armed again) as expected behavior. A real 5-day vacation incident
+        confirmed the thermostat stays at whatever temperature it happened to be
+        holding, indefinitely, under the old behavior.
+        """
         engine = _make_engine()
         c = _make_classification(hvac_mode="cool")
         engine._current_classification = c
@@ -171,8 +178,9 @@ class TestApplyClassificationOccupancy:
 
         asyncio.run(engine.apply_classification(c))
 
-        # No service calls should have been made
-        engine.hass.services.async_call.assert_not_called()
+        engine.hass.services.async_call.assert_called_once()
+        args, _ = engine.hass.services.async_call.call_args
+        assert args[2]["temperature"] == 83
 
     def test_home_applies_comfort_normally(self):
         """When home, classification arms the daytime comfort band (ceiling=comfort_cool for cool day).
@@ -291,7 +299,11 @@ class TestBedtimeOccupancy:
     """handle_bedtime should skip during vacation."""
 
     def test_bedtime_skipped_when_vacation(self):
-        """Vacation deep setback should not be overwritten by bedtime setback."""
+        """Bedtime-specific sleep temps are skipped for vacation — the setback wins
+        instead. Issue #505 sibling fix: unlike before, that setback must now be
+        actively reapplied here too (grace expiry landing inside the sleep window
+        routes to handle_bedtime() instead of apply_classification(), so the same
+        "already active" assumption must not silently do nothing)."""
         engine = _make_engine()
         c = _make_classification(hvac_mode="heat", day_type="cold")
         engine._current_classification = c
@@ -299,10 +311,13 @@ class TestBedtimeOccupancy:
 
         asyncio.run(engine.handle_bedtime())
 
-        engine.hass.services.async_call.assert_not_called()
+        engine.hass.services.async_call.assert_called_once()
+        args, _ = engine.hass.services.async_call.call_args
+        assert args[2]["temperature"] == 83  # vacation ceiling, not bedtime heat temps
 
     def test_bedtime_skipped_when_away(self):
-        """Issue #101: Away setback is already active — bedtime should not override it."""
+        """Issue #101/#505: bedtime-specific sleep temps are skipped when AWAY, but
+        the away setback must be actively reapplied here too, not just assumed."""
         engine = _make_engine()
         c = _make_classification(hvac_mode="heat", day_type="cold")
         engine._current_classification = c
@@ -310,8 +325,9 @@ class TestBedtimeOccupancy:
 
         asyncio.run(engine.handle_bedtime())
 
-        # Bedtime is skipped when AWAY — away setback wins
-        engine.hass.services.async_call.assert_not_called()
+        engine.hass.services.async_call.assert_called_once()
+        args, _ = engine.hass.services.async_call.call_args
+        assert args[2]["temperature"] == 80  # away ceiling, not bedtime heat temps
 
     def test_bedtime_runs_when_home(self):
         """Bedtime arms the sleep band — needs thermostat capabilities to produce a service call.

--- a/tools/simulations/golden/MANIFEST.json
+++ b/tools/simulations/golden/MANIFEST.json
@@ -159,13 +159,13 @@
     "issue": 229
   },
   "away_morning_wakeup_skipped_assertion": {
-    "sha256": "2ea261feff910e67b949b8efc06c03479f09cfe106564af4945d42a8a7925131",
-    "signed": "2026-06-10",
+    "sha256": "5c5aa27b6de12700ee7f3219faee80b113d3d0a7d5d118d8c88f167d53c7356c",
+    "signed": "2026-07-20",
     "issue": 229
   },
   "morning_wakeup_skipped_away_occupancy": {
-    "sha256": "f577212489dfad85c6c23232b3177bbd7ef0a8431b0069b41d044957f78cb9cc",
-    "signed": "2026-06-10",
+    "sha256": "e013ef1001712ceae649c71fbccb8d72d8a71751c12b12f26f43cd6c28f1a934",
+    "signed": "2026-07-20",
     "issue": 229
   },
   "away_natvent_activates_free_cooling": {
@@ -219,8 +219,8 @@
     "issue": 229
   },
   "vacation_mode_full_lifecycle": {
-    "sha256": "5dfe1f15ba040fe24fd5483b31445683d88b443b145991f34f12fba91e598615",
-    "signed": "2026-06-13",
+    "sha256": "29de99c31b0d1f7ee87a85559dae4968f19290294554a846ee1f6a861b142e99",
+    "signed": "2026-07-20",
     "issue": 229
   },
   "whole_house_fan_hvac_suppression": {

--- a/tools/simulations/golden/away_morning_wakeup_skipped_assertion.json
+++ b/tools/simulations/golden/away_morning_wakeup_skipped_assertion.json
@@ -1,17 +1,25 @@
 {
   "name": "away_morning_wakeup_skipped_assertion",
-  "description": "Away mode with bedtime setback active (79F). Bedtime fires while away (setback also skipped). Wakeup event fires at 07:00 while still away. Production handle_morning_wakeup() returns silently with no event when occupancy is not home/guest. The last observable decision at 07:00 is bedtime_setback_skipped from the prior cycle.",
+  "description": "Away mode with setback active (79F). Bedtime fires while away — bedtime-specific sleep temps are skipped but the away setback is actively reapplied (Issue #505). Wakeup event fires at 07:00 while still away. Production handle_morning_wakeup() returns silently with no event when occupancy is not home/guest. The last observable decision at 07:00 is the setback_applied from the 22:30 bedtime-time reapply.",
   "source": "synthetic",
   "issue": 229,
   "notes": [
     "Production handle_morning_wakeup(): if occupancy not in (home, guest), returns silently (no event emitted).",
     "The 07:00 wakeup call produces no new event log entry.",
-    "production_outcome_at uses last-decision-at-or-before lookup, so it returns bedtime_setback_skipped",
+    "production_outcome_at uses last-decision-at-or-before lookup, so it returns the last decision",
     "from 22:30 as the 'current' observable state at 07:00.",
     "This correctly documents: (1) away setback stays active, (2) wakeup comfort restore is suppressed.",
     "The existing away-mode-classification-cycle golden mentions this behavior in notes but has no",
     "explicit wakeup event — this scenario adds that explicit coverage.",
-    "Covers Priority 6b away_morning_wakeup from plan abundant-mapping-clarke.md."
+    "Covers Priority 6b away_morning_wakeup from plan abundant-mapping-clarke.md.",
+    "Issue #505 update: handle_bedtime()'s DEFER_OCCUPANCY branch previously only emitted",
+    "bedtime_setback_skipped and did nothing else — that was itself part of the #505 bug class",
+    "(a sibling of the vacation gap: if grace expires inside the sleep window instead of at 22:30's",
+    "scheduled bedtime, the same 'setback already active' assumption could be false). The fix makes",
+    "handle_bedtime() actively reapply the away/vacation setback in addition to skipping sleep temps,",
+    "so the 22:30 event is now setback_applied (79F) rather than a bare bedtime_setback_skipped with",
+    "no accompanying write. The wakeup-is-silent-while-away behavior this scenario is actually named",
+    "for is unchanged; only the setpoint-facing outcome of the prior bedtime cycle improved."
   ],
   "config": {
     "comfort_heat": 70,
@@ -53,15 +61,16 @@
     },
     {
       "at": "2026-07-16T07:00:00",
-      "expect": "bedtime_setback_skipped",
+      "expect": "setback_applied",
+      "expect_temp": 79.0,
       "track": "logic",
-      "reason": "Wakeup fires while away — handle_morning_wakeup() returns silently with no event (occupancy not home/guest). production_outcome_at returns bedtime_setback_skipped from the prior 22:30 cycle as the last observable decision. Away setback maintained; no comfort restore."
+      "reason": "Wakeup fires while away — handle_morning_wakeup() returns silently with no event (occupancy not home/guest). production_outcome_at returns the setback_applied (79F) from the prior 22:30 bedtime-time reapply (Issue #505) as the last observable decision. Away setback maintained; no comfort restore."
     }
   ],
   "verdict": {
     "type": "positive",
-    "summary": "Morning wakeup produces no event while away — last observable decision is bedtime_setback_skipped; setback maintained",
-    "observed_behavior": "setback_applied (79F) on away → bedtime_setback_skipped at 22:30 → wakeup at 07:00 silent; last decision stays bedtime_setback_skipped",
-    "expected_behavior": "Wakeup event skipped when occupancy=away; away setback remains active until user returns"
+    "summary": "Morning wakeup produces no event while away — last observable decision is the away setback reapplied at bedtime; setback maintained",
+    "observed_behavior": "setback_applied (79F) on away → setback_applied (79F) again at 22:30 bedtime reapply → wakeup at 07:00 silent; last decision stays setback_applied",
+    "expected_behavior": "Wakeup event skipped when occupancy=away; away setback remains active (and is actively reconfirmed at bedtime, Issue #505) until user returns"
   }
 }

--- a/tools/simulations/golden/morning_wakeup_skipped_away_occupancy.json
+++ b/tools/simulations/golden/morning_wakeup_skipped_away_occupancy.json
@@ -1,15 +1,22 @@
 {
   "name": "morning_wakeup_skipped_away_occupancy",
-  "description": "Away mode with bedtime setback already active. Bedtime fires while away (setback skipped). Wakeup event fires at 07:00 while occupancy=away. Production handle_morning_wakeup() returns silently with no event. The last observable decision at 07:00 is bedtime_setback_skipped from the prior cycle.",
+  "description": "Away mode with setback already active. Bedtime fires while away — bedtime-specific sleep temps are skipped but the away setback is actively reapplied (Issue #505). Wakeup event fires at 07:00 while occupancy=away. Production handle_morning_wakeup() returns silently with no event. The last observable decision at 07:00 is the setback_applied from the 22:30 bedtime-time reapply.",
   "source": "synthetic",
   "issue": 229,
   "notes": [
     "Production behavior: handle_morning_wakeup() checks occupancy — if away/vacation, returns silently (no event).",
     "No 'morning_wakeup_skipped' event is emitted for the occupancy path (only manual_override path emits it).",
-    "production_outcome_at last-decision-at-or-before lookup returns bedtime_setback_skipped at 07:00.",
-    "This documents two things: (1) bedtime setback is skipped while away, (2) wakeup comfort restore",
+    "production_outcome_at last-decision-at-or-before lookup returns the last decision at 07:00.",
+    "This documents two things: (1) bedtime-specific sleep temps are skipped while away, (2) wakeup comfort restore",
     "is also suppressed while away — setback stays active until occupancy returns home.",
-    "Covers Priority 5 wakeup+away from plan abundant-mapping-clarke.md."
+    "Covers Priority 5 wakeup+away from plan abundant-mapping-clarke.md.",
+    "Issue #505 update: handle_bedtime()'s DEFER_OCCUPANCY branch previously only emitted",
+    "bedtime_setback_skipped and did nothing else. The fix makes it actively reapply the away/vacation",
+    "setback in addition to skipping sleep temps, so the 22:30 event is now setback_applied (79F)",
+    "rather than a bare bedtime_setback_skipped with no accompanying write. The wakeup-is-silent-",
+    "while-away behavior this scenario is named for is unchanged; only the setpoint-facing outcome",
+    "of the prior bedtime cycle improved. See away_morning_wakeup_skipped_assertion.json for the",
+    "near-identical sibling scenario updated for the same reason."
   ],
   "config": {
     "comfort_heat": 70,
@@ -51,15 +58,16 @@
     },
     {
       "at": "2026-07-15T07:00:00",
-      "expect": "bedtime_setback_skipped",
+      "expect": "setback_applied",
+      "expect_temp": 79.0,
       "track": "logic",
-      "reason": "Wakeup fires while occupancy=away — handle_morning_wakeup() returns silently with no event emitted. production_outcome_at returns bedtime_setback_skipped from the prior 22:30 cycle as the last observable decision. Comfort restore suppressed; setback maintained."
+      "reason": "Wakeup fires while occupancy=away — handle_morning_wakeup() returns silently with no event emitted. production_outcome_at returns the setback_applied (79F) from the prior 22:30 bedtime-time reapply (Issue #505) as the last observable decision. Comfort restore suppressed; setback maintained."
     }
   ],
   "verdict": {
     "type": "positive",
-    "summary": "Wakeup produces no event while away — last observable decision is bedtime_setback_skipped; comfort NOT restored",
-    "observed_behavior": "setback_applied (79F) on away → bedtime_setback_skipped at 22:30 → wakeup at 07:00 silent; last decision stays bedtime_setback_skipped",
-    "expected_behavior": "Morning wakeup respects away mode — no comfort restore while user is away; setback maintained"
+    "summary": "Wakeup produces no event while away — last observable decision is the away setback reapplied at bedtime; comfort NOT restored",
+    "observed_behavior": "setback_applied (79F) on away → setback_applied (79F) again at 22:30 bedtime reapply → wakeup at 07:00 silent; last decision stays setback_applied",
+    "expected_behavior": "Morning wakeup respects away mode — no comfort restore while user is away; setback maintained (and actively reconfirmed at bedtime, Issue #505)"
   }
 }

--- a/tools/simulations/golden/vacation_mode_full_lifecycle.json
+++ b/tools/simulations/golden/vacation_mode_full_lifecycle.json
@@ -8,7 +8,8 @@
     "The simulator _handle_occupancy_vacation() produces 'setback_applied' (not 'deep_setback_applied').",
     "Classification cycles while vacation call _handle_occupancy_vacation() → 'setback_applied' each time.",
     "comfort_restored fires on occupancy_home with comfort_cool=74F.",
-    "Covers Priority 4 vacation lifecycle from plan abundant-mapping-clarke.md."
+    "Covers Priority 4 vacation lifecycle from plan abundant-mapping-clarke.md.",
+    "Issue #505 test-integrity correction: the three mid-vacation assertions' `reason` text previously claimed to verify that classification cycles 'reapply' the setback — they don't, and never could, given production_outcome_at()'s most-recent-decision-at-or-before lookup semantics. Nothing in this scenario ever perturbs the setpoint away from the single occupancy_setback event fired at vacation entry, so these assertions passed identically whether or not apply_classification()'s vacation branch did anything on each cycle. This is exactly how issue #505 (vacation's deep setback was armed once at mode-entry and never re-applied for the rest of a real 5-day vacation) shipped despite this scenario's name. Reworded to state what is actually verified (no drift); the new vacation_occupancy_override_cleared.json pending scenario is what proves active reapplication, by perturbing the setpoint with a manual override before asserting the setback returns."
   ],
   "config": {
     "comfort_heat": 70,
@@ -79,19 +80,19 @@
       "at": "2026-07-15T10:30:00",
       "expect": "setback_applied",
       "expect_temp": 82.0,
-      "reason": "Classification while vacation reapplies vacation setback (82F) — comfort NOT restored"
+      "reason": "Issue #505 accuracy note: this and the next two assertions check that the setpoint REMAINS at the vacation setback (82F) through classification cycles — comfort is NOT restored. They do NOT prove the cycle actively re-wrote the setpoint (production_outcome_at() returns the most-recent decision at-or-before the assertion time, so this passes whether or not a fresh write happened, as long as nothing else perturbed the setpoint first). vacation_occupancy_override_cleared.json is the scenario that actually exercises and proves active reapplication, by perturbing the setpoint with a manual override first."
     },
     {
       "at": "2026-07-15T11:00:00",
       "expect": "setback_applied",
       "expect_temp": 82.0,
-      "reason": "Second classification cycle while vacation — setback maintained at 82F"
+      "reason": "Setback still holds at 82F (see the accuracy note on the previous assertion — this is a no-drift check, not proof of a fresh reapply)."
     },
     {
       "at": "2026-07-15T11:30:00",
       "expect": "setback_applied",
       "expect_temp": 82.0,
-      "reason": "Third classification cycle while vacation — setback maintained at 82F"
+      "reason": "Setback still holds at 82F (see the accuracy note two assertions up — this is a no-drift check, not proof of a fresh reapply)."
     },
     {
       "at": "2026-07-15T16:00:00",

--- a/tools/simulations/pending/vacation_occupancy_override_cleared.json
+++ b/tools/simulations/pending/vacation_occupancy_override_cleared.json
@@ -1,0 +1,92 @@
+{
+  "name": "vacation_occupancy_override_cleared",
+  "description": "Vacation-mode mirror of cancel_override_then_resume: a manual override set during vacation (e.g. cleaners visiting) must have the deep vacation setback restored the moment it's cancelled, not left at the override's setpoint until the next unrelated event (Issue #505)",
+  "source": "synthetic",
+  "issue": 505,
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 74,
+    "setback_heat": 60,
+    "setback_cool": 79,
+    "natural_vent_delta": 3.0,
+    "override_confirm_seconds": 5,
+    "manual_grace_seconds": 3600,
+    "wake_time": "04:00",
+    "briefing_time": "04:15"
+  },
+  "events": [
+    {
+      "time": "2026-07-15T08:00:00",
+      "type": "classification",
+      "day_type": "warm",
+      "hvac_mode": "cool",
+      "note": "Morning classification at home, before vacation begins — needed so handle_occupancy_vacation() has a classification to arm a band against."
+    },
+    {
+      "time": "2026-07-15T10:00:00",
+      "type": "occupancy_vacation",
+      "note": "User leaves for a multi-day vacation — deep cool setback: setback_cool(79) + VACATION_SETBACK_EXTRA(3) = 82F"
+    },
+    {
+      "time": "2026-07-15T10:00:01",
+      "type": "temp_update",
+      "indoor_f": 75.0,
+      "outdoor_f": 82.0,
+      "note": "Indoor still cooling toward the setback, outdoor hot."
+    },
+    {
+      "time": "2026-07-16T12:43:00",
+      "type": "thermostat_state_changed",
+      "hvac_mode": "cool",
+      "temperature": 75.0,
+      "note": "Cleaners bump the thermostat to 75F cool while the home is on vacation — mid-afternoon, unambiguously outside any sleep window (mirrors issue #505's real Activity Record's second, unambiguous override episode)."
+    },
+    {
+      "time": "2026-07-16T12:43:06",
+      "type": "temp_update",
+      "indoor_f": 75.0,
+      "outdoor_f": 87.0,
+      "note": "6s later (past override_confirm_seconds=5) — override confirms."
+    },
+    {
+      "time": "2026-07-16T13:54:00",
+      "type": "cancel_override",
+      "note": "Cleaners' visit ends and the override is cancelled from the dashboard — real api.py-mirroring cancel flow: clear_manual_override() + _cancel_grace_timers() immediately, then a REAL 10s async_call_later before re-applying the classification."
+    },
+    {
+      "time": "2026-07-16T13:54:11",
+      "type": "temp_update",
+      "indoor_f": 75.0,
+      "outdoor_f": 90.0,
+      "note": "11s after cancel — past the real 10s re-apply delay, forcing the scheduler to reach it."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-07-15T10:00:00",
+      "expect": "setback_applied",
+      "expect_temp": 82.0,
+      "reason": "Vacation entry: setback_cool(79) + VACATION_SETBACK_EXTRA(3) = 82F."
+    },
+    {
+      "at": "2026-07-16T13:54:10",
+      "expect": "setback_applied",
+      "expect_temp": 82.0,
+      "track": "integration",
+      "reason": "Issue #505 root-cause fix: 11s after cancel_override, apply_classification()'s DEFER_OCCUPANCY branch for VACATION must call handle_occupancy_vacation() (mirroring the AWAY branch's handle_occupancy_away()) and restore the 82F deep setback — not leave the thermostat at the cleaners' 75F override setpoint. Live production logs for the real issue #505 incident showed this never happened: 'Vacation mode — skipping classification temp change (deep setback preserved)' repeated unchanged for the rest of the 5-day vacation."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "Cancel override during vacation: automation immediately restores the deep vacation setback",
+    "observed_behavior": "setback_applied (82F) fires 11s after cancel_override, from apply_classification()'s DEFER_OCCUPANCY branch calling handle_occupancy_vacation()",
+    "expected_behavior": "Vacation's deep setback is restored on override-clear exactly like away mode already does — occupant leaves for vacation, a temporary override never leaves the home at normal comfort temperature for the rest of the trip"
+  },
+  "notes": [
+    "Direct vacation-mode mirror of tools/simulations/golden/cancel_override_then_resume.json (the AWAY-mode version of this exact sequence, which already passes). There was no vacation equivalent prior to Issue #505 — the coverage gap tracked the code gap exactly.",
+    "Revert test: with the automation.py:1513 DEFER_OCCUPANCY-VACATION branch reverted to its pre-fix log-and-return form, the 07:43:10 assertion fails (no setback_applied event fires — event_log ends at override cleared/grace expired). Confirms this assertion genuinely depends on the fix, not a coincidental re-apply.",
+    "override_confirm_seconds/manual_grace_seconds mirror cancel_override_then_resume.json's values for the same reason (short wall-clock span; grace long enough that the explicit cancel_override event — not an auto-expiry — is what's under test)."
+  ],
+  "use_coordinator": true,
+  "skip_startup_coalesce": true
+}


### PR DESCRIPTION
## Summary

- `apply_classification()`'s `DEFER_OCCUPANCY` branch special-cased VACATION to log "deep setback preserved" and return, never calling the existing `handle_occupancy_vacation()` the way the AWAY branch already calls `handle_occupancy_away()` every 30-min cycle. Live production logs from a real 5-day vacation confirm the 82°F deep setback fired exactly **once**, at mode entry, and never again — indoor held at normal comfort temperature (73-75°F) for nearly the entire trip.
- Same fix applied to two sibling gaps with the identical shape: `handle_bedtime()` and `handle_pre_cool()`'s own `DEFER_OCCUPANCY` branches skipped for both AWAY and VACATION with no re-push at all, relying on `apply_classification()`'s 30-min cycle as an implicit backstop that doesn't apply when grace expires inside the sleep window (affects AWAY too, not just vacation, in that narrower case).
- Original design gap from Issue #85, not a regression. Home and guest mode were never affected — confirmed structurally (`decide_scheduled_band_gate()` only routes AWAY/VACATION through `DEFER_OCCUPANCY`; guest has no `handle_occupancy_guest()` at all).
- Fix reuses the existing, already-correct `handle_occupancy_vacation()`/`handle_occupancy_away()` — net reduction in special-cased logic, no new functions.

## Golden scenario changes (test-integrity, not just new coverage)

- `away_morning_wakeup_skipped_assertion.json` / `morning_wakeup_skipped_away_occupancy.json`: bedtime-cycle assertion now correctly expects `setback_applied` (the away setback being reconfirmed at bedtime) instead of a bare `bedtime_setback_skipped` — a direct, correct consequence of the bedtime sibling fix.
- `vacation_mode_full_lifecycle.json`: reworded three assertions whose `reason` text claimed to verify "reapplication" but couldn't — `production_outcome_at()`'s most-recent-decision-at-or-before lookup means those assertions pass identically whether or not a fresh write happens, as long as nothing else perturbs the setpoint first. This is part of why #505 shipped despite a scenario literally named for this behavior.
- New `tools/simulations/pending/vacation_occupancy_override_cleared.json`: direct vacation-mode mirror of the existing `cancel_override_then_resume.json` (AWAY), which is what actually proves active reapplication by perturbing the setpoint with a manual override before asserting the setback returns.

## Test plan

- [x] `pytest tests/` — 3481 passed
- [x] `python tools/simulate.py` — 74/74 golden scenarios passed, `--check-integrity` clean
- [x] `python tools/simulate.py --pending -v` — new vacation scenario passes
- [x] Revert-test discipline: reverted the `automation.py` fix and confirmed the new unit tests (4 of 5) and the new pending scenario fail without it; restored
- [x] `ruff check` / `ruff format` clean
- [x] `test_version_sync.py` passes (0.5.26 → 0.5.27)
- [x] Docs updated: `docs/occupancy-dispatch-spec.md` §30-Minute Poll Guards and §Bedtime and Wakeup Guards corrected to describe the fixed behavior (was previously the same stale text the bug shipped under)

## Scope notes

- `docs/incident-classes.md` was **not** given a new detection-code-backed incident class for this failure pattern — doing so accurately would require new `coordinator.py` detection logic (a distinct feature), not just a documentation row.
- 3 pre-existing `test_door_window.py` failures (`TestGracePeriodDuration`/`TestGracePeriodExpiry`, only when run in file isolation, not in the full suite) were confirmed via `git stash` to exist identically on unmodified `main` — unrelated to this change.