### PR TITLE
Fix #545: prevent recurrence of blocking-I/O-in-async bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.42] — 2026-08-01
+
+- Fix #545: strengthened project guidance and automated checks to prevent a repeat of
+  #543-style bugs (blocking file I/O called directly from async code, stalling Home
+  Assistant's event loop). `claude.md`'s Thread-Safety Requirements section now explicitly
+  covers blocking I/O, not just CPU-bound computation. Ruff's `ASYNC` lint category is now
+  enabled (catches a blocking call written directly inline in an async function, going
+  forward). `tests/test_executor_offload.py` gained a registry-driven check
+  (`TestBlockingIOExecutorOffload`) that verifies known blocking sub-component methods are
+  never called unwrapped from any async method in `coordinator.py` — the part that actually
+  would have caught #543. No user-visible behavior change; contributor-facing tooling only.
+
 ## [0.5.41] — 2026-08-01
 
 - Fix #543: `chart_log.py`'s `ChartStateLog.load()`/`save()` performed synchronous file I/O

--- a/claude.md
+++ b/claude.md
@@ -163,11 +163,18 @@ Any automation phase that changes the thermostat setpoint (even temporarily) MUS
 
 ### Thread-Safety Requirements (CRITICAL)
 
-**Decision**: Any heavy synchronous computation called from an `async` method MUST be offloaded to a thread-pool executor via `await hass.async_add_executor_job()`. Blocking the HA event loop with CPU-bound work causes event loop jitter and can trigger HA watchdog restarts.
+**Decision**: Any blocking work called from an `async` method MUST be offloaded to a thread-pool executor via `await hass.async_add_executor_job()`. This covers two distinct hazards, both of which stall the HA event loop for the entire Home Assistant instance (not just this integration) and can trigger HA watchdog restarts: **heavy synchronous computation** (CPU-bound work) and **blocking I/O** (file reads/writes, `os.replace`/`os.chmod`, `tempfile`, sockets, subprocess calls). Treat both as equally in scope — do not read this section as "CPU work only."
 
 #### Rule
 
-Before calling a function from inside an `async def` method, ask: **"Does this run more than ~10 ms of synchronous Python?"** If yes, offload it:
+Before calling a function from inside an `async def` method, ask **both** questions — either one alone is sufficient to require offloading:
+
+1. **CPU heuristic**: "Does this run more than ~10 ms of synchronous Python?"
+2. **I/O heuristic** (does not depend on timing): "Does this call ever touch a filesystem, socket, or subprocess — `open`, `Path.read_text`/`write_text`, `os.replace`, `os.chmod`, `tempfile`, `requests`/`urllib`, `subprocess`?" If yes, it must be offloaded regardless of how fast it usually runs in testing — disk/network latency spikes are exactly when blocking the event loop hurts most, and they won't show up in a quick local test.
+
+This applies just as much to a call one level removed — `self._some_helper.save()` — as to a literal `open(...)` written inline. A blocking call doesn't stop being blocking because it's hidden behind a method name; check what the callee actually does, not just what the call site looks like.
+
+If either question is "yes," offload it:
 
 ```python
 import functools
@@ -175,20 +182,25 @@ import functools
 result = await self.hass.async_add_executor_job(functools.partial(heavy_sync_function, arg1, arg2, keyword=value))
 ```
 
+For a plain bound method with no extra arguments, `functools.partial` isn't needed — pass the method directly: `await self.hass.async_add_executor_job(self._chart_log.save)`.
+
 **Capture all arguments in the event loop thread** (i.e., evaluate `self.*` attributes and helper calls like `self._get_indoor_temp()` before `functools.partial`, not inside the executor). The executor runs the partial with no additional arguments.
 
 #### Canonical Examples
 
-- `_build_predicted_indoor_future()` in `coordinator.py` — ODE integration + OLS math (~400 lines). Called from `_async_update_data()` and `_async_send_briefing()` via executor. Fixed in Issue #376.
+- `_build_predicted_indoor_future()` in `coordinator.py` — ODE integration + OLS math (~400 lines). Called from `_async_update_data()` and `_async_send_briefing()` via executor. Fixed in Issue #376 (the CPU-bound case this section was originally written for).
 - OLS regression functions in `learning.py` (`compute_k_passive`, `compute_k_active`, etc.) — called from synchronous commit helpers that are themselves invoked via `async_add_executor_job`. Already correct.
+- `ChartStateLog.load()`/`save()` in `chart_log.py` — plain synchronous `tempfile`/`os.replace`/`os.chmod`/`Path.read_text` calls, zero CPU-bound math. Called from `coordinator.py`'s `__init__` (moved to `async_restore_state()`) and two `async` methods. Fixed in Issue #543 — this is the **I/O case**, and it shipped unwrapped and passed review for months precisely because nothing about it looked like "heavy computation": no loop, no math, just `self._chart_log.save()`. If you're checking whether your code needs offloading, don't just ask "is this slow" — ask "does the thing I'm calling touch disk."
 
 #### What Does NOT Need Offloading
 
 - Simple dict lookups, attribute reads, string formatting — these complete in microseconds.
 - Coroutine calls (`await some_async_fn()`) — already non-blocking by definition.
-- I/O already wrapped in `async_add_executor_job` (file reads, DB writes) — do not double-wrap.
+- I/O that is *already* wrapped in `async_add_executor_job` at its call site — do not double-wrap. This is the only I/O exemption; it is not a blanket "I/O is handled elsewhere" pass. New I/O you're adding is your responsibility to wrap.
 
-**Violation protocol**: Same as Security — stop, flag, and ask before shipping new CPU-heavy code that runs synchronously inside an `async` method.
+**Violation protocol**: Same as Security — stop, flag, and ask before shipping new CPU-heavy or blocking-I/O code that runs synchronously inside an `async` method.
+
+**Enforcement**: This rule is checked, not just asserted. Ruff's `ASYNC` lint category (enabled in `pyproject.toml`) catches a blocking call written literally inline in an async function (e.g. `open()`, a `Path` method, `time.sleep`). `tests/test_executor_offload.py` catches known blocking sub-component methods (see its `_BLOCKING_METHODS` registry) called unwrapped from any async method in `coordinator.py` — the pattern that actually bit Issue #543, since ruff's `ASYNC` rules don't see through a method call into another module. If you introduce a new I/O sub-component (a new `chart_log.py`/`state.py`/`learning.py`-shaped class), add its blocking methods to that registry.
 
 ### Security Requirements (CRITICAL)
 

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,15 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.41"
+VERSION = "0.5.42"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.42": [
+        "Fix #545: strengthened project guidance and automated checks to prevent a repeat of"
+        " #543-style bugs (blocking file I/O called directly from async code, stalling Home"
+        " Assistant). No user-visible behavior change — this is contributor-facing tooling"
+        " (docs, lint rule, and a regression test) only.",
+    ],
     "0.5.41": [
         "Fix #543: Chart-log save/load no longer runs synchronously on Home Assistant's event"
         " loop — could cause brief startup/update stalls. The integration also now correctly"
@@ -1341,6 +1347,58 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    545: {
+        "version_fixed": "0.5.42",
+        "title": (
+            "Issue #543 (blocking file I/O called directly from async coordinator methods)"
+            " passed review for months despite this project already having a CRITICAL-tier"
+            " rule against blocking the event loop, because that rule (claude.md's"
+            " Thread-Safety Requirements, added after Issue #376) was framed entirely around"
+            " CPU-bound computation — blocking I/O was only mentioned as a 'don't"
+            " double-wrap' assumption — and its enforcement (tests/test_executor_offload.py)"
+            " was hardcoded to the 3 call sites from that earlier issue's specific function,"
+            " with no way to catch a different function/pattern"
+        ),
+        "scope_covered": (
+            "claude.md: Thread-Safety Requirements section broadened to explicitly cover"
+            " blocking I/O (file reads/writes, os.replace/os.chmod, tempfile, sockets,"
+            " subprocess) as equally in-scope as CPU-bound work, with a second heuristic"
+            " question that doesn't depend on timing, ChartStateLog/#543 added as a second"
+            " canonical example explaining why it was missed (no CPU-heavy math, blocking call"
+            " hidden behind a helper method name), the 'I/O already wrapped' exemption"
+            " reworded so it can't be misread as a blanket I/O pass, and a new Enforcement"
+            " line cross-referencing the two mechanisms below. pyproject.toml: ruff's ASYNC"
+            " lint category (flake8-async) enabled — verified zero existing violations across"
+            " the whole repo except one pre-existing false-positive-for-purpose case in"
+            " tools/take_screenshots.py (a standalone Playwright CLI script with its own"
+            " private event loop, not Home Assistant's shared one), which got a scoped"
+            " per-file-ignore with a comment explaining why. Catches ASYNC230/240/210/212/220"
+            "/221/222/251 (blocking open/Path methods/sync HTTP/subprocess/sleep) written"
+            " literally inline in any async function going forward — verified this would NOT"
+            " have caught #543 itself, since #543's blocking call was hidden inside a helper"
+            " object's method, not literally inline. tests/test_executor_offload.py: new"
+            " registry-driven TestBlockingIOExecutorOffload class with a _BLOCKING_METHODS set"
+            " of (attribute, method) pairs (_chart_log.load/save, _state_persistence.load/save,"
+            " learning.load_state/save_state) checked against every async method in"
+            " coordinator.py (not just a hardcoded list of call sites) — this is the part that"
+            " actually would have caught #543. Verified both that it passes against the"
+            " current (fixed) coordinator.py and, via a synthetic reproduction of the original"
+            " pre-fix pattern, that it correctly flags a blocking call in an async method"
+            " while correctly ignoring the same call in a sync method and a properly-wrapped"
+            " async_add_executor_job reference."
+        ),
+        "scope_not_covered": (
+            "No runtime behavior change — this is entirely contributor-facing tooling/docs."
+            " The _BLOCKING_METHODS registry is manually maintained, not auto-discovered — a"
+            " new I/O sub-component's blocking methods must be added to it by whoever"
+            " introduces them; nothing currently enforces that the registry itself stays"
+            " complete. Does not add a generic taint-analysis-style blocking-call detector"
+            " (out of scope, not this project's established testing style). Does not extend"
+            " ruff ASYNC or the registry check to files outside custom_components/coordinator.py"
+            " (e.g. api.py, automation.py) — those are covered only by the older, narrower"
+            " TestODEExecutorOffload checks where applicable."
+        ),
+    },
     543: {
         "version_fixed": "0.5.41",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.41"
+  "version": "0.5.42"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,15 @@ line-length = 120
 exclude = [".claude"]
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "UP", "B", "SIM", "T20"]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "T20", "ASYNC"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["T20"]
 "tools/*" = ["T20"]
+# take_screenshots.py runs its own private asyncio loop for Playwright, not Home
+# Assistant's shared event loop — the ASYNC240 hazard (stalling a live production
+# loop) doesn't apply to a one-off local CLI script.
+"tools/take_screenshots.py" = ["ASYNC240"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_executor_offload.py
+++ b/tests/test_executor_offload.py
@@ -1,10 +1,16 @@
-"""Regression tests for Issue #376: ODE/OLS computation executor offload.
+"""Regression tests for Issue #376 and Issue #543/#545: executor offload for
+blocking work called from async methods in coordinator.py.
 
-Verifies that _build_predicted_indoor_future is never called directly from
-async methods in coordinator.py (which would block the HA event loop).
+TestODEExecutorOffload (Issue #376) verifies that _build_predicted_indoor_future
+is never called directly from specific async methods — CPU-bound work.
 
-The fix wraps all async callsites in await hass.async_add_executor_job(functools.partial(...)).
-If someone removes the wrapper, the AST test catches it at test time rather than in prod.
+TestBlockingIOExecutorOffload (Issue #543/#545) is registry-driven and generalizes
+the same idea to blocking I/O: known blocking sub-component methods (chart_log,
+state persistence, learning) must never be called directly from ANY async method
+in coordinator.py, not just a hardcoded list of call sites.
+
+If someone removes an executor wrapper, these AST tests catch it at test time
+rather than in prod.
 """
 
 from __future__ import annotations
@@ -175,4 +181,88 @@ class TestODEExecutorOffload:
         assert executor_calls, (
             "async_add_executor_job not found in ClimateAdvisorChartDataView.get(). "
             "The chart endpoint must offload get_chart_data to the thread pool."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #543 / #545: generalized check for blocking sub-component methods
+# called unwrapped from ANY async method in coordinator.py.
+# ---------------------------------------------------------------------------
+
+# Known (attribute_name, method_name) pairs that do blocking I/O and must never
+# be called directly from an async method — only passed by reference to
+# await hass.async_add_executor_job(self.<attr>.<method>, ...).
+# Add an entry here whenever a new I/O sub-component is introduced (chart_log.py,
+# state.py, learning.py are the existing ones as of Issue #543/#545).
+_BLOCKING_METHODS: set[tuple[str, str]] = {
+    ("_chart_log", "load"),
+    ("_chart_log", "save"),
+    ("_state_persistence", "load"),
+    ("_state_persistence", "save"),
+    ("learning", "load_state"),
+    ("learning", "save_state"),
+}
+
+
+def _find_blocking_calls_in_node(fn_node: ast.AST) -> list[ast.Call]:
+    """Walk fn_node and return any direct calls shaped like self.<attr>.<method>(...)
+    where (<attr>, <method>) is a known-blocking pair from _BLOCKING_METHODS.
+
+    Correctly-offloaded code never produces this Call shape at all — the fix passes
+    self.<attr>.<method> by reference to hass.async_add_executor_job(...) without
+    invoking it (e.g. `await self.hass.async_add_executor_job(self._chart_log.save)`).
+    So unlike _find_direct_calls_in_node above (which must skip functools.partial's
+    arguments, since those ARE real calls to the wrapped function), no exclusion
+    logic is needed here: any matching Call node is, by construction, a direct
+    blocking call that bypassed the executor.
+    """
+    blocking_calls = []
+
+    class _Visitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and isinstance(func.value, ast.Attribute)
+                and isinstance(func.value.value, ast.Name)
+                and func.value.value.id == "self"
+                and (func.value.attr, func.attr) in _BLOCKING_METHODS
+            ):
+                blocking_calls.append(node)
+            self.generic_visit(node)
+
+    _Visitor().visit(fn_node)
+    return blocking_calls
+
+
+class TestBlockingIOExecutorOffload:
+    """Known blocking sub-component methods must never be called directly from
+    any async method in coordinator.py.
+
+    Regression for Issue #543: ChartStateLog.load()/save() did blocking file I/O
+    (tempfile write, os.replace, os.chmod, Path.read_text) but were called directly
+    from async coordinator methods without going through
+    await hass.async_add_executor_job(...), stalling the HA event loop for the
+    entire Home Assistant instance. Unlike TestODEExecutorOffload above (hardcoded
+    to 3 call sites for one function), this check is registry-driven and applies to
+    EVERY async method in coordinator.py — add new (attribute, method) pairs to
+    _BLOCKING_METHODS as new I/O sub-components are introduced (see
+    claude.md's Thread-Safety Requirements section).
+    """
+
+    def test_no_blocking_calls_in_any_async_method(self):
+        source = COORDINATOR_PY.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        offenders: list[tuple[str, ast.Call]] = []
+        for name, node in _extract_async_methods(tree):
+            for call in _find_blocking_calls_in_node(node):
+                offenders.append((name, call))
+
+        assert not offenders, (
+            "Blocking sub-component method(s) called directly (not via "
+            "hass.async_add_executor_job) inside async method(s): "
+            + ", ".join(f"{name}() at line {call.lineno}" for name, call in offenders)
+            + ". Wrap in await self.hass.async_add_executor_job(self.<attr>.<method>) "
+            "to avoid blocking the HA event loop."
         )


### PR DESCRIPTION
## Summary

After shipping #543/#544 (ChartStateLog I/O offloaded to the executor), the question came up:
does this project have guidance that would stop a future contributor from reintroducing the
same class of mistake? Answer: yes, but with a real gap #543 fell straight through.

`claude.md`'s "Thread-Safety Requirements" rule (added after Issue #376) is real, CRITICAL-tier,
project-wide guidance — but it's framed entirely around **CPU-bound computation** ("heavy
synchronous computation," "~10ms of synchronous Python," "CPU-heavy code"). Blocking file I/O
was mentioned exactly once, as a "don't double-wrap" assumption. A contributor adding a
synchronous file-write helper with zero CPU-bound math (exactly what `ChartStateLog.load()`/
`save()` was) could read that section and reasonably conclude it doesn't apply. Enforcement
(`tests/test_executor_offload.py`) had the same shape of gap: hardcoded to 3 call sites for one
specific function, no way to catch a different pattern.

Three additive changes, no runtime behavior change:

- **`claude.md`**: broadened the Thread-Safety Requirements section to explicitly cover blocking
  I/O (file reads/writes, `os.replace`/`os.chmod`, `tempfile`, sockets, subprocess) as equally
  in-scope as CPU-bound work, with a second, timing-independent trigger question. Added
  `ChartStateLog`/#543 as a second canonical example, explicitly explaining *why* it was missed
  (no CPU-heavy math, blocking call hidden behind a helper method name — `self._chart_log.save()`
  doesn't visibly "look like" the kind of code the old rule warned about). Reworded the "I/O
  already wrapped" exemption so it can't be misread as a blanket pass for I/O in general.
- **`pyproject.toml`**: enabled ruff's `ASYNC` lint category. Verified **zero existing
  violations** across the repo except one legitimate false positive (`tools/take_screenshots.py`
  — a standalone Playwright CLI script with its own private event loop, not HA's shared one),
  which got a scoped per-file-ignore with a comment explaining why. This is a free guardrail
  against a *literal* blocking call written inline in a future async method — verified it would
  **not** have caught #543 itself, since ASYNC230/240 only see calls written directly in the
  async function's own source, not ones hidden a level down inside a helper object's method.
- **`tests/test_executor_offload.py`**: new registry-driven `TestBlockingIOExecutorOffload`
  class — a `_BLOCKING_METHODS` set of `(attribute, method)` pairs (`_chart_log.load/save`,
  `_state_persistence.load/save`, `learning.load_state/save_state`) checked against **every**
  async method in `coordinator.py`, not a hardcoded list of call sites. This is the part that
  actually would have caught #543. Verified two ways: it passes against the current (fixed)
  `coordinator.py`, and — via a synthetic reproduction of the original pre-fix pattern — it
  correctly flags a blocking call in an async method while correctly ignoring the identical call
  in a sync method and a properly-wrapped `async_add_executor_job` reference.

Closes #545

## Test plan
- [x] `ruff check --select ASYNC` — clean (one scoped, documented ignore)
- [x] `ruff check .` (full, with ASYNC now enabled) — clean
- [x] `pytest tests/test_executor_offload.py -v` — 4 passed, including the new registry-driven check
- [x] Synthetic true-positive check: new AST test correctly detects a reproduction of the original #543 bug pattern
- [x] `pytest tests/test_version_sync.py` — passes
- [x] Full suite: `pytest tests/ -q` — 3635 passed, 5 skipped, 0 failed