### PR TITLE
Fix #551: revert broken SSH multiplexing, batch commands instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.45] — 2026-08-01
+
+- Fix #551: reverted #549's SSH connection multiplexing (`ControlMaster`) in
+  `tools/deploy.py` — live testing showed it fails immediately against a real HAOS SSH
+  add-on on this project's Windows/Git-for-Windows SSH client, making deploys worse (failing
+  on the very first connection instead of getting partway through). Replaced with command
+  batching — combining several remote commands into fewer SSH round trips — to reduce
+  connection count and avoid tripping the add-on's rate-limit protection, without depending
+  on client-side multiplexing support. `docs/SSH-SETUP.md` documents both the batching
+  approach and the ControlMaster reversion. Developer/deployment tooling only — no change to
+  the integration itself.
+
 ## [0.5.44] — 2026-08-01
 
 - Fix #549: `tools/deploy.py` now multiplexes all of its SSH/SCP connections through one real

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.44"
+VERSION = "0.5.45"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.45": [
+        "Fix #551: reverted #549's SSH connection multiplexing in `tools/deploy.py` — it"
+        " failed outright on Windows/Git-for-Windows SSH clients against a real HAOS SSH"
+        " add-on. Replaced with command batching (fewer, combined SSH round trips) to reduce"
+        " connection count and avoid tripping the add-on's rate-limit protection, without"
+        " depending on client-side multiplexing support. Developer/deployment tooling only —"
+        " no change to the integration itself.",
+    ],
     "0.5.44": [
         "Fix #549: `tools/deploy.py` now multiplexes all of its SSH/SCP connections through"
         " one real connection per run (SSH `ControlMaster`), instead of opening 6-8 separate"
@@ -1359,6 +1367,60 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    551: {
+        "version_fixed": "0.5.45",
+        "title": (
+            "#549's SSH ControlMaster multiplexing, merged to fix deploy.py's rate-limit"
+            " problem, made deploys worse in live testing: every connection attempt failed"
+            " immediately (~1s, not a timeout) with 'mux_client_request_session: read from"
+            " master failed: Connection reset by peer' / 'Failed to connect to new control"
+            " master' — reproduced consistently as the very first connection of a fresh run"
+            " (ruling out the rate limiter), with both Windows-style and POSIX-style control"
+            " socket paths, while a bare non-multiplexed connection to the same host succeeded"
+            " instantly immediately before and after each failure — indicating ControlMaster"
+            " itself doesn't work reliably with this project's Windows/Git-for-Windows SSH"
+            " client build against this HAOS SSH add-on"
+        ),
+        "scope_covered": (
+            "tools/deploy.py: removed control_path(), _multiplex_args(), and"
+            " close_control_master() entirely; ssh_args()/scp_args() no longer add any"
+            " ControlMaster/ControlPath/ControlPersist options; main()'s try/finally wrapper"
+            " (which existed only to call close_control_master()) removed, restoring the"
+            " original flow. Replaced with command batching to address the original"
+            " connection-count problem without depending on client-side multiplexing support:"
+            " create_backup() combines the remote existence check and tar creation into one"
+            " SSH call (was two); the new prep_remote_target() combines temp-file cleanup,"
+            " legacy climate_advisor.bak.* directory removal (now via a single 'ls | xargs -r"
+            " rm -rf' instead of one rm per matched directory), and mkdir -p into one SSH call"
+            " (replacing clean_legacy_backups() plus the separate mkdir previously inside"
+            " deploy_files()); do_rollback()'s restore-extract and temp-cleanup combined into"
+            " one call. Reduces a typical full-deploy run from ~10-11 SSH/SCP connections to"
+            " ~8. Verified live against the real HA host: both new combined commands"
+            " (create_backup's tar-or-skip logic, prep_remote_target's cleanup+mkdir sequence)"
+            " execute correctly and produce the expected results. docs/SSH-SETUP.md updated to"
+            " describe the batching approach and explicitly document the ControlMaster"
+            " reversion and why, so a future contributor doesn't re-attempt the same fix"
+            " without knowing it was already tried and found unreliable here."
+        ),
+        "scope_not_covered": (
+            "Command batching is a best-effort mitigation, not a guaranteed fix — it reduces"
+            " connection count (~10-11 to ~8) but doesn't eliminate SSH connections entirely,"
+            " so a sufficiently strict rate limit on the HA SSH add-on's Protection mode could"
+            " still trip. The authoritative fix (raising or disabling that setting) remains a"
+            " manual, server-side step documented in docs/SSH-SETUP.md, outside this repo's"
+            " control. Does not investigate root-causing exactly why ControlMaster fails on"
+            " this specific client/server combination (e.g. whether it's a Git-for-Windows"
+            " MSYS AF_UNIX socket emulation issue specifically) — the live evidence was"
+            " sufficient to conclude it's unreliable here without further diagnosis, but the"
+            " underlying mechanism remains unconfirmed. A pre-existing cosmetic issue was"
+            " observed but not fixed: the remote login shell appears to be zsh, whose default"
+            " NOMATCH option prints a 'zsh:1: no matches found: ...' stderr line when the"
+            " legacy-backup glob pattern matches nothing (harmless — the surrounding command"
+            " sequence still completes correctly via xargs -r's empty-input no-op — but noisy"
+            " in logs); this behavior predates this fix (same glob pattern was already used by"
+            " the original clean_legacy_backups()) and was left as-is to avoid scope creep."
+        ),
+    },
     549: {
         "version_fixed": "0.5.44",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.44"
+  "version": "0.5.45"
 }

--- a/docs/SSH-SETUP.md
+++ b/docs/SSH-SETUP.md
@@ -119,19 +119,31 @@ and removes the ambiguity entirely.
 ### First few steps succeed, then "Connection reset by peer" / "Connection timed out" for the rest of the run
 This is the signature of the SSH add-on's rate-limit/brute-force protection ("Protection
 mode," a fail2ban-style feature many HAOS SSH add-ons enable by default) blocking your
-machine's IP after several connections in a short window — `deploy.py` opens 6-8 separate
-SSH/SCP connections per run (connection test, dir check, backup, cleanup, file copy, restart,
-log check), which can trip it even though every connection was legitimate.
+machine's IP after several connections in a short window — a full `deploy.py` run opens
+several separate SSH/SCP connections (connection test, backup, remote cleanup, file copy,
+restart, log check), which can trip it even though every connection was legitimate.
 
-Since #549, `deploy.py` multiplexes all of those through a single real SSH connection
-(`ControlMaster`/`ControlPath`/`ControlPersist`, set up automatically — no config needed), so
-the add-on only ever sees one connection per run. If you still hit this:
+Since #551, `deploy.py` batches what used to be several separate remote commands into fewer,
+combined round trips (e.g. the backup existence-check + tar creation happen in one SSH call
+instead of two; temp-file cleanup + legacy-backup removal + directory setup happen in one call
+instead of three-plus) to reduce the total connection count per run.
+
+(An earlier attempt, #549, tried SSH connection multiplexing — `ControlMaster` — for the same
+goal. It was reverted in #551: it failed outright on this project's Windows/Git-for-Windows SSH
+client against a real HAOS SSH add-on, with `ControlMaster` connections immediately getting
+`Connection reset by peer` even when a plain, non-multiplexed connection to the same host
+succeeded instantly right before and after. If you're on a different platform where
+`ControlMaster` is reliable, adding it back locally is safe to try — just be aware it wasn't
+portable enough to ship by default here.)
+
+Batching reduces connection count but isn't a guarantee against a strict rate limit. If you
+still hit this:
 - Check your SSH add-on's configuration for a "Protection mode" or rate-limit setting and
-  raise its threshold or disable it, at least while deploying
+  raise its threshold or disable it, at least while deploying — this is the authoritative fix
 - If it just tripped, wait for its cooldown window to clear before retrying — retrying
   immediately usually just extends the block
-- You can verify multiplexing is active mid-run: a control socket appears at
-  `~/.ssh/sockets/deploy-<user>-<host>-<port>.sock` while `deploy.py` is running
+- `python tools/deploy.py --skip-restart` skips the restart + log-check steps (2 fewer
+  connections), useful when iterating on file changes without needing a full deploy each time
 
 ### Can't find `/config/custom_components/`
 - The directory may not exist yet. Create it: `mkdir -p /config/custom_components/`

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -137,42 +137,9 @@ def validate_config(config: dict[str, str]) -> list[str]:
     return errors
 
 
-def control_path(config: dict[str, str]) -> str:
-    """Path for the SSH multiplexing control socket shared by every ssh/scp call this run.
-
-    Issue #549: the HA SSH add-on's rate-limit protection ("Protection mode," a fail2ban-style
-    feature many HAOS SSH add-ons enable by default) blocks a source IP after ~4-5 connections
-    in a short window, regardless of whether they succeeded. deploy.py opens 6-8 separate
-    ssh/scp connections per run, which trips it. Routing them all through one multiplexed
-    connection means the add-on only ever sees one.
-    """
-    sockets_dir = Path.home() / ".ssh" / "sockets"
-    sockets_dir.mkdir(parents=True, exist_ok=True)
-    return str(sockets_dir / f"deploy-{config['HA_SSH_USER']}-{config['HA_HOST']}-{config['HA_SSH_PORT']}.sock")
-
-
-def _multiplex_args(config: dict[str, str]) -> list[str]:
-    """Shared ControlMaster options so every ssh/scp call in a run reuses one connection.
-
-    ControlMaster=auto: the first call creates the master; every later call with a matching
-    ControlPath transparently tunnels through it instead of opening a new TCP connection.
-    ControlPersist=10m: keeps the master alive in the background for reuse across the whole
-    run (and briefly after), even though each individual ssh/scp command exits immediately.
-    """
-    return [
-        "-o",
-        f"ControlPath={control_path(config)}",
-        "-o",
-        "ControlMaster=auto",
-        "-o",
-        "ControlPersist=10m",
-    ]
-
-
 def ssh_args(config: dict[str, str]) -> list[str]:
     """Build SSH command-line arguments."""
     args = ["ssh", "-p", config["HA_SSH_PORT"], "-o", "StrictHostKeyChecking=accept-new", "-o", "ConnectTimeout=10"]
-    args.extend(_multiplex_args(config))
     if config["HA_SSH_KEY"]:
         args.extend(["-i", config["HA_SSH_KEY"]])
     if config["HA_SSH_KEY"] and sys.platform != "win32":
@@ -193,27 +160,9 @@ def ssh_target(config: dict[str, str]) -> str:
 def scp_args(config: dict[str, str]) -> list[str]:
     """Build SCP command-line arguments."""
     args = ["scp", "-P", config["HA_SSH_PORT"], "-o", "StrictHostKeyChecking=accept-new", "-r"]
-    args.extend(_multiplex_args(config))
     if config["HA_SSH_KEY"]:
         args.extend(["-i", config["HA_SSH_KEY"]])
     return args
-
-
-def close_control_master(config: dict[str, str]) -> None:
-    """Best-effort close of the multiplexed control connection at the end of a run.
-
-    Safe to call even if no master was ever established (ControlPersist means one may not
-    exist yet, e.g. if the run failed before the first ssh/scp call) — `-O exit` against a
-    missing/stale socket just fails harmlessly, which we ignore.
-    """
-    cpath = control_path(config)
-    if not Path(cpath).exists():
-        return
-    subprocess.run(
-        ["ssh", "-o", f"ControlPath={cpath}", "-O", "exit", ssh_target(config)],
-        capture_output=True,
-        text=True,
-    )
 
 
 def remote_path(config: dict[str, str]) -> str:
@@ -305,11 +254,23 @@ def run_validation() -> bool:
 def create_backup(config: dict[str, str]) -> None:
     step("Downloading backup from HA server")
     rpath = remote_path(config)
+    parent = f"{config['HA_CONFIG_PATH']}/custom_components"
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
 
-    rc, output = run_ssh(config, f"test -d '{rpath}' && echo yes || echo no")
-    if "yes" not in output:
+    # Issue #551: combine the existence check and the tar creation into one round trip
+    # (reduces connection count — see docs/SSH-SETUP.md's rate-limit note). Cleanup of
+    # /tmp/ca_backup.tar.gz happens later, batched into prep_remote_target().
+    cmd = (
+        f"if [ -d {shlex.quote(rpath)} ]; then "
+        f"tar czf /tmp/ca_backup.tar.gz -C {shlex.quote(parent)} climate_advisor && echo TARED; "
+        f"else echo NOEXIST; fi"
+    )
+    rc, output = run_ssh(config, cmd)
+    if "NOEXIST" in output:
         info("No existing installation found. Skipping backup.")
+        return
+    if "TARED" not in output:
+        fail(f"Remote tar failed: {output}")
         return
 
     BACKUP_DIR.mkdir(exist_ok=True)
@@ -317,24 +278,14 @@ def create_backup(config: dict[str, str]) -> None:
         os.chmod(BACKUP_DIR, 0o700)
     local_tar = BACKUP_DIR / f"climate_advisor-{timestamp}.tar.gz"
     target = ssh_target(config)
-    parent = f"{config['HA_CONFIG_PATH']}/custom_components"
 
-    # Tar+gzip the remote directory and download it locally
-    try:
-        rc, output = run_ssh(config, f"tar czf /tmp/ca_backup.tar.gz -C '{parent}' climate_advisor")
-        if rc != 0:
-            fail(f"Remote tar failed: {output}")
-            return
+    cmd = scp_args(config) + [f"{target}:/tmp/ca_backup.tar.gz", str(local_tar)]
+    rc, output = run_local(cmd)
+    if rc != 0:
+        fail(f"Backup download failed: {output}")
+        return
 
-        cmd = scp_args(config) + [f"{target}:/tmp/ca_backup.tar.gz", str(local_tar)]
-        rc, output = run_local(cmd)
-        if rc != 0:
-            fail(f"Backup download failed: {output}")
-            return
-
-        ok(f"Backup saved: {local_tar}")
-    finally:
-        run_ssh(config, "rm -f /tmp/ca_backup.tar.gz")
+    ok(f"Backup saved: {local_tar}")
 
 
 def prune_backups(config: dict[str, str]) -> None:
@@ -351,23 +302,26 @@ def prune_backups(config: dict[str, str]) -> None:
     ok(f"Pruned {removed} old backup(s), {min(len(backups), BACKUP_KEEP_COUNT)} kept")
 
 
-def clean_legacy_backups(config: dict[str, str]) -> None:
-    """Remove old climate_advisor.bak.* directories from custom_components/.
+def prep_remote_target(config: dict[str, str]) -> None:
+    """Clean up temp/legacy state and ensure the target directory exists — one round trip.
 
-    These backup directories contain manifest.json files that cause HA's
-    loader to discover them as duplicate integrations, breaking import.
+    Issue #551: combines what used to be 3+ separate SSH connections (temp backup-tar
+    cleanup, legacy climate_advisor.bak.* directory removal, mkdir -p) into a single
+    command, to reduce the total connection count deploy.py opens per run — the HA SSH
+    add-on's rate-limit protection can block a source IP after several connections in a
+    short window (see docs/SSH-SETUP.md).
+
+    Legacy .bak.* directories contain manifest.json files that cause HA's loader to
+    discover them as duplicate integrations, breaking import — removed unconditionally
+    if any are found.
     """
     rpath = remote_path(config)
-    rc, output = run_ssh(config, f"ls -1d {shlex.quote(rpath)}.bak.* 2>/dev/null")
-    if rc != 0 or not output.strip():
-        return
-
-    dirs = [d.strip() for d in output.splitlines() if d.strip()]
-    if dirs:
-        step(f"Removing {len(dirs)} legacy backup dir(s) from custom_components/")
-        for d in dirs:
-            run_ssh(config, f"rm -rf {shlex.quote(d)}")
-        ok(f"Removed {len(dirs)} legacy backup dir(s)")
+    cmd = (
+        f"rm -f /tmp/ca_backup.tar.gz; "
+        f"ls -1d {shlex.quote(rpath)}.bak.* 2>/dev/null | xargs -r rm -rf; "
+        f"mkdir -p {shlex.quote(rpath)}"
+    )
+    run_ssh(config, cmd)
 
 
 def ensure_brand_dir() -> None:
@@ -402,8 +356,7 @@ def deploy_files(config: dict[str, str]) -> bool:
     # Ensure brand/ dir has icon + logo for HA's Add Integration dialog
     ensure_brand_dir()
 
-    # Ensure remote directory exists
-    run_ssh(config, f"mkdir -p '{rpath}'")
+    # Remote target directory already ensured by prep_remote_target() (Issue #551)
 
     # Copy files and subdirectories (e.g. brand/), excluding __pycache__
     local_items = [str(f) for f in COMPONENT_DIR.iterdir() if (f.is_file() or f.is_dir()) and f.name != "__pycache__"]
@@ -503,8 +456,12 @@ def do_rollback(config: dict[str, str]) -> None:
         info("Rollback cancelled.")
         return
 
-    run_ssh(config, f"rm -rf '{rpath}' && tar xzf /tmp/ca_restore.tar.gz -C '{parent}'")
-    run_ssh(config, "rm -f /tmp/ca_restore.tar.gz")
+    # Issue #551: combined into one round trip (reduces connection count)
+    run_ssh(
+        config,
+        f"rm -rf {shlex.quote(rpath)} && tar xzf /tmp/ca_restore.tar.gz -C {shlex.quote(parent)}; "
+        f"rm -f /tmp/ca_restore.tar.gz",
+    )
     ok("Backup restored")
 
     step("Restarting Home Assistant core")
@@ -560,52 +517,49 @@ def main() -> None:
     print(f"  Host: {config['HA_HOST']}:{config['HA_SSH_PORT']}")
     print(f"  Target: {rpath}")
 
-    try:
-        if args.rollback:
-            do_rollback(config)
-            sys.exit(0)
+    if args.rollback:
+        do_rollback(config)
+        sys.exit(0)
 
-        # Step 1: Validate
-        if not run_validation():
-            sys.exit(1)
+    # Step 1: Validate
+    if not run_validation():
+        sys.exit(1)
 
-        if args.dry_run:
-            ensure_brand_dir()
-            print(f"\n{Color.CYAN}============================================{Color.RESET}")
-            print(f"{Color.YELLOW}  DRY RUN complete. No changes made.{Color.RESET}")
-            print(f"{Color.CYAN}============================================{Color.RESET}")
-            print("\nFiles that would be deployed:")
-            for f in sorted(COMPONENT_DIR.rglob("*")):
-                if f.is_file() and "__pycache__" not in f.parts:
-                    gray(str(f.relative_to(COMPONENT_DIR)))
-            sys.exit(0)
+    if args.dry_run:
+        ensure_brand_dir()
+        print(f"\n{Color.CYAN}============================================{Color.RESET}")
+        print(f"{Color.YELLOW}  DRY RUN complete. No changes made.{Color.RESET}")
+        print(f"{Color.CYAN}============================================{Color.RESET}")
+        print("\nFiles that would be deployed:")
+        for f in sorted(COMPONENT_DIR.rglob("*")):
+            if f.is_file() and "__pycache__" not in f.parts:
+                gray(str(f.relative_to(COMPONENT_DIR)))
+        sys.exit(0)
 
-        # Step 2: Test SSH (also establishes the multiplexed connection every later
-        # step in this run reuses — see control_path()/Issue #549)
-        if not test_ssh(config):
-            sys.exit(1)
+    # Step 2: Test SSH
+    if not test_ssh(config):
+        sys.exit(1)
 
-        # Step 3: Backup
-        create_backup(config)
-        prune_backups(config)
-        clean_legacy_backups(config)
+    # Step 3: Backup + remote prep (Issue #551: batched into few round trips —
+    # see prep_remote_target()/create_backup())
+    create_backup(config)
+    prune_backups(config)
+    prep_remote_target(config)
 
-        # Step 4: Deploy
-        if not deploy_files(config):
-            sys.exit(1)
+    # Step 4: Deploy
+    if not deploy_files(config):
+        sys.exit(1)
 
-        # Step 5: Restart
-        restart_ha(config, skip=args.skip_restart)
+    # Step 5: Restart
+    restart_ha(config, skip=args.skip_restart)
 
-        # Step 6: Verify
-        if not args.skip_restart:
-            check_logs(config)
+    # Step 6: Verify
+    if not args.skip_restart:
+        check_logs(config)
 
-        print(f"\n{Color.GREEN}============================================{Color.RESET}")
-        print(f"{Color.GREEN}  Deployment complete!{Color.RESET}")
-        print(f"{Color.GREEN}============================================{Color.RESET}")
-    finally:
-        close_control_master(config)
+    print(f"\n{Color.GREEN}============================================{Color.RESET}")
+    print(f"{Color.GREEN}  Deployment complete!{Color.RESET}")
+    print(f"{Color.GREEN}============================================{Color.RESET}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

#549's SSH `ControlMaster` multiplexing, merged to fix `deploy.py`'s rate-limit problem, made
deploys *worse* in live testing: every connection attempt failed immediately (~1s, not a
timeout) with `mux_client_request_session: read from master failed: Connection reset by peer` /
`Failed to connect to new control master` — reproduced as the very first connection of a fresh
run (ruling out the rate limiter, since nothing had connected in the preceding 15+ minutes),
with both Windows-style and POSIX-style control socket paths, while a bare non-multiplexed
connection to the same host succeeded instantly immediately before and after each failed
attempt. This points to `ControlMaster` itself being unreliable with this project's
Windows/Git-for-Windows SSH client build against this HAOS SSH add-on, not a config or
rate-limit issue.

- `tools/deploy.py`: removed `control_path()`, `_multiplex_args()`, and
  `close_control_master()` entirely; `ssh_args()`/`scp_args()` no longer add any
  `ControlMaster`/`ControlPath`/`ControlPersist` options; `main()`'s `try`/`finally` wrapper
  (which existed only to call `close_control_master()`) removed.
- Replaced with **command batching** to address the original connection-count problem without
  depending on client-side multiplexing support:
  - `create_backup()` combines the remote existence check and tar creation into one SSH call
    (was two)
  - new `prep_remote_target()` combines temp-file cleanup, legacy `climate_advisor.bak.*`
    directory removal (now a single `ls | xargs -r rm -rf` instead of one `rm` per matched
    directory), and `mkdir -p` into one SSH call (replacing `clean_legacy_backups()` plus the
    separate `mkdir` previously inside `deploy_files()`)
  - `do_rollback()`'s restore-extract and temp-cleanup combined into one call
  - Reduces a typical full-deploy run from ~10-11 SSH/SCP connections to ~8
- Verified live against the real HA host: both new combined commands (the tar-or-skip backup
  logic, and the cleanup+mkdir sequence) execute correctly and produce the expected results.
- `docs/SSH-SETUP.md` documents the batching approach and explicitly records the `ControlMaster`
  reversion and why, so this isn't re-attempted blind by a future contributor.

**Honest caveat**: batching reduces connection count but isn't a guaranteed fix for a strict
rate limit — documented in `docs/SSH-SETUP.md` alongside the recommendation to adjust the SSH
add-on's Protection mode setting as the authoritative fix if this is still hit.

Closes #551

## Test plan
- [x] `ruff check .` — clean
- [x] `pytest tests/test_version_sync.py` — passes
- [x] Full suite: `pytest tests/ -q` — 3635 passed, 5 skipped, 0 failed
- [x] Live verification against the real HA host: both new combined shell commands
      (`create_backup`'s tar-or-skip logic, `prep_remote_target`'s cleanup+mkdir sequence)
      execute correctly