### PR TITLE
Fix #511: interpolate outdoor temp between hourly forecast points for weather-service installs

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,21 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.28"
+VERSION = "0.5.29"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.29": [
+        "Fix #511: for installs with no dedicated outdoor sensor (weather-service source"
+        " only, e.g. Met.no), the dashboard's 'Actual Outdoor' reading and the automation"
+        " decisions based on it could lag or lead true conditions by up to an hour during"
+        " a temperature ramp — the weather integration's live reading only refreshes"
+        " roughly hourly, so it was really a stale point-sample, not a live value."
+        " Outdoor temp is now estimated by interpolating between the two nearest hourly"
+        " forecast points, refreshed every 5 minutes, feeding the dashboard, the"
+        " windows-recommended flag, nat-vent/economizer gating, and thermal-learning"
+        " model accuracy. Installs with a dedicated sensor or input_number are unaffected"
+        " — they already had a true live reading.",
+    ],
     "0.5.28": [
         "Fix #508: pressing 'Cancel Fan Override' on the dashboard cleared the fan override"
         " but left the grace-period countdown running for its full original duration — up to"
@@ -1208,6 +1220,60 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    511: {
+        "version_fixed": "0.5.29",
+        "title": (
+            "Weather-service-only installs' outdoor temp reading was a stale point-sample,"
+            " not a live value, causing chart/automation errors of up to ~4°F during ramps"
+        ),
+        "scope_covered": (
+            "Confirmed via live chart_log cross-correlation analysis (SSH-pulled, ~107 days"
+            " of data) that for weather-service installs with no dedicated sensor (e.g."
+            " Met.no's weather.forecast_home), the 'temperature' attribute used as 'Actual"
+            " Outdoor' is a step function that plateaus 30-90 min before updating — a"
+            " ~50-55 min effective phase lag against true conditions, producing a +3-4°F"
+            " morning-warming bias and a -2°F evening-cooling bias. _get_outdoor_temp()"
+            " now interpolates linearly between the two nearest hourly-forecast points"
+            " (new _interpolate_hourly_outdoor_temp(), built on a new shared"
+            " _parse_forecast_entries() parsing helper also used by the two pre-existing"
+            " forecast-reading functions) instead of trusting the live attribute directly,"
+            " unconditionally for weather_service source — sensor/input_number installs are"
+            " untouched. The estimate now refreshes every 5 minutes via the existing thermal-"
+            " sample timer (new _refresh_weather_service_outdoor_temp(), gated to skip"
+            " entirely for sensor/input_number sources) instead of only once per 30-min"
+            " cycle, and a new single _apply_outdoor_temp() propagation method consolidates"
+            " what were previously 4 independently-written touch points (30-min cycle x2"
+            " lines, daily briefing, and the new 5-min tick) across the coordinator and"
+            " automation engine mirror. _async_end_of_day()'s midnight reset now"
+            " immediately re-fetches the hourly forecast instead of leaving up to a ~30-min"
+            " gap where interpolation degrades nightly to the pre-fix behavior. All"
+            " downstream consumers (automation gating, chart 'actual outdoor' values,"
+            " classification windows-gate, outdoor sensor entity, api.py dashboard payload)"
+            " inherit the fix automatically since they all read the same"
+            " _last_outdoor_temp/coordinator.data fields this change updates — no separate"
+            " code changes were needed in automation.py, sensor.py, or api.py."
+        ),
+        "scope_not_covered": (
+            "The 'Predicted Outdoor' line (_extract_current_hour_forecast_temp/"
+            "_build_future_forecast_outdoor) still uses nearest-neighbor selection, not"
+            " interpolation — its own ~30-60 min offset is unchanged; fixing it would make"
+            " predicted and actual nearly coincide for weather-service installs, defeating"
+            " the point of two separate lines, and the user's stated mental model (predicted"
+            " = a frozen morning snapshot, actual = live-tracking) is a distinct feature"
+            " needing new persisted state, tracked separately. A likely pre-existing Celsius-"
+            " unit bug was found (not fixed) in that same predicted-outdoor path: it never"
+            " applies to_fahrenheit() to raw forecast values before they reach get_chart_data()'s"
+            " _conv()/from_fahrenheit() conversion, unlike every other outdoor-temp read path"
+            " in the file — flagged for a separate issue, not touched here to keep this PR's"
+            " blast radius scoped to the reported bug. Target Band chart history has zero"
+            " persistence (confirmed, unrelated pre-existing gap) and the no-HVAC counterfactual"
+            " prediction question is undecided — both tracked as separate follow-up issues, not"
+            " addressed in this change. The nat-vent threshold arithmetic duplication"
+            " (comfort_cool + nat_vent_delta, computed independently at 4 sites) was identified"
+            " during design but deliberately deferred/not touched, to keep this PR's diff"
+            " minimal for a live-HVAC-controlling production deploy."
+        ),
+    },
     508: {
         "version_fixed": "0.5.28",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -696,7 +696,24 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
     @callback
     def _async_thermal_sample_tick(self, now: datetime) -> None:
         """Sample active thermal observations on the 5-min tick."""
+        self._refresh_weather_service_outdoor_temp()
         self._sample_all_observations()
+
+    def _refresh_weather_service_outdoor_temp(self) -> None:
+        """Refresh the interpolated outdoor estimate every 5 min (Issue #511).
+
+        Weather-service installs only — sensor/input_number installs already get
+        live updates via their own state-change listener (see coordinator.py ~608)
+        and must not be touched here, since they have a true live reading already.
+        """
+        source = self.config.get("outdoor_temp_source", TEMP_SOURCE_WEATHER_SERVICE)
+        if source in (TEMP_SOURCE_SENSOR, TEMP_SOURCE_INPUT_NUMBER):
+            return
+        weather_entity = self.config.get("weather_entity")
+        weather_state = self.hass.states.get(weather_entity) if weather_entity else None
+        if not weather_state:
+            return
+        self._apply_outdoor_temp(self._get_outdoor_temp(weather_state.attributes), record_history=False)
 
     async def async_restore_state(self) -> None:
         """Restore operational state from disk after startup."""
@@ -1390,6 +1407,37 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             )
             c.windows_recommended = False
 
+    def _apply_outdoor_temp(self, value: float | None, *, record_history: bool) -> None:
+        """Propagate a newly-read outdoor temperature to every downstream consumer.
+
+        Consolidates what used to be 3-4 independently-written touch points (the
+        30-min main cycle, the daily briefing, and now the 5-min tick added by
+        Issue #511) into a single shared function, so a new consumer only needs
+        to be wired in once.
+
+        record_history=True only from the 30-min cycle — the observed-extremes
+        history used for classification's high/low correction intentionally stays
+        on its existing 30-min cadence; sampling it 6x more often via the 5-min
+        tick could subtly affect classification stability and is out of scope.
+        """
+        if value is None:
+            return
+        previous = getattr(self, "_last_outdoor_temp", None)
+        self._last_outdoor_temp = value
+        self.automation_engine.update_outdoor_temp(value)
+        self._apply_outdoor_windows_gate()
+        if record_history:
+            self._outdoor_temp_history.append((dt_util.now().isoformat(), value))
+        if getattr(self, "data", None):
+            self.data[ATTR_OUTDOOR_TEMP] = value
+            self.async_update_listeners()
+        if previous is None or abs(value - previous) >= 0.1:
+            _LOGGER.info(
+                "Outdoor temp updated: %s → %.1f°F",
+                f"{previous:.1f}°F" if previous is not None else "unknown",
+                value,
+            )
+
     async def _do_startup_coalesce(self) -> None:
         """Proactively coalesce HVAC and nat-vent state 5 minutes after restart (Issue #321)."""
         open_sensors = [s for s in self._resolved_sensors if self._is_sensor_open(s)]
@@ -1624,8 +1672,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 "threshold_cool": self.config.get(CONF_THRESHOLD_COOL, DEFAULT_THRESHOLD_COOL),
             }
             self._current_classification = classify_day(forecast, previous_day_type=prev_type, **_thresh)
-            self._last_outdoor_temp = forecast.current_outdoor_temp
-            self._apply_outdoor_windows_gate()
+            # record_history=True here; the 5-min tick (Issue #511) always passes False
+            # so _outdoor_temp_history keeps its existing 30-min cadence.
+            self._apply_outdoor_temp(forecast.current_outdoor_temp, record_history=True)
 
             # Chart log: emit classification_change event when day type changes
             if prev_type is not None and prev_type != self._current_classification.day_type:
@@ -1856,11 +1905,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 self._startup_retries_remaining = 5
                 self._startup_retry_delay = 30
 
-            # Record temperature history for dashboard chart
+            # Outdoor temp history + automation-engine mirror now handled by
+            # _apply_outdoor_temp() above (Issue #511 consolidation).
             now_str = dt_util.now().isoformat()
-            self._outdoor_temp_history.append((now_str, forecast.current_outdoor_temp))
-            # Keep automation engine's outdoor temp current for natural vent decisions
-            self.automation_engine.update_outdoor_temp(forecast.current_outdoor_temp)
             if forecast.current_indoor_temp is not None:
                 self._indoor_temp_history.append((now_str, forecast.current_indoor_temp))
 
@@ -2285,7 +2332,31 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                             state.state,
                         )
 
-        # weather_service source or fallback
+        # weather_service source or fallback: interpolate between the two nearest
+        # hourly-forecast points instead of trusting the weather integration's live
+        # "temperature" attribute directly — that attribute is itself often just a
+        # coarse point-sample of the same hourly model (e.g. Met.no refreshes ~hourly),
+        # so it can lag or lead true current conditions by up to ~an hour during a
+        # temperature ramp (Issue #511).
+        interpolated, method = _interpolate_hourly_outdoor_temp(
+            getattr(self, "_hourly_forecast_temps", None), dt_util.now()
+        )
+        if interpolated is not None:
+            # Hourly forecast entries report temperature in the weather entity's
+            # native unit, same as weather_attrs["temperature"] below — must go
+            # through the same conversion, not just the live-attribute fallback.
+            interpolated_f = to_fahrenheit(interpolated, unit)
+            if method == "edge-nearest":
+                _LOGGER.debug(
+                    "Outdoor temp: edge-clamped interpolation (%.1f°F) — now is outside the hourly forecast range",
+                    interpolated_f,
+                )
+            return interpolated_f
+
+        _LOGGER.warning(
+            "Hourly forecast interpolation unavailable for outdoor temp — "
+            "falling back to weather nowcast attribute (integration may not support hourly forecasts)"
+        )
         return to_fahrenheit(float(weather_attrs.get("temperature", 65)), unit)
 
     def _get_indoor_temp(self) -> float | None:
@@ -2633,8 +2704,10 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         }
         classification = classify_day(forecast, previous_day_type=prev_type, **_thresh)
         self._current_classification = classification
-        self._last_outdoor_temp = forecast.current_outdoor_temp
-        self._apply_outdoor_windows_gate()
+        # Issue #511: also mirrors to automation_engine now (previously this call
+        # site didn't — a minor pre-existing gap closed as a side effect of the
+        # single-function consolidation).
+        self._apply_outdoor_temp(forecast.current_outdoor_temp, record_history=False)
 
         # Daily incremental solar phase re-fit (Issue #310/#312)
         if self.config.get("learning_enabled", True):
@@ -2945,6 +3018,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._outdoor_temp_history.clear()
         self._indoor_temp_history.clear()
         self._hourly_forecast_temps.clear()
+        # Issue #511: refetch immediately rather than waiting for the next 30-min
+        # cycle — otherwise outdoor-temp interpolation has nothing to interpolate
+        # against for up to ~30 min after every midnight reset, degrading nightly
+        # to the raw (pre-Issue #511) weather attribute with a WARNING each time.
+        self._hourly_forecast_temps = await self._get_hourly_forecast_data()
+        self.automation_engine._hourly_forecast_temps = self._hourly_forecast_temps
 
         # Reset pre-cool state for the new day
         if self._pre_cool_trigger_cancel is not None:
@@ -8332,6 +8411,34 @@ def _build_outdoor_curve(
     return result
 
 
+def _parse_forecast_entries(hourly_forecast: list[dict] | None) -> list[tuple[datetime, float]]:
+    """Extract raw (datetime, temperature) pairs from hourly forecast entries.
+
+    Shared field-extraction/validation used by every function that reads
+    self._hourly_forecast_temps, so entry-shape parsing (datetime/time key
+    fallback, temperature/temp key fallback, ISO parse failure handling) only
+    needs to be correct in one place. Timestamps are returned exactly as
+    parsed (naive or aware, in original order) — callers apply their own
+    timezone normalization, since existing callers intentionally differ in
+    how they treat naive timestamps (UTC-anchored delta comparison vs.
+    local-display formatting).
+    """
+    if not hourly_forecast:
+        return []
+    result: list[tuple[datetime, float]] = []
+    for entry in hourly_forecast:
+        dt_str = entry.get("datetime") or entry.get("time")
+        temp = entry.get("temperature") if entry.get("temperature") is not None else entry.get("temp")
+        if dt_str is None or temp is None:
+            continue
+        try:
+            dt_obj = datetime.fromisoformat(dt_str)
+            result.append((dt_obj, float(temp)))
+        except (ValueError, TypeError):
+            continue
+    return result
+
+
 def _build_future_forecast_outdoor(
     hourly_forecast: list[dict] | None,
     classification: Any | None = None,
@@ -8349,20 +8456,11 @@ def _build_future_forecast_outdoor(
     """
     now = dt_util.now()
     result = []
-    if hourly_forecast:
-        for entry in hourly_forecast:
-            dt_str = entry.get("datetime") or entry.get("time")
-            temp = entry.get("temperature") if entry.get("temperature") is not None else entry.get("temp")
-            if dt_str is None or temp is None:
-                continue
-            try:
-                dt_obj = datetime.fromisoformat(dt_str)
-                local_dt = dt_util.as_local(dt_obj) if dt_obj.tzinfo else dt_obj
-                if local_dt < now:
-                    continue
-                result.append({"ts": local_dt.isoformat(), "temp": round(float(temp), 1)})
-            except (ValueError, TypeError):
-                continue
+    for dt_obj, temp in _parse_forecast_entries(hourly_forecast):
+        local_dt = dt_util.as_local(dt_obj) if dt_obj.tzinfo else dt_obj
+        if local_dt < now:
+            continue
+        result.append({"ts": local_dt.isoformat(), "temp": round(temp, 1)})
     if not result and classification is not None:
         # Hourly forecast unavailable — build cosine curve for display
         cosine = _cosine_outdoor_curve(classification.today_high, classification.today_low)
@@ -8386,26 +8484,78 @@ def _extract_current_hour_forecast_temp(
     exact hour matching would never find the current hour. Instead, find the
     entry with minimum absolute time delta to now.
     """
-    if not hourly_forecast:
+    entries = _parse_forecast_entries(hourly_forecast)
+    if not entries:
         return None
     now_utc = now.replace(tzinfo=UTC) if now.tzinfo is None else now.astimezone(UTC)
     best_temp: float | None = None
     best_delta: float = float("inf")
-    for entry in hourly_forecast:
-        dt_str = entry.get("datetime") or entry.get("time")
-        temp = entry.get("temperature") if entry.get("temperature") is not None else entry.get("temp")
-        if dt_str is None or temp is None:
-            continue
-        try:
-            dt_obj = datetime.fromisoformat(dt_str)
-            entry_utc = dt_obj.replace(tzinfo=UTC) if dt_obj.tzinfo is None else dt_obj.astimezone(UTC)
-            delta = abs((entry_utc - now_utc).total_seconds())
-            if delta < best_delta and delta <= 7200:
-                best_delta = delta
-                best_temp = round(float(temp), 1)
-        except (ValueError, TypeError):
-            continue
+    for dt_obj, temp in entries:
+        entry_utc = dt_obj.replace(tzinfo=UTC) if dt_obj.tzinfo is None else dt_obj.astimezone(UTC)
+        delta = abs((entry_utc - now_utc).total_seconds())
+        if delta < best_delta and delta <= 7200:
+            best_delta = delta
+            best_temp = round(temp, 1)
     return best_temp
+
+
+def _interpolate_hourly_outdoor_temp(
+    hourly_forecast: list[dict] | None,
+    now: datetime,
+) -> tuple[float | None, str]:
+    """Estimate current outdoor temp by linearly interpolating between the two
+    hourly forecast entries bracketing `now`.
+
+    HA's hourly forecast returns entries starting at the next full hour, so a
+    single reading nearest to `now` (as _extract_current_hour_forecast_temp
+    does) can be up to ~59 minutes out of phase with where outdoor temp
+    actually is within that hour. Interpolating between the two bracketing
+    entries estimates the current position along that trajectory instead.
+
+    Returns (temp, method):
+      "interpolated": now falls between two usable entries — true linear interpolation.
+      "edge-nearest": now is within 2h before the first entry or after the last —
+          clamped to that single edge value (mirrors the ±2h tolerance already
+          used by _extract_current_hour_forecast_temp).
+      "unavailable": empty/unparseable forecast, or now is outside the ±2h edge
+          tolerance on both ends — caller must fall back.
+
+    All comparisons use absolute UTC time deltas, never wall-clock hour
+    arithmetic, so this is safe across DST transitions.
+    """
+    entries = _parse_forecast_entries(hourly_forecast)
+    if not entries:
+        return None, "unavailable"
+
+    def _to_utc(dt_obj: datetime) -> datetime:
+        return dt_obj.replace(tzinfo=UTC) if dt_obj.tzinfo is None else dt_obj.astimezone(UTC)
+
+    now_utc = _to_utc(now)
+    normalized = sorted(((_to_utc(dt_obj), temp) for dt_obj, temp in entries), key=lambda pair: pair[0])
+
+    first_dt, first_temp = normalized[0]
+    last_dt, last_temp = normalized[-1]
+
+    if now_utc <= first_dt:
+        if (first_dt - now_utc).total_seconds() <= 7200:
+            return round(first_temp, 1), "edge-nearest"
+        return None, "unavailable"
+
+    if now_utc >= last_dt:
+        if (now_utc - last_dt).total_seconds() <= 7200:
+            return round(last_temp, 1), "edge-nearest"
+        return None, "unavailable"
+
+    for (dt_before, temp_before), (dt_after, temp_after) in zip(normalized, normalized[1:], strict=False):
+        if dt_before <= now_utc <= dt_after:
+            span = (dt_after - dt_before).total_seconds()
+            if span <= 0:
+                return round(temp_before, 1), "edge-nearest"
+            fraction = (now_utc - dt_before).total_seconds() / span
+            interpolated = temp_before + (temp_after - temp_before) * fraction
+            return round(interpolated, 1), "interpolated"
+
+    return None, "unavailable"
 
 
 def _derive_predicted_setpoint(

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.28"
+  "version": "0.5.29"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -995,6 +995,9 @@ class TestBriefingRegeneration:
         coord.learning.get_thermal_model.return_value = {}
 
         coord._async_save_state = AsyncMock()
+        # Issue #511: _async_end_of_day now refetches the hourly forecast immediately
+        # after clearing it, to close the midnight interpolation data gap.
+        coord._get_hourly_forecast_data = AsyncMock(return_value=[])
 
         # Stubs for Phase 2 ceiling guard (not under test here)
         coord._get_indoor_temp = MagicMock(return_value=None)

--- a/tests/test_outdoor_temp_interpolation.py
+++ b/tests/test_outdoor_temp_interpolation.py
@@ -1,0 +1,209 @@
+"""Tests for outdoor-temperature interpolation (Issue #511).
+
+_parse_forecast_entries() is the shared field-extraction helper used by
+_extract_current_hour_forecast_temp, _build_future_forecast_outdoor, and the
+new _interpolate_hourly_outdoor_temp. _interpolate_hourly_outdoor_temp()
+estimates current outdoor temp by linearly interpolating between the two
+hourly-forecast entries bracketing `now`, instead of nearest-neighbor-picking
+a single (possibly up-to-59-min-stale) entry.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+
+from custom_components.climate_advisor.coordinator import (
+    _interpolate_hourly_outdoor_temp,
+    _parse_forecast_entries,
+)
+
+
+def _entry(dt: datetime, temp: float) -> dict:
+    return {"datetime": dt.isoformat(), "temperature": temp}
+
+
+class TestParseForecastEntries:
+    """Shared parsing helper: field extraction and validation only."""
+
+    def test_empty_and_none_return_empty_list(self):
+        assert _parse_forecast_entries(None) == []
+        assert _parse_forecast_entries([]) == []
+
+    def test_extracts_datetime_and_temperature_fields(self):
+        dt = datetime(2026, 5, 11, 12, 0, 0, tzinfo=UTC)
+        result = _parse_forecast_entries([_entry(dt, 70.0)])
+        assert result == [(dt, 70.0)]
+
+    def test_falls_back_to_time_and_temp_keys(self):
+        result = _parse_forecast_entries([{"time": "2026-05-11T12:00:00+00:00", "temp": 65.0}])
+        assert result == [(datetime(2026, 5, 11, 12, 0, 0, tzinfo=UTC), 65.0)]
+
+    def test_skips_entries_missing_datetime_or_temperature(self):
+        entries = [
+            {"datetime": "2026-05-11T12:00:00+00:00"},  # no temp
+            {"temperature": 70.0},  # no datetime
+            {},
+        ]
+        assert _parse_forecast_entries(entries) == []
+
+    def test_skips_unparseable_datetime(self):
+        entries = [{"datetime": "not-a-date", "temperature": 70.0}]
+        assert _parse_forecast_entries(entries) == []
+
+    def test_preserves_original_order_not_sorted(self):
+        dt1 = datetime(2026, 5, 11, 14, 0, 0, tzinfo=UTC)
+        dt2 = datetime(2026, 5, 11, 12, 0, 0, tzinfo=UTC)
+        result = _parse_forecast_entries([_entry(dt1, 75.0), _entry(dt2, 65.0)])
+        assert result == [(dt1, 75.0), (dt2, 65.0)]
+
+
+class TestInterpolateHourlyOutdoorTemp:
+    """Linear interpolation between bracketing hourly-forecast entries."""
+
+    def test_empty_and_none_return_unavailable(self):
+        now = datetime(2026, 5, 11, 12, 0, 0, tzinfo=UTC)
+        assert _interpolate_hourly_outdoor_temp(None, now) == (None, "unavailable")
+        assert _interpolate_hourly_outdoor_temp([], now) == (None, "unavailable")
+
+    def test_all_entries_unparseable_returns_unavailable(self):
+        now = datetime(2026, 5, 11, 12, 0, 0, tzinfo=UTC)
+        entries = [{"datetime": "garbage", "temperature": 70.0}]
+        assert _interpolate_hourly_outdoor_temp(entries, now) == (None, "unavailable")
+
+    def test_exact_midpoint_interpolation(self):
+        """now exactly halfway between two 1h-apart entries → average of the two temps."""
+        now = datetime(2026, 5, 11, 13, 30, 0, tzinfo=UTC)
+        entries = [
+            _entry(datetime(2026, 5, 11, 13, 0, 0, tzinfo=UTC), 70.0),
+            _entry(datetime(2026, 5, 11, 14, 0, 0, tzinfo=UTC), 74.0),
+        ]
+        result, method = _interpolate_hourly_outdoor_temp(entries, now)
+        assert result == 72.0
+        assert method == "interpolated"
+
+    def test_quarter_point_interpolation(self):
+        """now 15 min into a 1h span → 25% of the way from first temp to second."""
+        now = datetime(2026, 5, 11, 13, 15, 0, tzinfo=UTC)
+        entries = [
+            _entry(datetime(2026, 5, 11, 13, 0, 0, tzinfo=UTC), 60.0),
+            _entry(datetime(2026, 5, 11, 14, 0, 0, tzinfo=UTC), 68.0),
+        ]
+        result, method = _interpolate_hourly_outdoor_temp(entries, now)
+        assert result == 62.0
+        assert method == "interpolated"
+
+    def test_non_hour_aligned_gap_interpolation(self):
+        """Bracketing entries need not be exactly 1h apart."""
+        now = datetime(2026, 5, 11, 13, 20, 0, tzinfo=UTC)
+        entries = [
+            _entry(datetime(2026, 5, 11, 13, 0, 0, tzinfo=UTC), 70.0),
+            _entry(datetime(2026, 5, 11, 13, 40, 0, tzinfo=UTC), 74.0),
+        ]
+        result, method = _interpolate_hourly_outdoor_temp(entries, now)
+        # 20 of 40 minutes elapsed = 50% of the way from 70 to 74
+        assert result == 72.0
+        assert method == "interpolated"
+
+    def test_before_first_entry_within_2h_clamps_to_edge(self):
+        now = datetime(2026, 5, 11, 11, 0, 0, tzinfo=UTC)
+        entries = [_entry(datetime(2026, 5, 11, 12, 30, 0, tzinfo=UTC), 65.0)]
+        result, method = _interpolate_hourly_outdoor_temp(entries, now)
+        assert result == 65.0
+        assert method == "edge-nearest"
+
+    def test_before_first_entry_beyond_2h_unavailable(self):
+        now = datetime(2026, 5, 11, 9, 0, 0, tzinfo=UTC)
+        entries = [_entry(datetime(2026, 5, 11, 12, 0, 0, tzinfo=UTC), 65.0)]
+        result, method = _interpolate_hourly_outdoor_temp(entries, now)
+        assert result is None
+        assert method == "unavailable"
+
+    def test_after_last_entry_within_2h_clamps_to_edge(self):
+        now = datetime(2026, 5, 11, 15, 30, 0, tzinfo=UTC)
+        entries = [_entry(datetime(2026, 5, 11, 14, 0, 0, tzinfo=UTC), 80.0)]
+        result, method = _interpolate_hourly_outdoor_temp(entries, now)
+        assert result == 80.0
+        assert method == "edge-nearest"
+
+    def test_after_last_entry_beyond_2h_unavailable(self):
+        now = datetime(2026, 5, 11, 20, 0, 0, tzinfo=UTC)
+        entries = [_entry(datetime(2026, 5, 11, 14, 0, 0, tzinfo=UTC), 80.0)]
+        result, method = _interpolate_hourly_outdoor_temp(entries, now)
+        assert result is None
+        assert method == "unavailable"
+
+    def test_unsorted_input_still_interpolates_correctly(self):
+        """Entries out of order in the raw list must still bracket correctly."""
+        now = datetime(2026, 5, 11, 13, 30, 0, tzinfo=UTC)
+        entries = [
+            _entry(datetime(2026, 5, 11, 15, 0, 0, tzinfo=UTC), 90.0),
+            _entry(datetime(2026, 5, 11, 13, 0, 0, tzinfo=UTC), 70.0),
+            _entry(datetime(2026, 5, 11, 14, 0, 0, tzinfo=UTC), 74.0),
+        ]
+        result, method = _interpolate_hourly_outdoor_temp(entries, now)
+        assert result == 72.0
+        assert method == "interpolated"
+
+    def test_duplicate_timestamp_entries_do_not_divide_by_zero(self):
+        now = datetime(2026, 5, 11, 13, 0, 0, tzinfo=UTC)
+        entries = [
+            _entry(datetime(2026, 5, 11, 13, 0, 0, tzinfo=UTC), 70.0),
+            _entry(datetime(2026, 5, 11, 13, 0, 0, tzinfo=UTC), 71.0),
+        ]
+        result, method = _interpolate_hourly_outdoor_temp(entries, now)
+        assert result is not None
+        assert method in ("interpolated", "edge-nearest")
+
+    def test_naive_now_treated_as_utc(self):
+        """A naive `now` (no tzinfo) is treated as UTC, matching _extract_current_hour_forecast_temp."""
+        now = datetime(2026, 5, 11, 13, 30, 0)  # naive
+        entries = [
+            _entry(datetime(2026, 5, 11, 13, 0, 0, tzinfo=UTC), 70.0),
+            _entry(datetime(2026, 5, 11, 14, 0, 0, tzinfo=UTC), 74.0),
+        ]
+        result, method = _interpolate_hourly_outdoor_temp(entries, now)
+        assert result == 72.0
+        assert method == "interpolated"
+
+    def test_dst_spring_forward_transition_is_absolute_time_safe(self):
+        """Simulates a US-style spring-forward: wall clock jumps 02:00 -> 03:00,
+        so a naive local wall-clock diff would see 2 local "hours" between entries
+        that are actually only 1 hour apart in real (UTC) time.
+
+        Uses fixed UTC-offset `timezone` objects rather than ZoneInfo, so this
+        test doesn't depend on the platform having an IANA tzdata database
+        installed (not guaranteed on Windows without the `tzdata` package).
+        Interpolation must use absolute elapsed seconds, not wall-clock hour
+        arithmetic, so the fraction computed across the offset change is still
+        correct.
+        """
+        pst = timezone(timedelta(hours=-8))
+        pdt = timezone(timedelta(hours=-7))
+        # 01:00 PST and 04:00 PDT differ by 3 "wall-clock hours" but only 2 real
+        # hours (01:00 PST = 09:00 UTC, 04:00 PDT = 11:00 UTC) across the gap.
+        before = datetime(2026, 3, 8, 1, 0, 0, tzinfo=pst)
+        after = datetime(2026, 3, 8, 4, 0, 0, tzinfo=pdt)
+        entries = [_entry(before, 50.0), _entry(after, 58.0)]
+
+        # now = 1 real hour after `before` (10:00 UTC) = halfway through the 2h real span
+        now = datetime(2026, 3, 8, 10, 0, 0, tzinfo=UTC)
+        result, method = _interpolate_hourly_outdoor_temp(entries, now)
+        assert method == "interpolated"
+        assert result == 54.0  # exact midpoint of 50.0 and 58.0
+
+    def test_dst_fall_back_transition_is_absolute_time_safe(self):
+        """Simulates a US-style fall-back: wall clock repeats 01:00-02:00,
+        so a naive local wall-clock diff would see fewer local "hours" between
+        entries than actually elapsed in real (UTC) time.
+        """
+        pdt = timezone(timedelta(hours=-7))
+        pst = timezone(timedelta(hours=-8))
+        before = datetime(2026, 11, 1, 0, 0, 0, tzinfo=pdt)  # 00:00 PDT = 07:00 UTC
+        after = datetime(2026, 11, 1, 3, 0, 0, tzinfo=pst)  # 03:00 PST = 11:00 UTC (real span = 4h)
+        entries = [_entry(before, 50.0), _entry(after, 66.0)]
+
+        # now = 2 real hours after `before` (09:00 UTC) = halfway through the 4h real span
+        now = datetime(2026, 11, 1, 9, 0, 0, tzinfo=UTC)
+        result, method = _interpolate_hourly_outdoor_temp(entries, now)
+        assert method == "interpolated"
+        assert result == 58.0  # exact midpoint of 50.0 and 66.0

--- a/tests/test_outdoor_temp_propagation.py
+++ b/tests/test_outdoor_temp_propagation.py
@@ -1,0 +1,267 @@
+"""Coordinator-level tests for outdoor-temp propagation (Issue #511).
+
+Exercises the real ClimateAdvisorCoordinator._apply_outdoor_temp(),
+_refresh_weather_service_outdoor_temp(), _get_outdoor_temp(), and
+_async_end_of_day() via the established object.__new__() + types.MethodType()
+partial-instantiation pattern (see test_contact_status.py, test_daily_record_accuracy.py)
+rather than replicating their logic — per project doctrine, mirroring the logic
+under test can't catch a bug in that logic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+if "homeassistant" not in sys.modules:
+    from conftest import _install_ha_stubs
+
+    _install_ha_stubs()
+
+from custom_components.climate_advisor.const import (
+    ATTR_OUTDOOR_TEMP,
+    TEMP_SOURCE_INPUT_NUMBER,
+    TEMP_SOURCE_SENSOR,
+    TEMP_SOURCE_WEATHER_SERVICE,
+)
+
+
+def _get_coordinator_class():
+    """Return the current ClimateAdvisorCoordinator class (see test_daily_record_accuracy.py
+    for why this must be a fresh import rather than a module-level reference)."""
+    mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+    return mod.ClimateAdvisorCoordinator
+
+
+def _make_coordinator(outdoor_temp_source: str = TEMP_SOURCE_WEATHER_SERVICE, **config_overrides) -> object:
+    """Build a bare coordinator bound to the real outdoor-temp-propagation methods."""
+    ClimateAdvisorCoordinator = _get_coordinator_class()
+    coord = object.__new__(ClimateAdvisorCoordinator)
+    coord.config = {
+        "outdoor_temp_source": outdoor_temp_source,
+        "outdoor_temp_entity": "sensor.outdoor_temp",
+        "weather_entity": "weather.forecast_home",
+        "temp_unit": "fahrenheit",
+        **config_overrides,
+    }
+    coord.hass = MagicMock()
+    coord.automation_engine = MagicMock()
+    coord._last_outdoor_temp = None
+    coord._current_classification = None
+    coord._outdoor_temp_history = []
+    coord.data = None
+    coord.async_update_listeners = MagicMock()
+    coord._apply_outdoor_windows_gate = types.MethodType(ClimateAdvisorCoordinator._apply_outdoor_windows_gate, coord)
+    coord._apply_outdoor_temp = types.MethodType(ClimateAdvisorCoordinator._apply_outdoor_temp, coord)
+    coord._get_outdoor_temp = types.MethodType(ClimateAdvisorCoordinator._get_outdoor_temp, coord)
+    coord._refresh_weather_service_outdoor_temp = types.MethodType(
+        ClimateAdvisorCoordinator._refresh_weather_service_outdoor_temp, coord
+    )
+    coord._async_thermal_sample_tick = types.MethodType(ClimateAdvisorCoordinator._async_thermal_sample_tick, coord)
+    coord._sample_all_observations = MagicMock()
+    return coord
+
+
+def _fc_entry(iso_dt: str, temp: float) -> dict:
+    return {"datetime": iso_dt, "temperature": temp}
+
+
+class TestApplyOutdoorTemp:
+    def test_sets_last_outdoor_temp_and_mirrors_to_automation_engine(self):
+        coord = _make_coordinator()
+        coord._apply_outdoor_temp(72.0, record_history=False)
+        assert coord._last_outdoor_temp == 72.0
+        coord.automation_engine.update_outdoor_temp.assert_called_once_with(72.0)
+
+    def test_none_value_is_a_no_op(self):
+        coord = _make_coordinator()
+        coord._last_outdoor_temp = 70.0
+        coord._apply_outdoor_temp(None, record_history=True)
+        assert coord._last_outdoor_temp == 70.0
+        coord.automation_engine.update_outdoor_temp.assert_not_called()
+        assert coord._outdoor_temp_history == []
+
+    def test_record_history_true_appends_history(self):
+        coord = _make_coordinator()
+        coord._apply_outdoor_temp(68.0, record_history=True)
+        assert len(coord._outdoor_temp_history) == 1
+        assert coord._outdoor_temp_history[0][1] == 68.0
+
+    def test_record_history_false_does_not_append(self):
+        coord = _make_coordinator()
+        coord._apply_outdoor_temp(68.0, record_history=False)
+        assert coord._outdoor_temp_history == []
+
+    def test_patches_coordinator_data_and_notifies_listeners_when_data_exists(self):
+        coord = _make_coordinator()
+        coord.data = {ATTR_OUTDOOR_TEMP: 60.0, "other_key": "unchanged"}
+        coord._apply_outdoor_temp(75.0, record_history=False)
+        assert coord.data[ATTR_OUTDOOR_TEMP] == 75.0
+        assert coord.data["other_key"] == "unchanged"
+        coord.async_update_listeners.assert_called_once()
+
+    def test_no_listener_notification_when_data_is_none(self):
+        coord = _make_coordinator()
+        assert coord.data is None
+        coord._apply_outdoor_temp(75.0, record_history=False)
+        coord.async_update_listeners.assert_not_called()
+
+
+class TestRefreshWeatherServiceOutdoorTemp:
+    def test_weather_service_source_updates_last_outdoor_temp(self):
+        coord = _make_coordinator(outdoor_temp_source=TEMP_SOURCE_WEATHER_SERVICE)
+        weather_state = MagicMock()
+        weather_state.attributes = {"temperature": 71.0}
+        coord.hass.states.get = MagicMock(return_value=weather_state)
+        coord._hourly_forecast_temps = []  # forces fallback to the live attribute
+        coord._refresh_weather_service_outdoor_temp()
+        assert coord._last_outdoor_temp == 71.0
+        coord.automation_engine.update_outdoor_temp.assert_called_once_with(71.0)
+
+    def test_sensor_source_is_skipped_entirely(self):
+        coord = _make_coordinator(outdoor_temp_source=TEMP_SOURCE_SENSOR)
+        coord.hass.states.get = MagicMock(side_effect=AssertionError("must not be called for sensor source"))
+        coord._refresh_weather_service_outdoor_temp()
+        assert coord._last_outdoor_temp is None
+        coord.automation_engine.update_outdoor_temp.assert_not_called()
+
+    def test_input_number_source_is_skipped_entirely(self):
+        coord = _make_coordinator(outdoor_temp_source=TEMP_SOURCE_INPUT_NUMBER)
+        coord.hass.states.get = MagicMock(side_effect=AssertionError("must not be called for input_number source"))
+        coord._refresh_weather_service_outdoor_temp()
+        assert coord._last_outdoor_temp is None
+
+    def test_missing_weather_entity_state_is_a_silent_no_op(self):
+        coord = _make_coordinator(outdoor_temp_source=TEMP_SOURCE_WEATHER_SERVICE)
+        coord.hass.states.get = MagicMock(return_value=None)
+        coord._refresh_weather_service_outdoor_temp()
+        assert coord._last_outdoor_temp is None
+        coord.automation_engine.update_outdoor_temp.assert_not_called()
+
+    def test_two_consecutive_ticks_with_different_forecasts_produce_different_values(self):
+        """Simulates two 5-min ticks where the hourly forecast bracket changes —
+        _last_outdoor_temp must actually vary, not stay pinned to a single stale value."""
+        coord = _make_coordinator(outdoor_temp_source=TEMP_SOURCE_WEATHER_SERVICE)
+        weather_state = MagicMock()
+        weather_state.attributes = {"temperature": 999.0}  # would only be used if interpolation unavailable
+        coord.hass.states.get = MagicMock(return_value=weather_state)
+
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now") as mock_now:
+            mock_now.return_value = datetime(2026, 5, 11, 13, 10, 0, tzinfo=UTC)
+            coord._hourly_forecast_temps = [
+                _fc_entry("2026-05-11T13:00:00+00:00", 70.0),
+                _fc_entry("2026-05-11T14:00:00+00:00", 74.0),
+            ]
+            coord._refresh_weather_service_outdoor_temp()
+            first = coord._last_outdoor_temp
+
+            mock_now.return_value = datetime(2026, 5, 11, 13, 40, 0, tzinfo=UTC)
+            coord._refresh_weather_service_outdoor_temp()
+            second = coord._last_outdoor_temp
+
+        assert first != second
+        assert first == pytest.approx(70.7, abs=0.05)  # 10/60 of the way from 70 to 74
+        assert second == pytest.approx(72.7, abs=0.05)  # 40/60 of the way from 70 to 74
+
+    def test_async_thermal_sample_tick_calls_refresh_then_sample(self):
+        """The 5-min tick must refresh outdoor temp before sampling observations.
+
+        _async_thermal_sample_tick is decorated with @callback, which the test
+        stub layer replaces with a MagicMock (homeassistant.core is a MagicMock
+        module) — so the class attribute captured at import time is already a
+        swallowed mock, not the real function (per project doctrine on invoking
+        @callback-decorated methods directly). Patching coordinator.callback
+        directly doesn't survive a reload (the module's `from homeassistant.core
+        import callback` re-fetches it), so the source (homeassistant.core.callback)
+        must be patched instead, before reloading. Reload again (unpatched)
+        immediately after so every other test in this session keeps seeing the
+        normal swallowed-by-default behavior.
+        """
+        coordinator_module = importlib.import_module("custom_components.climate_advisor.coordinator")
+        with patch("homeassistant.core.callback", side_effect=lambda fn: fn):
+            importlib.reload(coordinator_module)
+            real_tick = coordinator_module.ClimateAdvisorCoordinator._async_thermal_sample_tick
+        importlib.reload(coordinator_module)  # restore default (swallowed) state for other tests
+
+        coord = _make_coordinator(outdoor_temp_source=TEMP_SOURCE_WEATHER_SERVICE)
+        weather_state = MagicMock()
+        weather_state.attributes = {"temperature": 65.0}
+        coord.hass.states.get = MagicMock(return_value=weather_state)
+        coord._hourly_forecast_temps = []
+        coord._async_thermal_sample_tick = types.MethodType(real_tick, coord)
+
+        coord._async_thermal_sample_tick(datetime(2026, 5, 11, 13, 0, 0, tzinfo=UTC))
+        assert coord._last_outdoor_temp == 65.0
+        coord._sample_all_observations.assert_called_once()
+
+
+class TestChartMachineryNonRegressionGuardrail:
+    """Issue #511 must not touch _pred_archive, chart_log, _build_predicted_indoor_future,
+    or _compute_target_band_schedule — the outdoor-temp refresh path is a fully separate
+    code path from chart-prediction machinery (verified during design; this test guards
+    against future accidental coupling)."""
+
+    def test_apply_outdoor_temp_does_not_touch_pred_archive(self):
+        coord = _make_coordinator()
+        coord._pred_archive = {"sentinel": 123.0}
+        coord._apply_outdoor_temp(70.0, record_history=False)
+        assert coord._pred_archive == {"sentinel": 123.0}
+
+    def test_refresh_weather_service_outdoor_temp_does_not_call_build_predicted_indoor_future(self):
+        coord = _make_coordinator(outdoor_temp_source=TEMP_SOURCE_WEATHER_SERVICE)
+        weather_state = MagicMock()
+        weather_state.attributes = {"temperature": 65.0}
+        coord.hass.states.get = MagicMock(return_value=weather_state)
+        coord._hourly_forecast_temps = []
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        with (
+            patch.object(mod, "_build_predicted_indoor_future") as mock_ode,
+            patch.object(mod, "_compute_target_band_schedule") as mock_band,
+        ):
+            coord._refresh_weather_service_outdoor_temp()
+            mock_ode.assert_not_called()
+            mock_band.assert_not_called()
+
+
+class TestAsyncEndOfDayRefetchesHourlyForecast:
+    """Issue #511: the midnight reset must not leave a data gap for interpolation."""
+
+    def test_hourly_forecast_repopulated_immediately_after_clear(self):
+        ClimateAdvisorCoordinator = _get_coordinator_class()
+        coord = object.__new__(ClimateAdvisorCoordinator)
+        coord.config = {"learning_enabled": True}
+        coord._today_record = None
+        coord._briefing_sent_today = True
+        coord._briefing_day_type = "warm"
+        coord._hvac_on_since = None
+        coord._last_violation_check = None
+        coord._outdoor_temp_history = [("2026-05-11T12:00:00", 70.0)]
+        coord._indoor_temp_history = [("2026-05-11T12:00:00", 71.0)]
+        coord._hourly_forecast_temps = [_fc_entry("2026-05-11T13:00:00+00:00", 70.0)]
+        coord.automation_engine = MagicMock()
+        coord._pre_cool_trigger_cancel = None
+        coord._pre_cool_trigger_scheduled = True
+        coord._pre_cool_status = "scheduled"
+        coord._pre_cool_trigger_dt = None
+        coord._pre_cool_target = None
+
+        new_forecast = [_fc_entry("2026-05-12T00:00:00+00:00", 60.0)]
+        coord._get_hourly_forecast_data = AsyncMock(return_value=new_forecast)
+        coord._async_save_state = AsyncMock()
+
+        coord._async_end_of_day = types.MethodType(ClimateAdvisorCoordinator._async_end_of_day, coord)
+
+        from datetime import UTC, datetime
+
+        asyncio.run(coord._async_end_of_day(datetime(2026, 5, 11, 23, 59, 0, tzinfo=UTC)))
+
+        assert coord._hourly_forecast_temps == new_forecast
+        assert coord._outdoor_temp_history == []
+        coord._get_hourly_forecast_data.assert_awaited_once()
+        coord._async_save_state.assert_awaited_once()


### PR DESCRIPTION
## Summary

- For installs with no dedicated outdoor sensor (`outdoor_temp_source: weather_service`, e.g. Met.no's `weather.forecast_home`), "Actual Outdoor" and every automation decision based on it read a stale point-sample of the weather integration's live `temperature` attribute — confirmed via live chart_log analysis (~107 days pulled via SSH) to plateau 30-90 min before updating, producing up to a ~4°F error during morning/evening temperature ramps and corrupting the thermal-learning OLS regression's 5-min sampling.
- Outdoor temp is now estimated via linear interpolation between the two nearest hourly forecast points, refreshed every 5 minutes via the existing thermal-sample timer (previously only refreshed once per 30-min cycle).
- A new `_apply_outdoor_temp()` consolidates 4 independently-written propagation touch points (30-min cycle x2, daily briefing, new 5-min tick) into one function; a new shared `_parse_forecast_entries()` helper removes duplicated parsing boilerplate across 3 forecast-reading functions.
- The midnight reset now immediately refetches the hourly forecast, closing a ~30-min nightly data gap.
- Sensor/input_number-configured installs are fully unaffected — untouched code path, already live via an existing state-change listener.

## Explicitly out of scope (tracked as separate follow-up issues)

- "Predicted Outdoor" line's own ~30-60 min offset (nearest-neighbor vs. interpolation) — deliberately not touched; fixing it would make the two chart lines nearly coincide for weather-service installs, defeating the point of showing both.
- Target Band chart history — confirmed zero persistence, pre-existing and unrelated.
- The no-HVAC counterfactual prediction question — undecided product question, unrelated.
- A likely pre-existing Celsius-unit bug found (not fixed) in the predicted-outdoor path — flagged for its own issue.
- Nat-vent threshold arithmetic duplication (4 sites) — identified during design, deliberately deferred to keep this PR's diff minimal for a live-HVAC-controlling production deploy.

## Test plan

- [x] New unit tests: `tests/test_outdoor_temp_interpolation.py` (20 tests — parsing helper + interpolation edge cases including DST transitions)
- [x] New coordinator-level tests: `tests/test_outdoor_temp_propagation.py` (15 tests — propagation, weather-service vs. sensor gating, midnight refetch, chart-machinery non-regression guardrail)
- [x] Existing regression suite (`tests/test_prediction.py`) confirms the parsing-helper refactor is behavior-preserving for the two pre-existing forecast functions (100/100 passed)
- [x] Full test suite: 3531/3531 passed, including with `-W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`
- [x] `python tools/simulate.py`: 74/74 golden scenarios passed
- [x] `python tools/validate.py`: all checks passed
- [x] `ruff check` / `ruff format`: clean