### PR TITLE
Fix #547: deploy.py surfaces which SSH identity file will be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.43] — 2026-08-01
+
+- Fix #547: `tools/deploy.py` now prints which SSH identity file it will use before
+  connecting (`Using SSH key: ...`), resolved locally via `ssh -G` with no network I/O.
+  `docs/SSH-SETUP.md` documents a Windows-specific gotcha where two different `ssh.exe`
+  binaries commonly on `PATH` (Git's MSYS build and Windows' native OpenSSH client) can
+  resolve default identity files differently, and recommends setting `HA_SSH_KEY` explicitly
+  to remove the ambiguity. Deployment tooling and docs only — no change to the integration.
+
 ## [0.5.42] — 2026-08-01
 
 - Fix #545: strengthened project guidance and automated checks to prevent a repeat of

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,15 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.42"
+VERSION = "0.5.43"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.43": [
+        "Fix #547: `tools/deploy.py` now prints which SSH identity file it will use before"
+        " connecting, and the SSH setup guide documents a Windows-specific default-key-"
+        " resolution gotcha. Developer/deployment tooling only — no change to the integration"
+        " itself.",
+    ],
     "0.5.42": [
         "Fix #545: strengthened project guidance and automated checks to prevent a repeat of"
         " #543-style bugs (blocking file I/O called directly from async code, stalling Home"
@@ -1347,6 +1353,36 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    547: {
+        "version_fixed": "0.5.43",
+        "title": (
+            "Deploying #543/#545 hit intermittent SSH connection resets/timeouts;"
+            " confirming which SSH key tools/deploy.py would actually use required a manual"
+            " investigation (reading ssh_args()'s HA_SSH_KEY handling, checking ~/.ssh/"
+            " contents, running ssh -G by hand) instead of being visible from the tool itself"
+        ),
+        "scope_covered": (
+            "tools/deploy.py: new resolve_ssh_identity() helper — resolves and prints which"
+            " SSH identity file will be used (via ssh -G <user>@<host>, a local-only call, no"
+            " network I/O) before test_ssh() attempts the actual connection. No change to"
+            " connection/deploy logic itself; HA_SSH_KEY was already optional and per-user"
+            " (git-ignored .deploy.env), never hardcoded in source. docs/SSH-SETUP.md:"
+            " Troubleshooting section gained a note on Windows' two-ssh.exe-on-PATH situation"
+            " (Git's MSYS build vs. the native OpenSSH client, which can resolve default"
+            " identities differently depending on invocation context) recommending explicit"
+            " HA_SSH_KEY as a zero-downside way to remove the ambiguity, plus a"
+            " self-diagnostic (ssh -G user@host) users can run themselves."
+        ),
+        "scope_not_covered": (
+            "Does not root-cause the original #543/#545 deploy connection resets/timeouts —"
+            " those were separately diagnosed (via ssh -v and Test-NetConnection) as a"
+            " connection-churn/rate-limit reaction on the HA SSH add-on side (deploy.py opens"
+            " ~6-8 sequential SSH connections per run), not a key-resolution problem; not"
+            " addressed here since it's server-side add-on configuration, outside this repo's"
+            " control. No user-visible or runtime behavior change — deployment tooling and"
+            " docs only."
+        ),
+    },
     545: {
         "version_fixed": "0.5.42",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.42"
+  "version": "0.5.43"
 }

--- a/docs/SSH-SETUP.md
+++ b/docs/SSH-SETUP.md
@@ -98,6 +98,19 @@ This runs validation only and shows what would be deployed without making change
 - Verify your public key is in the add-on's Authorized Keys config
 - Make sure you're pointing to the correct private key file
 - Check the key wasn't accidentally modified (re-copy it)
+- `python tools/deploy.py` prints the resolved identity file (`Using SSH key: ...`) before
+  connecting — check that it's the key you expect. You can also run this yourself, purely
+  locally (no connection attempted): `ssh -G <user>@<host>` and look for the `identityfile`
+  line(s).
+
+### Windows: default-key resolution behaves inconsistently
+Windows commonly has two `ssh.exe` binaries on `PATH` — Git for Windows' bundled MSYS build
+and Windows' native OpenSSH client — which can resolve default identity files differently
+depending on how a program invokes `ssh` (this affects `HOME` resolution and, in turn, which
+`~/.ssh/` default key gets picked). If you have a specific key you expect to be used, set
+`HA_SSH_KEY=~/.ssh/your_key` explicitly in `.deploy.env` rather than relying on default
+resolution — it costs nothing (still per-user, git-ignored config, not hardcoded anywhere)
+and removes the ambiguity entirely.
 
 ### "Host key verification failed"
 - The deploy script uses `StrictHostKeyChecking=no` to avoid this

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -169,6 +169,29 @@ def remote_path(config: dict[str, str]) -> str:
     return f"{config['HA_CONFIG_PATH']}/custom_components/climate_advisor"
 
 
+def resolve_ssh_identity(config: dict[str, str]) -> str | None:
+    """Locally resolve which SSH identity file would be used, without connecting.
+
+    Issue #547: on Windows, two different ssh.exe binaries (Git's MSYS build and
+    Windows' native OpenSSH client) commonly sit on PATH and can resolve default
+    identities differently depending on invocation context, making key-related
+    connection failures hard to diagnose. This surfaces the answer up front —
+    `ssh -G` only resolves config locally, it never opens a network connection.
+    Returns None if resolution fails or no candidate identity file exists on disk.
+    """
+    if config["HA_SSH_KEY"]:
+        return config["HA_SSH_KEY"]
+
+    result = subprocess.run(["ssh", "-G", ssh_target(config)], capture_output=True, text=True)
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if line.lower().startswith("identityfile "):
+            candidate = line.split(None, 1)[1]
+            if Path(candidate).expanduser().exists():
+                return candidate
+    return None
+
+
 # ---------------------------------------------------------------------------
 # SSH helpers
 # ---------------------------------------------------------------------------
@@ -200,6 +223,14 @@ def run_local(command: list[str]) -> tuple[int, str]:
 
 def test_ssh(config: dict[str, str]) -> bool:
     step(f"Testing SSH connection to {config['HA_HOST']}:{config['HA_SSH_PORT']}")
+    identity = resolve_ssh_identity(config)
+    if identity:
+        info(f"Using SSH key: {identity}")
+    else:
+        info(
+            "No SSH key file resolved (HA_SSH_KEY unset, no default identity file found) — "
+            "relying on ssh-agent or other auth."
+        )
     rc, output = run_ssh(config, "echo ok")
     if rc == 0 and "ok" in output:
         ok("SSH connection successful")


### PR DESCRIPTION
## Summary

Deploying #543/#545 hit intermittent SSH connection resets/timeouts. Confirming which SSH key
`tools/deploy.py` would actually use required a manual investigation (reading `ssh_args()`'s
`HA_SSH_KEY` handling, checking `~/.ssh/` contents, running `ssh -G` by hand) instead of being
visible from the tool itself.

- `tools/deploy.py`: new `resolve_ssh_identity()` helper prints the resolved SSH key (via
  `ssh -G <user>@<host>`, local-only, no network I/O) before `test_ssh()` attempts the real
  connection. No change to connection/deploy logic — `HA_SSH_KEY` was already optional and
  per-user (git-ignored `.deploy.env`), never hardcoded in source.
- `docs/SSH-SETUP.md`: documents a Windows-specific gotcha where two different `ssh.exe`
  binaries commonly on `PATH` (Git's MSYS build and the native OpenSSH client) can resolve
  default identity files differently depending on invocation context, and recommends setting
  `HA_SSH_KEY` explicitly to remove the ambiguity, plus a self-diagnostic users can run
  themselves.

Note: this does **not** fix the original connection resets/timeouts from deploying #545 — those
were separately diagnosed (via `ssh -v` and `Test-NetConnection`) as a connection-churn/rate-limit
reaction on the HA SSH add-on side (`deploy.py` opens ~6-8 sequential SSH connections per run),
not a key-resolution problem, and are outside this repo's control (server-side add-on config).

Closes #547

## Test plan
- [x] `ruff check .` — clean
- [x] `pytest tests/test_version_sync.py` — passes
- [x] Direct verification of `resolve_ssh_identity()` (both explicit-`HA_SSH_KEY` and
      default-resolution paths) — correctly resolves `~/.ssh/id_ed25519`, no network I/O
- [x] Full suite: `pytest tests/ -q` — 3635 passed, 5 skipped, 0 failed