### PR TITLE
Fix #515: repo-wide ruff format drift + pin ruff upper bound

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -159,9 +159,7 @@ Before calling a function from inside an `async def` method, ask: **"Does this r
 ```python
 import functools
 
-result = await self.hass.async_add_executor_job(
-    functools.partial(heavy_sync_function, arg1, arg2, keyword=value)
-)
+result = await self.hass.async_add_executor_job(functools.partial(heavy_sync_function, arg1, arg2, keyword=value))
 ```
 
 **Capture all arguments in the event loop thread** (i.e., evaluate `self.*` attributes and helper calls like `self._get_indoor_temp()` before `functools.partial`, not inside the executor). The executor runs the partial with no additional arguments.
@@ -274,6 +272,8 @@ replace the README badge with a hardcoded string, or skip a GitHub Release on a 
   ```python
   def _consume_coroutine(coro):
       coro.close()
+
+
   hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
   ```
   Reference implementations: `test_door_window.py:255`, `test_resume_from_pause.py:44`
@@ -911,6 +911,8 @@ Any callback passed to `async_call_later` that calls `hass.async_create_task` MU
 @callback
 def _schedule_work(_now: Any) -> None:
     self.hass.async_create_task(_do_async_work())
+
+
 async_call_later(self.hass, delay, _schedule_work)
 ```
 Never: `async_call_later(self.hass, delay, lambda _now: self.hass.async_create_task(_do_async_work()))`. `callback` is imported from `homeassistant.core` and is already present in `automation.py` and `coordinator.py`. Issue #325 fixed four violations of this rule.

--- a/docs/05-LEARNING-ENGINE-DESIGN.md
+++ b/docs/05-LEARNING-ENGINE-DESIGN.md
@@ -476,16 +476,16 @@ Returns the current accumulated thermal model from `thermal_model_cache`.
 ```python
 {
     # Core physics parameters
-    "k_passive": float | None,              # envelope decay rate (hr⁻¹, negative)
-    "k_active_heat": float | None,          # HVAC heating contribution (°F/hr, positive)
-    "k_active_cool": float | None,          # HVAC cooling contribution (°F/hr, negative)
-    "k_vent": float | None,                 # fan-only ventilation decay rate (hr⁻¹, negative)
-    "k_vent_window": float | None,          # window-open ventilation decay rate (hr⁻¹, negative)
-    "k_solar": float | None,               # solar gain coefficient (°F/hr per unit solar factor)
+    "k_passive": float | None,  # envelope decay rate (hr⁻¹, negative)
+    "k_active_heat": float | None,  # HVAC heating contribution (°F/hr, positive)
+    "k_active_cool": float | None,  # HVAC cooling contribution (°F/hr, negative)
+    "k_vent": float | None,  # fan-only ventilation decay rate (hr⁻¹, negative)
+    "k_vent_window": float | None,  # window-open ventilation decay rate (hr⁻¹, negative)
+    "k_solar": float | None,  # solar gain coefficient (°F/hr per unit solar factor)
     # Confidence
-    "confidence": str,                      # HVAC confidence: "none"|"low"|"medium"|"high" (heat+cool obs count)
-    "confidence_k_passive": str,            # passive confidence: "none"|"low"|"medium"|"high" (passive obs count)
-    "confidence_k_hvac": str,              # same as "confidence" — explicit alias
+    "confidence": str,  # HVAC confidence: "none"|"low"|"medium"|"high" (heat+cool obs count)
+    "confidence_k_passive": str,  # passive confidence: "none"|"low"|"medium"|"high" (passive obs count)
+    "confidence_k_hvac": str,  # same as "confidence" — explicit alias
     # Observation counts
     "observation_count_heat": int,
     "observation_count_cool": int,
@@ -537,10 +537,10 @@ Analyzes historical records where both forecast and observed temperatures are pr
 
 ```python
 {
-    "high_bias": float,       # mean forecast high error in °F (positive = forecast runs warm)
-    "low_bias": float,        # mean forecast low error in °F (positive = forecast runs warm)
-    "confidence": str,        # "none" | "low" | "medium" | "high"
-    "sample_count": int,      # number of days used to compute the bias
+    "high_bias": float,  # mean forecast high error in °F (positive = forecast runs warm)
+    "low_bias": float,  # mean forecast low error in °F (positive = forecast runs warm)
+    "confidence": str,  # "none" | "low" | "medium" | "high"
+    "sample_count": int,  # number of days used to compute the bias
 }
 ```
 
@@ -603,11 +603,11 @@ The `get_compliance_summary()` method returns a dict suitable for sensor attribu
 
 ```python
 {
-    "status": "active",            # or "collecting_data"
+    "status": "active",  # or "collecting_data"
     "days_recorded": 28,
-    "window_compliance": 0.35,     # 35% of recommended days
+    "window_compliance": 0.35,  # 35% of recommended days
     "avg_daily_hvac_runtime_minutes": 145.5,
-    "comfort_score": 0.92,         # 92% of time in comfort range
+    "comfort_score": 0.92,  # 92% of time in comfort range
     "total_manual_overrides": 8,
     "pending_suggestions": 2,
 }

--- a/docs/06-LOGGING-GUIDELINES.md
+++ b/docs/06-LOGGING-GUIDELINES.md
@@ -120,9 +120,9 @@ _LOGGER.debug("No persisted state found — starting fresh")
 **WARNING — recoverable problem with fallback** (coordinator.py):
 ```python
 _LOGGER.warning(
-    "Outdoor temp entity %s has non-numeric state %r; "
-    "falling back to weather attribute",
-    entity_id, state.state,
+    "Outdoor temp entity %s has non-numeric state %r; falling back to weather attribute",
+    entity_id,
+    state.state,
 )
 ```
 

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -950,7 +950,7 @@ Prior to Issue #147, MILD day window scheduling used hardcoded `time(10, 0)` (op
 
 ```python
 # classifier.py (pre-v0.3.46) — lines 118–119
-self.window_open_time = time(10, 0)   # always 10am
+self.window_open_time = time(10, 0)  # always 10am
 self.window_close_time = time(17, 0)  # always 5pm
 ```
 
@@ -961,8 +961,8 @@ These literals were correct as a starting guess but systematically incorrect for
 **Constants moved to `const.py`:**
 
 ```python
-MILD_WINDOW_OPEN_HOUR = 10    # MILD-day window open fallback (was hardcoded in classifier.py)
-MILD_WINDOW_CLOSE_HOUR = 17   # MILD-day window close fallback
+MILD_WINDOW_OPEN_HOUR = 10  # MILD-day window open fallback (was hardcoded in classifier.py)
+MILD_WINDOW_CLOSE_HOUR = 17  # MILD-day window close fallback
 ```
 
 **`classifier.py` now uses the constants:**

--- a/docs/activity-report-table.md
+++ b/docs/activity-report-table.md
@@ -277,8 +277,7 @@ In `tests/test_ai_activity_table.py`, add a test that asserts:
 ```python
 def test_my_new_event_settings_populated():
     table = build_event_timeline_table(
-        [{"time": "10:00", "type": "my_new_event",
-          "setpoint_f": 72.0, "mode": "cool", "trigger": "user_schedule"}],
+        [{"time": "10:00", "type": "my_new_event", "setpoint_f": 72.0, "mode": "cool", "trigger": "user_schedule"}],
         config={"temp_unit": "fahrenheit"},
         hours=24,
         now=datetime.now(),

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -159,10 +159,10 @@ class AISkillDefinition:
     name: str
     description: str
     system_prompt: str
-    context_builder: Callable        # async (hass, coordinator, **kwargs) → str
-    response_parser: Callable        # (content: str) → dict
-    fallback: Callable | None        # (coordinator, context, **kwargs) → dict; None = use _error_result()
-    triggered_by: str                # "auto" | "manual" (default "manual")
+    context_builder: Callable  # async (hass, coordinator, **kwargs) → str
+    response_parser: Callable  # (content: str) → dict
+    fallback: Callable | None  # (coordinator, context, **kwargs) → dict; None = use _error_result()
+    triggered_by: str  # "auto" | "manual" (default "manual")
     # optional per-skill config key overrides:
     config_key_model: str | None
     config_key_max_tokens: str | None
@@ -190,10 +190,10 @@ Every `async_execute()` call returns exactly this shape, regardless of path take
 {
     "success": bool,
     "source": "ai" | "fallback" | "error",
-    "data": dict,                  # parsed skill output or fallback output
-    "error": str | None,           # error message; None on success
-    "input_context": str,          # the assembled context string sent to Claude
-    "raw_response": str,           # Claude's raw text response; "" on failure
+    "data": dict,  # parsed skill output or fallback output
+    "error": str | None,  # error message; None on success
+    "input_context": str,  # the assembled context string sent to Claude
+    "raw_response": str,  # Claude's raw text response; "" on failure
 }
 ```
 
@@ -293,7 +293,7 @@ Seven context blocks are assembled independently. Each is wrapped in its own `tr
     "hypotheses": str,
     "recommended_actions": str,
     "assumptions": str,
-    "full_text": str,           # always holds complete raw Claude response
+    "full_text": str,  # always holds complete raw Claude response
 }
 ```
 
@@ -330,42 +330,46 @@ Key public entry points called by external modules:
 @dataclass
 class ClaudeResponse:
     success: bool
-    content: str                  # Claude's raw text; "" on failure
+    content: str  # Claude's raw text; "" on failure
     input_tokens: int
     output_tokens: int
-    estimated_cost: float         # USD; computed from _MODEL_COSTS
+    estimated_cost: float  # USD; computed from _MODEL_COSTS
     latency_ms: int
     error: str | None
     rate_limited: bool
     circuit_open: bool
     budget_exceeded: bool
 
+
 @dataclass
 class _CircuitBreaker:
-    state: str                    # "closed" | "open" | "half_open"
+    state: str  # "closed" | "open" | "half_open"
     consecutive_failures: int
-    opened_at: datetime | None    # set when state → "open"
+    opened_at: datetime | None  # set when state → "open"
+
 
 @dataclass
 class _RateLimitCounters:
     auto_requests_today: int
     manual_requests_today: int
-    counter_date: date            # date of last reset
+    counter_date: date  # date of last reset
+
 
 @dataclass
 class _BudgetTracker:
-    monthly_cost: float           # USD accumulated this calendar month
-    budget_month: int             # calendar month (1–12) of current accumulation window
+    monthly_cost: float  # USD accumulated this calendar month
+    budget_month: int  # calendar month (1–12) of current accumulation window
+
 
 @dataclass
 class AISkillDefinition:
     name: str
     description: str
     system_prompt: str
-    context_builder: Callable     # async (hass, coordinator, **kwargs) → str
-    response_parser: Callable     # (content: str) → dict
+    context_builder: Callable  # async (hass, coordinator, **kwargs) → str
+    response_parser: Callable  # (content: str) → dict
     fallback: Callable | None
-    triggered_by: str             # "auto" | "manual"
+    triggered_by: str  # "auto" | "manual"
     model_config_key: str | None
     max_tokens_config_key: str | None
     reasoning_config_key: str | None

--- a/docs/ai-skills-spec.md
+++ b/docs/ai-skills-spec.md
@@ -129,13 +129,13 @@ Every `async_execute()` call returns exactly this shape:
 
 ```python
 {
-    "success": bool,          # True only on the AI success path
-    "source": str,            # "ai" | "fallback" | "error"
-    "data": dict,             # parsed skill output, fallback output, or {} on error
-    "error": str | None,      # error message string; None on success
-    "input_context": str,     # assembled context string; "" if context build failed early
-    "raw_response": str,      # Claude's raw text; "" on failure/fallback
-    "truncated": bool,        # True iff Claude's stop_reason was "max_tokens" (AI success path only)
+    "success": bool,  # True only on the AI success path
+    "source": str,  # "ai" | "fallback" | "error"
+    "data": dict,  # parsed skill output, fallback output, or {} on error
+    "error": str | None,  # error message string; None on success
+    "input_context": str,  # assembled context string; "" if context build failed early
+    "raw_response": str,  # Claude's raw text; "" on failure/fallback
+    "truncated": bool,  # True iff Claude's stop_reason was "max_tokens" (AI success path only)
 }
 ```
 
@@ -279,11 +279,11 @@ Formats the `get_engine_status()` return value from `LearningEngine` as a multi-
 
 ```python
 # All other engines (flat scalar):
-engine_status["k_passive"]["value"]           # float | None
+engine_status["k_passive"]["value"]  # float | None
 
 # k_active_hvac only (nested dict):
-engine_status["k_active_hvac"]["value"]["heat"]   # float | None
-engine_status["k_active_hvac"]["value"]["cool"]   # float | None
+engine_status["k_active_hvac"]["value"]["heat"]  # float | None
+engine_status["k_active_hvac"]["value"]["cool"]  # float | None
 ```
 
 **Active gate:** An engine is displayed as active when `value is not None` (or for k_active_hvac: either `heat is not None or cool is not None`). A `"since"` date is included when available; if the engine was active before date tracking was introduced (pre-v0.3.46), it displays as `"pre-v0.3.46"`.
@@ -444,7 +444,7 @@ Splits on `## HEADER` lines. Expected headers and output keys:
     "hypotheses": str,
     "recommended_actions": str,
     "assumptions": str,
-    "full_text": str,   # always populated; holds complete raw Claude response
+    "full_text": str,  # always populated; holds complete raw Claude response
 }
 ```
 

--- a/docs/briefing-spec.md
+++ b/docs/briefing-spec.md
@@ -33,7 +33,7 @@ The briefing fires at `briefing_time` (default 06:00), which typically precedes 
 (default 06:30) and the daily classification event. The briefing uses:
 
 ```python
-today_date = dt_util.now().date()       # calendar today
+today_date = dt_util.now().date()  # calendar today
 tomorrow_date = today_date + timedelta(days=1)
 ```
 

--- a/docs/claude-api-spec.md
+++ b/docs/claude-api-spec.md
@@ -228,15 +228,15 @@ A successful attempt on any retry number returns immediately without sleep.
 ```python
 @dataclass
 class ClaudeResponse:
-    success: bool          # True iff the API call completed and returned a valid response
-    content: str           # Claude's raw text response; always "" when success=False
-    input_tokens: int      # Tokens consumed from the prompt; 0 when success=False
-    output_tokens: int     # Tokens in the response; 0 when success=False
+    success: bool  # True iff the API call completed and returned a valid response
+    content: str  # Claude's raw text response; always "" when success=False
+    input_tokens: int  # Tokens consumed from the prompt; 0 when success=False
+    output_tokens: int  # Tokens in the response; 0 when success=False
     estimated_cost: float  # USD cost estimate from _MODEL_COSTS; 0.0 when success=False
-    latency_ms: float      # Wall-clock ms from first attempt to return (includes retries)
-    error: str | None      # Error message string; None when success=True
-    rate_limited: bool     # True iff rejected by the daily rate limit guard (pre-flight)
-    circuit_open: bool     # True iff rejected by the circuit breaker guard (pre-flight)
+    latency_ms: float  # Wall-clock ms from first attempt to return (includes retries)
+    error: str | None  # Error message string; None when success=True
+    rate_limited: bool  # True iff rejected by the daily rate limit guard (pre-flight)
+    circuit_open: bool  # True iff rejected by the circuit breaker guard (pre-flight)
     budget_exceeded: bool  # True iff rejected by the monthly budget guard (pre-flight)
 ```
 

--- a/docs/forecast-pipeline-spec.md
+++ b/docs/forecast-pipeline-spec.md
@@ -136,7 +136,7 @@ if today_fc is None and tomorrow_fc is None and len(forecast) >= 2:
     today_fc = forecast[0]
     tomorrow_fc = forecast[1]
 elif today_fc is None and tomorrow_fc is not None and len(forecast) >= 1:
-    today_fc = forecast[0]   # BUG: forecast[0] may be the same entry as tomorrow_fc
+    today_fc = forecast[0]  # BUG: forecast[0] may be the same entry as tomorrow_fc
 ```
 
 When the weather API returned a forecast array starting from tomorrow (no today entry), the

--- a/docs/grace-periods-spec.md
+++ b/docs/grace-periods-spec.md
@@ -471,7 +471,7 @@ This blocks ALL downstream classification effects: HVAC mode changes, temperatur
 
 ```python
 if _override_confirm_pending:
-    _override_confirm_cancel()   # cancels the pending timer
+    _override_confirm_cancel()  # cancels the pending timer
     _override_confirm_pending = False
     _override_confirm_time = None
     _override_confirm_mode = None

--- a/docs/repairs-brief.md
+++ b/docs/repairs-brief.md
@@ -104,11 +104,11 @@ No module-level data structures. `WeatherEntityRepairFlow` carries no persistent
 The entity selector schema:
 
 ```python
-vol.Schema({
-    vol.Required("weather_entity"): selector.EntitySelector(
-        selector.EntitySelectorConfig(domain="weather")
-    ),
-})
+vol.Schema(
+    {
+        vol.Required("weather_entity"): selector.EntitySelector(selector.EntitySelectorConfig(domain="weather")),
+    }
+)
 ```
 
 **Persistence:** none — the module is stateless. Issue persistence is managed by HA's issue registry, not by this module.

--- a/docs/sim-harness-brief.md
+++ b/docs/sim-harness-brief.md
@@ -57,6 +57,7 @@
 def run_production_scenario(scenario: dict) -> ProductionRunResult:
     """Drive the real AutomationEngine through a scenario dict, return logs."""
 
+
 # Build a headless engine for direct test use
 def build_headless_engine(
     config: dict | None = None,
@@ -69,9 +70,11 @@ def build_headless_engine(
 ) -> tuple[AutomationEngine, FakeHass, FakeScheduler, list]:
     """Returns (engine, fake_hass, scheduler, event_log)."""
 
+
 # Convert event_log to legacy outcome vocab
 def production_decisions(result: ProductionRunResult) -> list[ProductionDecision]:
     """Map event_log + action_log enrichment to time-ordered ProductionDecision list."""
+
 
 # Check a custom assertion type
 def check_assertion(
@@ -102,11 +105,12 @@ class ProductionRunResult:
     engine_state: dict[str, Any]  # snapshot of live engine flags
     callback_errors: list[tuple[datetime, BaseException]]
 
+
 @dataclass
 class ProductionDecision:
-    time: str          # naive ISO timestamp (tz stripped for lexicographic compare)
-    event_type: str    # raw production event type
-    outcome: str       # legacy outcome vocabulary string
+    time: str  # naive ISO timestamp (tz stripped for lexicographic compare)
+    event_type: str  # raw production event type
+    outcome: str  # legacy outcome vocabulary string
     target_temp: float | None  # set when a temperature was applied
 ```
 

--- a/docs/temperature-conversion.md
+++ b/docs/temperature-conversion.md
@@ -38,21 +38,26 @@ FAHRENHEIT: str = "fahrenheit"
 CELSIUS: str = "celsius"
 UNIT_SYMBOL: dict[str, str]  # {"fahrenheit": "°F", "celsius": "°C"}
 
+
 def to_fahrenheit(value: float, unit: str) -> float:
     """Convert an absolute temperature from display unit to internal °F.
     Use at HA config read boundaries (user-entered setpoints in Celsius homes)."""
+
 
 def from_fahrenheit(value: float, unit: str) -> float:
     """Convert an absolute temperature from internal °F to display unit.
     Use when displaying any stored temperature to the user."""
 
+
 def format_temp(value_fahrenheit: float, unit: str, decimals: int = 0) -> str:
     """Format an internal °F temperature as a display string, e.g. '22°C'.
     Calls from_fahrenheit() internally."""
 
+
 def convert_delta(value_fahrenheit: float, unit: str) -> float:
     """Convert a temperature delta or rate from °F scale to display unit scale.
     Scale only (×5/9 for Celsius) — no +32/−32 offset."""
+
 
 def format_temp_delta(delta_fahrenheit: float, unit: str, decimals: int = 0) -> str:
     """Format a temperature delta as a display string, e.g. '5°C'.

--- a/docs/thermal-model-v3-spec.md
+++ b/docs/thermal-model-v3-spec.md
@@ -388,8 +388,8 @@ When `_k_passive_via_bridge=True`, the confidence count requirement is bypassed 
 ```python
 _bridge_guard_applies = (
     _k_passive_via_bridge
-    and _windows_recommended          # classification has a window schedule
-    and not _hour_windows_open        # current hour is outside the open window
+    and _windows_recommended  # classification has a window schedule
+    and not _hour_windows_open  # current hour is outside the open window
 )
 ```
 When the guard applies, ramp interpolation is used for that hour. When windows are NOT recommended (no schedule), the bridge runs for all hours without guard interference.
@@ -521,12 +521,14 @@ def _solar_factor(
 
 ```python
 effective_hour = int(local_hour) - int(round(phase_offset_h))
-if effective_hour < THERMAL_SOLAR_DAYTIME_START_H:   # 8
+if effective_hour < THERMAL_SOLAR_DAYTIME_START_H:  # 8
     return 0.0
-if effective_hour >= THERMAL_SOLAR_DAYTIME_END_H:    # 18
+if effective_hour >= THERMAL_SOLAR_DAYTIME_END_H:  # 18
     return 0.0
 # sin curve over [8, 18), peak at effective_hour = 13
-angle = (effective_hour - THERMAL_SOLAR_DAYTIME_START_H) / (THERMAL_SOLAR_DAYTIME_END_H - THERMAL_SOLAR_DAYTIME_START_H) * π
+angle = (
+    (effective_hour - THERMAL_SOLAR_DAYTIME_START_H) / (THERMAL_SOLAR_DAYTIME_END_H - THERMAL_SOLAR_DAYTIME_START_H) * π
+)
 return max(0.0, sin(angle))
 ```
 
@@ -665,31 +667,31 @@ A chart_log window is eligible for a phase observation only when all six conditi
 
 ```python
 {
-  "k_passive": {
-    "active": bool,          # True when k_passive is not None
-    "value": float | None,   # current thermal_model_cache["k_passive"]
-    "confidence": str,       # "none" | "low" | "medium" | "high"
-  },
-  "k_solar": {
-    "active": bool,
-    "value": float | None,
-    "confidence": str,       # derived from observation_count_solar (same grade thresholds as k_passive)
-  },
-  "solar_phase_offset_h": {
-    "active": bool,          # True when solar_phase_offset_h is not None
-    "value": float | None,
-  },
-  "k_vent_window": {
-    "active": bool,
-    "value": float | None,
-  },
-  "k_active_hvac": {
-    "active": bool,                                  # True when k_active_heat or k_active_cool is not None
-    "value": {"heat": float | None, "cool": float | None},  # k_active_heat and k_active_cool
-  },
-  "ode_version": str,        # "v3" when k_solar or k_vent present; "basic" otherwise
-  "physics_eligible": bool,  # True when the ODE prediction path is currently active
-  "physics_eligible_reason": str,  # human-readable explanation of eligibility state
+    "k_passive": {
+        "active": bool,  # True when k_passive is not None
+        "value": float | None,  # current thermal_model_cache["k_passive"]
+        "confidence": str,  # "none" | "low" | "medium" | "high"
+    },
+    "k_solar": {
+        "active": bool,
+        "value": float | None,
+        "confidence": str,  # derived from observation_count_solar (same grade thresholds as k_passive)
+    },
+    "solar_phase_offset_h": {
+        "active": bool,  # True when solar_phase_offset_h is not None
+        "value": float | None,
+    },
+    "k_vent_window": {
+        "active": bool,
+        "value": float | None,
+    },
+    "k_active_hvac": {
+        "active": bool,  # True when k_active_heat or k_active_cool is not None
+        "value": {"heat": float | None, "cool": float | None},  # k_active_heat and k_active_cool
+    },
+    "ode_version": str,  # "v3" when k_solar or k_vent present; "basic" otherwise
+    "physics_eligible": bool,  # True when the ODE prediction path is currently active
+    "physics_eligible_reason": str,  # human-readable explanation of eligibility state
 }
 ```
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 pytest>=7.0
 pytest-cov>=4.0
-ruff>=0.4.0
+ruff>=0.4.0,<0.17
 pre-commit>=4.0


### PR DESCRIPTION
## Summary

- CI's \`ruff>=0.4.0\` (no upper bound) installs the latest ruff release at run time, which had drifted from the 0.15.7 the repo was actually formatted with — caused \`validate-and-test\`'s \`ruff format --check .\` to fail on PR #512 despite that PR's own files being correctly formatted (confirmed by reproducing the exact same 15-file failure against unmodified \`main\` when checked with ruff 0.16.0).
- Reformats the 15 affected files (all docs/*.md embedded Python code blocks + claude.md) with ruff 0.16.0 — formatting-only, zero logic changes.
- Pins \`ruff>=0.4.0,<0.17\` in \`requirements_test.txt\` so future ruff releases require a deliberate version bump instead of silently breaking CI on unrelated PRs again.

## Test plan

- [x] \`ruff format --check .\`: clean (265 files)
- [x] \`ruff check .\`: clean
- [x] Full test suite: 3531/3531 passed
- [x] \`python tools/simulate.py\`: golden suite unaffected (docs-only change)