### PR TITLE
Feat #593: remaining Activity Record payload-completeness + legacy renderer cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.61] — 2026-08-07
+
+- Feat #593: closed out the remaining Activity Record payload-completeness gaps from the #584 investigation — classification decisions now show the trend magnitude and the exact threshold/margin that produced the day type; setpoint retry/nudge events show the reject streak count; startup coalescing shows indoor/outdoor temps and fan archetype; the thermal-learning watchdog shows today's session count; the fan-stopped and incident-detected cards now use data they already had instead of a generic label; morning wake-up now reports an explicit skip reason when occupancy is away/vacation, matching its other skip reasons; and pre-cool deferring to an already-active nat-vent/WHF session now shows what indoor temp and target it's deferring to. Four renderer functions with no current emitter are now explicitly marked as legacy/historical-log-only.
+
 ## [0.5.60] — 2026-08-05
 
 - Feat #580: the dashboard's Activity Record report now defaults to the "Last 12 hours" time window instead of 24, and lists events newest-first (most recent at the top, oldest at the bottom) instead of oldest-first — so the events you actually care about no longer require scrolling past a full day of history to find. The AI Investigative Analysis report type is unaffected and keeps its own separate time-window defaults.

--- a/custom_components/climate_advisor/ai_skills_context.py
+++ b/custom_components/climate_advisor/ai_skills_context.py
@@ -51,7 +51,7 @@ from .const import (
     THERMAL_SWING_DEFAULT_F,
 )
 from .fan_status import is_ca_fan_running
-from .temperature import format_temp
+from .temperature import format_temp, format_temp_delta
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1599,15 +1599,30 @@ def _render_classification_applied(p: dict, unit: str) -> tuple[str, str]:
     label = f"Classification applied: {day_type}" if day_type else "Classification applied"
     if trend:
         label = f"{label} ({trend})"
-    settings = ""
+    settings_parts = []
     if old_m and hvac and old_m != hvac:
-        settings = f"mode: {old_m}->{hvac}"
+        settings_parts.append(f"mode: {old_m}->{hvac}")
+    today_high = p.get("today_high")
+    threshold = p.get("applied_threshold_f")
+    margin = p.get("threshold_margin_f")
+    if today_high is not None and threshold is not None and margin is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            settings_parts.append(
+                f"today's high {format_temp(today_high, unit)} vs. {day_type} threshold "
+                f"{format_temp(threshold, unit)} ({margin:+.1f}°F)"
+            )
+    trend_mag = p.get("trend_magnitude")
+    if trend_mag is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            settings_parts.append(f"trend magnitude {format_temp_delta(trend_mag, unit)}")
+    settings = ", ".join(settings_parts)
     return label, settings
 
 
 def _render_setpoint_rejected(p: dict, unit: str) -> tuple[str, str]:
     commanded = p.get("commanded")
     reported = p.get("reported")
+    streak = p.get("reject_streak")
     label = "Setpoint validation failed -- retry scheduled"
     settings = ""
     if commanded is not None and reported is not None:
@@ -1616,6 +1631,8 @@ def _render_setpoint_rejected(p: dict, unit: str) -> tuple[str, str]:
                 f"commanded {format_temp(float(commanded), unit)}, "
                 f"thermostat reports {format_temp(float(reported), unit)}"
             )
+    if streak is not None:
+        settings = f"{settings}, reject streak={streak}" if settings else f"reject streak={streak}"
     return label, settings
 
 
@@ -1623,6 +1640,7 @@ def _render_setpoint_nudge(p: dict, unit: str) -> tuple[str, str]:
     nudge_value = p.get("nudge_value")
     real_target = p.get("real_target")
     mode = p.get("mode", "")
+    streak = p.get("reject_streak")
     label = "Reconciling stuck setpoint -- nudging thermostat"
     settings = ""
     if nudge_value is not None and real_target is not None:
@@ -1631,6 +1649,8 @@ def _render_setpoint_nudge(p: dict, unit: str) -> tuple[str, str]:
                 f"nudge to {format_temp(float(nudge_value), unit)} ({mode}),"
                 f" then {format_temp(float(real_target), unit)} in 30s"
             )
+    if streak is not None:
+        settings = f"{settings}, reject streak={streak}" if settings else f"reject streak={streak}"
     return label, settings
 
 
@@ -1814,7 +1834,9 @@ def _render_fan_running_untracked(p: dict, unit: str) -> tuple[str, str]:
 
 
 def _render_fan_untracked_cleared(p: dict, unit: str) -> tuple[str, str]:
-    return "Fan stopped (untracked fan ended)", "fan: off"
+    fan_device = p.get("fan_device")
+    settings = f"fan: {fan_device} off" if fan_device else "fan: off"
+    return "Fan stopped (untracked fan ended)", settings
 
 
 def _render_fan_cancel(p: dict, unit: str) -> tuple[str, str]:
@@ -1936,6 +1958,8 @@ def _render_nat_vent_ac_assist_armed(p: dict, unit: str) -> tuple[str, str]:
     return "Nat-vent + AC assist armed (full band)", ""
 
 
+# Legacy event, no current emitter (Issue #593 audit) -- kept only to render
+# historically-persisted event logs from a removed nat-vent code path.
 def _render_nat_vent_sleep_ceiling_reached(p: dict, unit: str) -> tuple[str, str]:
     indoor = p.get("indoor_temp")
     cool = p.get("sleep_cool")
@@ -2029,20 +2053,28 @@ def _render_bedtime_setback_skipped(p: dict, unit: str) -> tuple[str, str]:
 
 def _render_morning_wakeup_skipped(p: dict, unit: str) -> tuple[str, str]:
     reason = p.get("reason", "")
+    occ = p.get("occupancy", "")
+    if reason == "occupancy" and occ:
+        return f"Morning wake-up skipped -- {occ} mode active", ""
     return (f"Morning wake-up skipped -- {reason}" if reason else "Morning wake-up skipped"), ""
 
 
 def _render_pre_cool_suppressed_nat_vent(p: dict, unit: str) -> tuple[str, str]:
     indoor = p.get("indoor")
     target = p.get("target")
-    label = "Pre-cool suppressed -- nat-vent already achieved target"
+    reason = p.get("reason")
+    if reason == "active_session":
+        label = "Pre-cool deferred -- nat-vent/WHF session already active"
+    else:
+        label = "Pre-cool suppressed -- nat-vent already achieved target"
+    settings = ""
     if indoor is not None and target is not None:
         with contextlib.suppress(TypeError, ValueError):
-            label = (
-                f"Pre-cool suppressed -- nat-vent: indoor {format_temp(float(indoor), unit)}"
-                f" <= target {format_temp(float(target), unit)}"
+            comparator = "<=" if reason != "active_session" else "chasing"
+            settings = (
+                f"indoor {format_temp(float(indoor), unit)} {comparator} target {format_temp(float(target), unit)}"
             )
-    return label, ""
+    return label, settings
 
 
 def _render_pre_cool_overshoot(p: dict, unit: str) -> tuple[str, str]:
@@ -2091,7 +2123,19 @@ def _render_startup_coalesced(p: dict, unit: str) -> tuple[str, str]:
     if sensors:
         notes.append(f"{sensors} sensor(s) open")
     suffix = " -- " + ", ".join(notes) if notes else ""
-    return f"Startup coalescing complete{suffix}", ""
+    settings_parts = []
+    indoor_f = p.get("indoor_f")
+    outdoor_f = p.get("outdoor_f")
+    if indoor_f is not None and outdoor_f is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            settings_parts.append(
+                f"indoor {format_temp(float(indoor_f), unit)} / outdoor {format_temp(float(outdoor_f), unit)}"
+            )
+    archetype = p.get("fan_archetype")
+    if archetype:
+        settings_parts.append(f"fan: {archetype}")
+    settings = ", ".join(settings_parts)
+    return f"Startup coalescing complete{suffix}", settings
 
 
 def _render_stuck_grace_recovered(p: dict, unit: str) -> tuple[str, str]:
@@ -2115,16 +2159,36 @@ def _render_thermal_learning_no_observations(p: dict, unit: str) -> tuple[str, s
         label = f"Thermal learning: no observations despite {runtime} min HVAC runtime"
     else:
         label = "Thermal learning: no observations recorded"
-    return label, ""
+    session_count = p.get("thermal_session_count")
+    settings = f"sessions today: {session_count}" if session_count is not None else ""
+    return label, settings
 
 
 def _render_incident_detected(p: dict, unit: str) -> tuple[str, str]:
     cls = p.get("incident_class", "")
+    incident_id = p.get("incident_id")
     label = f"Incident detected: {cls}" if cls else "Incident detected"
-    return label, ""
+    if incident_id:
+        label = f"{label} ({incident_id})"
+    settings_parts = []
+    indoor_f = p.get("indoor_f")
+    comfort_heat = p.get("comfort_heat")
+    comfort_cool = p.get("comfort_cool")
+    if indoor_f is not None and comfort_heat is not None and comfort_cool is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            settings_parts.append(
+                f"indoor {format_temp(float(indoor_f), unit)} vs. band "
+                f"[{format_temp(float(comfort_heat), unit)}/{format_temp(float(comfort_cool), unit)}]"
+            )
+    occupancy = p.get("occupancy_mode")
+    if occupancy:
+        settings_parts.append(f"occupancy: {occupancy}")
+    settings = ", ".join(settings_parts)
+    return label, settings
 
 
-# Legacy warm_day events (pre-P3, may appear in persisted event logs)
+# Legacy warm_day events (pre-P3, may appear in persisted event logs). Confirmed
+# zero current emitters (Issue #593 audit) -- kept renderer-only for history.
 def _render_warm_day_setback_applied(p: dict, unit: str) -> tuple[str, str]:
     old_t = p.get("old_setpoint_f")
     new_t = p.get("new_setpoint_f")

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -1833,8 +1833,12 @@ class AutomationEngine:
                             "day_type": classification.day_type,
                             "hvac_mode": classification.hvac_mode,
                             "trend": classification.trend_direction,
+                            "trend_magnitude": classification.trend_magnitude,
                             "old_hvac_mode": _old_mode_cls,
                             "indoor_f": indoor_temp,
+                            "today_high": classification.today_high,
+                            "applied_threshold_f": classification.applied_threshold_f,
+                            "threshold_margin_f": classification.threshold_margin_f,
                         },
                     )
             else:
@@ -2333,6 +2337,7 @@ class AutomationEngine:
                         {
                             "commanded": self._pending_setpoint_single,
                             "reported": reported,
+                            "reject_streak": self._setpoint_reject_streak,
                         },
                     )
                 # Retry after 15 minutes if no newer command has superseded this one.
@@ -2382,6 +2387,7 @@ class AutomationEngine:
                                     "nudge_value": _nudge_temp,
                                     "real_target": _retry_temp,
                                     "mode": _retry_mode,
+                                    "reject_streak": self._setpoint_reject_streak,
                                 },
                             )
                         await self.hass.services.async_call(
@@ -4596,6 +4602,11 @@ class AutomationEngine:
             )
             return "skipped: not eligible"
 
+        # Issue #593: computed up front (pure config + modifier, no gate/indoor dependency)
+        # so the DEFER_NAT_VENT "active_session" branch below can show the target it's
+        # deferring to, not just a generic "already achieved" label that never applied here.
+        pre_cool_target = compute_pre_cool_target(self.config, _modifier)
+
         # Issue #498: occupancy/override/paused/nat-vent checks below now route through the
         # single shared gate (desired_state.decide_scheduled_band_gate()) also used by
         # apply_classification()/handle_bedtime()/handle_morning_wakeup() — see that
@@ -4651,7 +4662,12 @@ class AutomationEngine:
             if self._emit_event_callback:
                 self._emit_event_callback(
                     "pre_cool_suppressed_nat_vent",
-                    {"modifier": _modifier, "reason": "active_session"},
+                    {
+                        "modifier": _modifier,
+                        "reason": "active_session",
+                        "target": pre_cool_target,
+                        "indoor": indoor_temp,
+                    },
                 )
             if _fan_cfg_pc in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
                 return "suppressed: nat-vent/WHF session active"
@@ -4662,7 +4678,6 @@ class AutomationEngine:
         hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
         raw_target = sleep_cool + _modifier  # negative modifier lowers the ceiling below sleep_cool
         floor = sleep_heat_floor + hysteresis
-        pre_cool_target = compute_pre_cool_target(self.config, _modifier)
 
         _LOGGER.info(
             "Pre-cool trigger fired: indoor=%s°F, target=%.1f°F, modifier=%.1f (sleep_cool=%.1f, floor=%.1f)",
@@ -4767,6 +4782,11 @@ class AutomationEngine:
                 "Morning wakeup skipped — occupancy mode is '%s'",
                 self._occupancy_mode,
             )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "morning_wakeup_skipped",
+                    {"reason": "occupancy", "occupancy": self._occupancy_mode},
+                )
             return
 
         if _gate == ScheduledBandGate.DEFER_OVERRIDE:

--- a/custom_components/climate_advisor/classifier.py
+++ b/custom_components/climate_advisor/classifier.py
@@ -59,6 +59,8 @@ class DayClassification:
     today_low: float
     tomorrow_high: float
     tomorrow_low: float
+    applied_threshold_f: float | None = None  # Threshold that produced day_type
+    threshold_margin_f: float | None = None  # today_high - applied_threshold_f
 
     # Computed recommendations
     hvac_mode: str = ""  # "heat", "cool", "off", "auto"
@@ -258,6 +260,19 @@ def classify_day(
 
     _LOGGER.debug("Day type — today_high=%.0f°F, classified=%s", today_high, day_type)
 
+    # Threshold that produced the final day_type (post-hysteresis), and how far
+    # today's high sits from it — surfaced to callers/Activity Record so the
+    # "why" behind classification_applied isn't only in a debug log (Issue #593).
+    _threshold_for_type = {
+        DAY_TYPE_HOT: threshold_hot,
+        DAY_TYPE_WARM: threshold_warm,
+        DAY_TYPE_MILD: threshold_mild,
+        DAY_TYPE_COOL: threshold_cool,
+        DAY_TYPE_COLD: threshold_cool,
+    }
+    applied_threshold = _threshold_for_type[day_type]
+    threshold_margin = today_high - applied_threshold
+
     # Determine trend by comparing tomorrow to today
     high_delta = tomorrow_high - today_high
     low_delta = forecast.tomorrow_low - forecast.today_low
@@ -289,4 +304,6 @@ def classify_day(
         today_low=forecast.today_low,
         tomorrow_high=tomorrow_high,
         tomorrow_low=forecast.tomorrow_low,
+        applied_threshold_f=applied_threshold,
+        threshold_margin_f=round(threshold_margin, 1),
     )

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,24 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.60"
+VERSION = "0.5.61"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.61": [
+        "Feat #593: closed out the remaining Activity Record payload-completeness gaps"
+        " from the #584 investigation — classification decisions now show the trend"
+        " magnitude and the exact threshold/margin that produced the day type; setpoint"
+        " retry/nudge events show the reject streak count; startup coalescing shows"
+        " indoor/outdoor temps and fan archetype; the thermal-learning watchdog shows"
+        " today's session count; the fan-stopped and incident-detected cards now use"
+        " data they already had (fan device, incident ID, comfort-band comparison)"
+        " instead of a generic label; morning wake-up now reports an explicit skip"
+        " reason when occupancy is away/vacation, matching its other skip reasons; and"
+        " pre-cool deferring to an already-active nat-vent/WHF session now shows what"
+        " indoor temp and target it's deferring to, instead of a bare notice. Four"
+        " renderer functions with no current emitter are now explicitly marked as"
+        " legacy/historical-log-only rather than looking like live, untested code.",
+    ],
     "0.5.60": [
         "Feat #580: the dashboard's Activity Record report now defaults to the"
         ' "Last 12 hours" time window instead of 24, and lists events newest-first'
@@ -1540,6 +1555,49 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    593: {
+        "version_fixed": "0.5.61",
+        "title": (
+            "Following the #584 investigation's full event-type audit (Block 4 of the"
+            " plan), several remaining Activity Record event types either discarded"
+            " payload data they already had, or omitted locally-computed inputs their"
+            " emit sites could have passed — leaving the reasoning behind those specific"
+            " decisions invisible even though the underlying data existed."
+        ),
+        "scope_covered": (
+            "classifier.py: DayClassification gained applied_threshold_f/"
+            "threshold_margin_f, computed in classify_day() from the final"
+            " (post-hysteresis) day_type against the threshold that produced it."
+            " automation.py: classification_applied payload now includes"
+            " trend_magnitude/today_high/applied_threshold_f/threshold_margin_f;"
+            " setpoint_rejected/setpoint_nudge now include reject_streak;"
+            " handle_morning_wakeup()'s DEFER_OCCUPANCY branch now emits"
+            " morning_wakeup_skipped (previously silent, unlike its DEFER_OVERRIDE/"
+            "DEFER_PAUSED siblings and handle_bedtime()'s equivalent branch);"
+            " pre_cool_suppressed_nat_vent's active_session branch (DEFER_NAT_VENT)"
+            " now includes indoor/target — pre_cool_target is computed once, up front,"
+            " before the gate checks, instead of after the branch that needed it."
+            " coordinator.py: startup_coalesced now includes indoor_f/outdoor_f/"
+            "fan_archetype; thermal_learning_no_observations now includes"
+            " thermal_session_count. ai_skills_context.py: renderers for"
+            " classification_applied, setpoint_rejected/setpoint_nudge,"
+            " startup_coalesced, thermal_learning_no_observations,"
+            " fan_untracked_cleared (now uses fan_device instead of a hardcoded"
+            ' "fan: off"), incident_detected (now uses incident_id and the'
+            " comfort-band comparison it already carried), morning_wakeup_skipped,"
+            " and pre_cool_suppressed_nat_vent were all updated to surface the new/"
+            "existing fields; nat_vent_sleep_ceiling_reached and the three legacy"
+            " warm_day_* renderers (confirmed zero current emitters) are now"
+            " explicitly commented as historical-log-only. Two golden simulations"
+            " (away_morning_wakeup_skipped_assertion, morning_wakeup_skipped_away_"
+            "occupancy) were updated with the user's explicit sign-off to expect the"
+            " new morning_wakeup_skipped event instead of relying on the prior silent"
+            " gap; no HVAC/decision-logic behavior changed in either. A pre-existing,"
+            " unrelated test-harness gap (a pending scenario passing by coincidence"
+            " due to the harness not advancing past a scheduled trigger) was found"
+            " during this work and filed separately as #598 rather than fixed here."
+        ),
+    },
     580: {
         "version_fixed": "0.5.60",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1634,6 +1634,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 "nat_vent_activated": nat_vent_activated,
                 "hvac_commanded": hvac_commanded,
                 "sensors_open_count": len(open_sensors),
+                "indoor_f": indoor,
+                "outdoor_f": outdoor,
+                "fan_archetype": self.config.get("fan_mode"),
             },
         )
         self._startup_coalesce_active = False
@@ -3135,7 +3138,10 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 )
                 self._emit_event(
                     "thermal_learning_no_observations",
-                    {"hvac_runtime_minutes": round(self._today_record.hvac_runtime_minutes, 1)},
+                    {
+                        "hvac_runtime_minutes": round(self._today_record.hvac_runtime_minutes, 1),
+                        "thermal_session_count": self._today_record.thermal_session_count,
+                    },
                 )
             self.learning.record_day(self._today_record)
             await self.hass.async_add_executor_job(self.learning.save_state)

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.60"
+  "version": "0.5.61"
 }

--- a/tests/test_activity_renderers.py
+++ b/tests/test_activity_renderers.py
@@ -1173,3 +1173,146 @@ class TestNewestFirstOrdering:
 
     def test_newest_first_empty_log_unaffected(self):
         assert _build_table([], newest_first=True) == _build_table([], newest_first=False)
+
+
+class TestPayloadCompletenessFollowUp:
+    """Issue #593: remaining payload-completeness + legacy renderer cleanup.
+
+    Each test calls the registered renderer directly with a representative payload
+    (mirroring how the real emit sites now populate it) and asserts the new field
+    actually reaches the rendered Settings/Event cell -- not just that it's present
+    in the payload dict.
+    """
+
+    def _render(self, event_type: str, payload: dict, unit: str = "fahrenheit") -> tuple[str, str]:
+        return _act_mod.EVENT_RENDERERS[event_type](payload, unit)
+
+    # -- K1: classification_applied trend/threshold -------------------------
+
+    def test_classification_applied_shows_threshold_margin(self):
+        label, settings = self._render(
+            "classification_applied",
+            {
+                "day_type": "hot",
+                "hvac_mode": "cool",
+                "trend": "stable",
+                "trend_magnitude": 1.2,
+                "old_hvac_mode": "off",
+                "today_high": 86.0,
+                "applied_threshold_f": 82.0,
+                "threshold_margin_f": 4.0,
+            },
+        )
+        assert "hot" in label
+        assert "82" in settings and "86" in settings
+        assert "+4.0" in settings or "4.0" in settings
+
+    def test_classification_applied_missing_threshold_data_no_crash(self):
+        label, settings = self._render(
+            "classification_applied", {"day_type": "mild", "hvac_mode": "off", "trend": "stable"}
+        )
+        assert "mild" in label
+        assert settings == ""
+
+    # -- K2: setpoint_rejected / setpoint_nudge retry streak -----------------
+
+    def test_setpoint_rejected_shows_reject_streak(self):
+        _label, settings = self._render("setpoint_rejected", {"commanded": 72.0, "reported": 74.0, "reject_streak": 3})
+        assert "reject streak=3" in settings
+
+    def test_setpoint_nudge_shows_reject_streak(self):
+        _label, settings = self._render(
+            "setpoint_nudge",
+            {"nudge_value": 73.0, "real_target": 72.0, "mode": "cool", "reject_streak": 2},
+        )
+        assert "reject streak=2" in settings
+
+    # -- K3: startup_coalesced indoor/outdoor/archetype -----------------------
+
+    def test_startup_coalesced_shows_indoor_outdoor_archetype(self):
+        _label, settings = self._render(
+            "startup_coalesced",
+            {
+                "nat_vent_activated": False,
+                "hvac_commanded": True,
+                "sensors_open_count": 0,
+                "indoor_f": 74.0,
+                "outdoor_f": 84.0,
+                "fan_archetype": "whole_house_fan",
+            },
+        )
+        assert "74" in settings and "84" in settings
+        assert "whole_house_fan" in settings
+
+    # -- K4: thermal_learning_no_observations session count -------------------
+
+    def test_thermal_learning_no_observations_shows_session_count(self):
+        _label, settings = self._render(
+            "thermal_learning_no_observations",
+            {"hvac_runtime_minutes": 45.0, "thermal_session_count": 0},
+        )
+        assert "sessions today: 0" in settings
+
+    # -- K5: fan_untracked_cleared uses fan_device -----------------------------
+
+    def test_fan_untracked_cleared_shows_fan_device(self):
+        _label, settings = self._render("fan_untracked_cleared", {"fan_device": "whf"})
+        assert "whf" in settings
+
+    def test_fan_untracked_cleared_missing_device_falls_back(self):
+        _label, settings = self._render("fan_untracked_cleared", {})
+        assert settings == "fan: off"
+
+    # -- K6: incident_detected uses incident_id + comfort compare -------------
+
+    def test_incident_detected_shows_id_and_band_comparison(self):
+        label, settings = self._render(
+            "incident_detected",
+            {
+                "incident_class": "comfort_violation",
+                "incident_id": "abc123",
+                "indoor_f": 76.0,
+                "comfort_heat": 68.0,
+                "comfort_cool": 74.0,
+                "occupancy_mode": "home",
+            },
+        )
+        assert "abc123" in label
+        assert "76" in settings and "68" in settings and "74" in settings
+        assert "home" in settings
+
+    # -- K7: morning_wakeup DEFER_OCCUPANCY now emits --------------------------
+
+    def test_morning_wakeup_skipped_occupancy_reason(self):
+        label, _settings = self._render("morning_wakeup_skipped", {"reason": "occupancy", "occupancy": "away"})
+        assert "away mode active" in label
+
+    # -- L: pre_cool_suppressed_nat_vent active_session now shows comparison --
+
+    def test_pre_cool_suppressed_active_session_shows_target(self):
+        label, settings = self._render(
+            "pre_cool_suppressed_nat_vent",
+            {"modifier": -2.0, "reason": "active_session", "target": 70.0, "indoor": 72.0},
+        )
+        assert "session already active" in label
+        assert "70" in settings and "72" in settings
+
+    def test_pre_cool_suppressed_achieved_reason_unchanged(self):
+        label, settings = self._render(
+            "pre_cool_suppressed_nat_vent",
+            {"modifier": -1.0, "reason": "achieved", "target": 70.0, "indoor": 69.0},
+        )
+        assert "already achieved" in label
+        assert "70" in settings and "69" in settings
+
+    # -- M: legacy dead renderers still render without crashing ---------------
+
+    def test_legacy_renderers_still_render_persisted_logs(self):
+        for event_type, payload in (
+            ("nat_vent_sleep_ceiling_reached", {"indoor_temp": 70.0, "sleep_cool": 70.0}),
+            ("warm_day_setback_applied", {"old_setpoint_f": 72.0, "new_setpoint_f": 68.0}),
+            ("warm_day_state_confirmed", {}),
+            ("warm_day_comfort_gap", {}),
+        ):
+            label, _settings = self._render(event_type, payload)
+            assert label

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -952,6 +952,38 @@ class TestClassificationHysteresis:
         result = classify_day(make_forecast(THRESHOLD_HOT - M - 1), previous_day_type=DAY_TYPE_HOT)
         assert result.day_type == DAY_TYPE_WARM
 
+
+# ---------------------------------------------------------------------------
+# Issue #593: applied_threshold_f / threshold_margin_f -- the threshold that
+# produced day_type, and today's high's distance from it, surfaced to callers
+# instead of staying trapped in a _LOGGER.debug() line.
+# ---------------------------------------------------------------------------
+
+
+class TestAppliedThresholdAndMargin:
+    def test_hot_day_reports_hot_threshold_and_positive_margin(self):
+        result = classify_day(make_forecast(THRESHOLD_HOT + 4))
+        assert result.applied_threshold_f == THRESHOLD_HOT
+        assert result.threshold_margin_f == 4.0
+
+    def test_warm_day_reports_warm_threshold(self):
+        result = classify_day(make_forecast(THRESHOLD_WARM))
+        assert result.applied_threshold_f == THRESHOLD_WARM
+        assert result.threshold_margin_f == 0.0
+
+    def test_cold_day_reports_cool_threshold_with_negative_margin(self):
+        """COLD has no dedicated threshold — margin is measured against the cool floor."""
+        result = classify_day(make_forecast(THRESHOLD_COOL - 5))
+        assert result.applied_threshold_f == THRESHOLD_COOL
+        assert result.threshold_margin_f == -5.0
+
+    def test_hysteresis_sticky_day_reports_threshold_for_final_day_type(self):
+        """When hysteresis keeps the previous day_type, the threshold must match
+        the day_type actually applied (previous), not the one first computed."""
+        result = classify_day(make_forecast(THRESHOLD_HOT + 1), previous_day_type=DAY_TYPE_WARM)
+        assert result.day_type == DAY_TYPE_WARM
+        assert result.applied_threshold_f == THRESHOLD_WARM
+
     # --- Large jump bypasses dead zone ---
 
     def test_large_jump_warm_to_hot(self):

--- a/tests/test_occupancy_automation.py
+++ b/tests/test_occupancy_automation.py
@@ -240,6 +240,24 @@ class TestMorningWakeupOccupancy:
 
         engine.hass.services.async_call.assert_not_called()
 
+    def test_wakeup_skipped_when_away_emits_morning_wakeup_skipped(self):
+        """Issue #593: DEFER_OCCUPANCY previously returned silently — unlike its
+        DEFER_OVERRIDE/DEFER_PAUSED siblings and unlike handle_bedtime's equivalent
+        branch, it never called _emit_event_callback, leaving this skip reason
+        entirely invisible in the Activity Record."""
+        engine = _make_engine()
+        emitted = []
+        engine._emit_event_callback = lambda event_type, payload: emitted.append((event_type, payload))
+        c = _make_classification(hvac_mode="heat", day_type="cold")
+        engine._current_classification = c
+        engine.set_occupancy_mode("away")
+
+        asyncio.run(engine.handle_morning_wakeup())
+
+        matches = [e for e in emitted if e[0] == "morning_wakeup_skipped"]
+        assert len(matches) == 1
+        assert matches[0][1] == {"reason": "occupancy", "occupancy": "away"}
+
     def test_wakeup_skipped_when_vacation(self):
         """Morning wakeup should not restore comfort during vacation."""
         engine = _make_engine()

--- a/tests/test_pre_cool.py
+++ b/tests/test_pre_cool.py
@@ -365,6 +365,27 @@ class TestHandlePreCoolNatVentBypass:
         assert payload["indoor"] == pytest.approx(74.5)
         assert payload["target"] == pytest.approx(75.0)
 
+    def test_active_session_deferral_event_carries_indoor_and_target(self):
+        """Issue #593: the DEFER_NAT_VENT 'active_session' branch fires before
+        pre_cool_target used to be computed, so its emit carried no comparison
+        data at all — reordered so it now shows what it's deferring to, same
+        as the 'achieved' bypass branch above."""
+        engine = _make_engine({"sleep_cool": 78.0, "comfort_heat": 70.0})
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda e, d: emitted.append((e, d))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
+        engine._natural_vent_active = True
+
+        asyncio.run(engine.handle_pre_cool(indoor_temp=73.0, nat_vent_just_closed=False))
+
+        suppressed = [(e, d) for e, d in emitted if e == "pre_cool_suppressed_nat_vent"]
+        assert len(suppressed) == 1
+        _, payload = suppressed[0]
+        assert payload["reason"] == "active_session"
+        assert payload["target"] == pytest.approx(75.0)
+        assert payload["indoor"] == pytest.approx(73.0)
+
 
 # ---------------------------------------------------------------------------
 # Tests: handle_pre_cool() — skip conditions

--- a/tests/test_startup_coalesce.py
+++ b/tests/test_startup_coalesce.py
@@ -521,6 +521,21 @@ class TestStartupCoalesceDoCoalesce:
         assert "hvac_commanded" in event_data
         assert "sensors_open_count" in event_data
 
+    def test_startup_coalesced_event_carries_indoor_outdoor_archetype(self):
+        """Issue #593: startup_coalesced previously only carried summary booleans —
+        indoor/outdoor temp and fan archetype were available locally but never
+        threaded into the payload."""
+        coord = _make_coalesce_coord_stub()
+        coord.config["fan_mode"] = "whole_house_fan"
+
+        asyncio.run(coord._do_startup_coalesce())
+
+        event_name, event_data = coord._emit_event.call_args[0]
+        assert event_name == "startup_coalesced"
+        assert event_data["indoor_f"] == 72.0
+        assert event_data["outdoor_f"] == 65.0
+        assert event_data["fan_archetype"] == "whole_house_fan"
+
     def test_startup_coalesce_active_cleared_after(self):
         """_startup_coalesce_active is False after _do_startup_coalesce runs."""
         coord = _make_coalesce_coord_stub()

--- a/tools/simulations/golden/MANIFEST.json
+++ b/tools/simulations/golden/MANIFEST.json
@@ -159,13 +159,13 @@
     "issue": 229
   },
   "away_morning_wakeup_skipped_assertion": {
-    "sha256": "5c5aa27b6de12700ee7f3219faee80b113d3d0a7d5d118d8c88f167d53c7356c",
-    "signed": "2026-07-20",
+    "sha256": "3f82436d23c2219e110a3730714ed5551891fca7a8219431312657f52c98aa81",
+    "signed": "2026-08-07",
     "issue": 229
   },
   "morning_wakeup_skipped_away_occupancy": {
-    "sha256": "e013ef1001712ceae649c71fbccb8d72d8a71751c12b12f26f43cd6c28f1a934",
-    "signed": "2026-07-20",
+    "sha256": "a57f603d79ce5bd914dcdb5502ab5c8565194da5e0c06fa690fc2afe5c83eaff",
+    "signed": "2026-08-07",
     "issue": 229
   },
   "away_natvent_activates_free_cooling": {

--- a/tools/simulations/golden/away_morning_wakeup_skipped_assertion.json
+++ b/tools/simulations/golden/away_morning_wakeup_skipped_assertion.json
@@ -1,14 +1,18 @@
 {
   "name": "away_morning_wakeup_skipped_assertion",
-  "description": "Away mode with setback active (79F). Bedtime fires while away — bedtime-specific sleep temps are skipped but the away setback is actively reapplied (Issue #505). Wakeup event fires at 07:00 while still away. Production handle_morning_wakeup() returns silently with no event when occupancy is not home/guest. The last observable decision at 07:00 is the setback_applied from the 22:30 bedtime-time reapply.",
+  "description": "Away mode with setback active (79F). Bedtime fires while away — bedtime-specific sleep temps are skipped but the away setback is actively reapplied (Issue #505). Wakeup event fires at 07:00 while still away. Production handle_morning_wakeup() no longer applies comfort-restore temps (occupancy guard), but now emits a morning_wakeup_skipped event (Issue #593) so the skip is visible in the Activity Record instead of silently absent.",
   "source": "synthetic",
   "issue": 229,
   "notes": [
-    "Production handle_morning_wakeup(): if occupancy not in (home, guest), returns silently (no event emitted).",
-    "The 07:00 wakeup call produces no new event log entry.",
-    "production_outcome_at uses last-decision-at-or-before lookup, so it returns the last decision",
-    "from 22:30 as the 'current' observable state at 07:00.",
-    "This correctly documents: (1) away setback stays active, (2) wakeup comfort restore is suppressed.",
+    "Production handle_morning_wakeup(): if occupancy not in (home, guest), no comfort-restore temps are applied.",
+    "Issue #593: the DEFER_OCCUPANCY branch previously returned with no event at all, unlike its",
+    "DEFER_OVERRIDE/DEFER_PAUSED siblings and handle_bedtime()'s equivalent branch — the skip was",
+    "entirely invisible in the Activity Record. Fixed to emit morning_wakeup_skipped with",
+    "{reason: 'occupancy', occupancy: <mode>}, so the 07:00 wakeup call now produces its own event",
+    "log entry ('Morning wake-up skipped -- away mode active') instead of leaving a silent gap that",
+    "required the reader to infer the skip from the absence of any entry.",
+    "This correctly documents: (1) away setback stays active, (2) wakeup comfort restore is suppressed,",
+    "(3) the suppression itself is now a visible, explained event.",
     "The existing away-mode-classification-cycle golden mentions this behavior in notes but has no",
     "explicit wakeup event — this scenario adds that explicit coverage.",
     "Covers Priority 6b away_morning_wakeup from plan abundant-mapping-clarke.md.",
@@ -18,8 +22,9 @@
     "scheduled bedtime, the same 'setback already active' assumption could be false). The fix makes",
     "handle_bedtime() actively reapply the away/vacation setback in addition to skipping sleep temps,",
     "so the 22:30 event is now setback_applied (79F) rather than a bare bedtime_setback_skipped with",
-    "no accompanying write. The wakeup-is-silent-while-away behavior this scenario is actually named",
-    "for is unchanged; only the setpoint-facing outcome of the prior bedtime cycle improved."
+    "no accompanying write. The wakeup-is-silent-comfort-wise-while-away behavior this scenario is",
+    "actually named for is unchanged; the setpoint-facing outcome of the prior bedtime cycle improved",
+    "(Issue #505), and the wakeup skip itself became a visible event (Issue #593)."
   ],
   "config": {
     "comfort_heat": 70,
@@ -49,7 +54,7 @@
     {
       "time": "2026-07-16T07:00:00",
       "type": "wakeup",
-      "note": "Wakeup fires while still away — production returns silently (no event emitted); last observable decision stays bedtime_setback_skipped"
+      "note": "Wakeup fires while still away — production emits morning_wakeup_skipped (Issue #593); no comfort-restore temps applied"
     }
   ],
   "assertions": [
@@ -61,16 +66,15 @@
     },
     {
       "at": "2026-07-16T07:00:00",
-      "expect": "setback_applied",
-      "expect_temp": 79.0,
+      "expect": "morning_wakeup_skipped",
       "track": "logic",
-      "reason": "Wakeup fires while away — handle_morning_wakeup() returns silently with no event (occupancy not home/guest). production_outcome_at returns the setback_applied (79F) from the prior 22:30 bedtime-time reapply (Issue #505) as the last observable decision. Away setback maintained; no comfort restore."
+      "reason": "Wakeup fires while away — handle_morning_wakeup() applies no comfort-restore temps (occupancy not home/guest) and, as of Issue #593, emits morning_wakeup_skipped ({reason: 'occupancy', occupancy: 'away'}) so the skip is visible in the Activity Record. Away setback maintained (still 79F, from the 22:30 bedtime-time reapply); no comfort restore."
     }
   ],
   "verdict": {
     "type": "positive",
-    "summary": "Morning wakeup produces no event while away — last observable decision is the away setback reapplied at bedtime; setback maintained",
-    "observed_behavior": "setback_applied (79F) on away → setback_applied (79F) again at 22:30 bedtime reapply → wakeup at 07:00 silent; last decision stays setback_applied",
-    "expected_behavior": "Wakeup event skipped when occupancy=away; away setback remains active (and is actively reconfirmed at bedtime, Issue #505) until user returns"
+    "summary": "Morning wakeup emits an explicit skip event while away — comfort is not restored; the away setback (reapplied at bedtime) remains active",
+    "observed_behavior": "setback_applied (79F) on away → setback_applied (79F) again at 22:30 bedtime reapply → morning_wakeup_skipped at 07:00 (occupancy=away, no comfort restore)",
+    "expected_behavior": "Wakeup comfort-restore skipped when occupancy=away, and the skip is now a visible, explained event (Issue #593); away setback remains active (and is actively reconfirmed at bedtime, Issue #505) until user returns"
   }
 }

--- a/tools/simulations/golden/morning_wakeup_skipped_away_occupancy.json
+++ b/tools/simulations/golden/morning_wakeup_skipped_away_occupancy.json
@@ -1,22 +1,25 @@
 {
   "name": "morning_wakeup_skipped_away_occupancy",
-  "description": "Away mode with setback already active. Bedtime fires while away — bedtime-specific sleep temps are skipped but the away setback is actively reapplied (Issue #505). Wakeup event fires at 07:00 while occupancy=away. Production handle_morning_wakeup() returns silently with no event. The last observable decision at 07:00 is the setback_applied from the 22:30 bedtime-time reapply.",
+  "description": "Away mode with setback already active. Bedtime fires while away — bedtime-specific sleep temps are skipped but the away setback is actively reapplied (Issue #505). Wakeup event fires at 07:00 while occupancy=away. Production handle_morning_wakeup() applies no comfort-restore temps and, as of Issue #593, emits morning_wakeup_skipped so the skip is visible in the Activity Record.",
   "source": "synthetic",
   "issue": 229,
   "notes": [
-    "Production behavior: handle_morning_wakeup() checks occupancy — if away/vacation, returns silently (no event).",
-    "No 'morning_wakeup_skipped' event is emitted for the occupancy path (only manual_override path emits it).",
-    "production_outcome_at last-decision-at-or-before lookup returns the last decision at 07:00.",
+    "Production behavior: handle_morning_wakeup() checks occupancy — if away/vacation, no comfort-restore temps are applied.",
+    "Issue #593: the occupancy path previously emitted no event at all (only the manual_override/",
+    "paused_by_door paths emitted morning_wakeup_skipped) — the occupancy skip was entirely invisible",
+    "in the Activity Record. Fixed to emit morning_wakeup_skipped with {reason: 'occupancy',",
+    "occupancy: 'away'} for this path too, mirroring handle_bedtime()'s equivalent branch.",
     "This documents two things: (1) bedtime-specific sleep temps are skipped while away, (2) wakeup comfort restore",
-    "is also suppressed while away — setback stays active until occupancy returns home.",
+    "is also suppressed while away, now as a visible/explained event — setback stays active until occupancy returns home.",
     "Covers Priority 5 wakeup+away from plan abundant-mapping-clarke.md.",
     "Issue #505 update: handle_bedtime()'s DEFER_OCCUPANCY branch previously only emitted",
     "bedtime_setback_skipped and did nothing else. The fix makes it actively reapply the away/vacation",
     "setback in addition to skipping sleep temps, so the 22:30 event is now setback_applied (79F)",
     "rather than a bare bedtime_setback_skipped with no accompanying write. The wakeup-is-silent-",
-    "while-away behavior this scenario is named for is unchanged; only the setpoint-facing outcome",
-    "of the prior bedtime cycle improved. See away_morning_wakeup_skipped_assertion.json for the",
-    "near-identical sibling scenario updated for the same reason."
+    "comfort-wise-while-away behavior this scenario is named for is unchanged; the setpoint-facing",
+    "outcome of the prior bedtime cycle improved (Issue #505) and the wakeup skip itself became a",
+    "visible event (Issue #593). See away_morning_wakeup_skipped_assertion.json for the near-identical",
+    "sibling scenario updated for the same reason."
   ],
   "config": {
     "comfort_heat": 70,
@@ -46,7 +49,7 @@
     {
       "time": "2026-07-15T07:00:00",
       "type": "wakeup",
-      "note": "Wakeup fires while still away — production returns silently (no event); last observable decision stays bedtime_setback_skipped"
+      "note": "Wakeup fires while still away — production emits morning_wakeup_skipped (Issue #593); no comfort-restore temps applied"
     }
   ],
   "assertions": [
@@ -58,16 +61,15 @@
     },
     {
       "at": "2026-07-15T07:00:00",
-      "expect": "setback_applied",
-      "expect_temp": 79.0,
+      "expect": "morning_wakeup_skipped",
       "track": "logic",
-      "reason": "Wakeup fires while occupancy=away — handle_morning_wakeup() returns silently with no event emitted. production_outcome_at returns the setback_applied (79F) from the prior 22:30 bedtime-time reapply (Issue #505) as the last observable decision. Comfort restore suppressed; setback maintained."
+      "reason": "Wakeup fires while occupancy=away — handle_morning_wakeup() applies no comfort-restore temps and, as of Issue #593, emits morning_wakeup_skipped ({reason: 'occupancy', occupancy: 'away'}) so the skip is visible in the Activity Record. Comfort restore suppressed; away setback (79F, from the 22:30 bedtime-time reapply) maintained."
     }
   ],
   "verdict": {
     "type": "positive",
-    "summary": "Wakeup produces no event while away — last observable decision is the away setback reapplied at bedtime; comfort NOT restored",
-    "observed_behavior": "setback_applied (79F) on away → setback_applied (79F) again at 22:30 bedtime reapply → wakeup at 07:00 silent; last decision stays setback_applied",
-    "expected_behavior": "Morning wakeup respects away mode — no comfort restore while user is away; setback maintained (and actively reconfirmed at bedtime, Issue #505)"
+    "summary": "Wakeup emits an explicit skip event while away — comfort is NOT restored; the away setback reapplied at bedtime remains active",
+    "observed_behavior": "setback_applied (79F) on away → setback_applied (79F) again at 22:30 bedtime reapply → morning_wakeup_skipped at 07:00 (occupancy=away, no comfort restore)",
+    "expected_behavior": "Morning wakeup respects away mode — no comfort restore while user is away, and the skip is now a visible, explained event (Issue #593); setback maintained (and actively reconfirmed at bedtime, Issue #505)"
   }
 }

--- a/tools/simulations/pending/vacation_occupancy_override_cleared.json
+++ b/tools/simulations/pending/vacation_occupancy_override_cleared.json
@@ -3,6 +3,7 @@
   "description": "Vacation-mode mirror of cancel_override_then_resume: a manual override set during vacation (e.g. cleaners visiting) must have the deep vacation setback restored the moment it's cancelled, not left at the override's setpoint until the next unrelated event (Issue #505)",
   "source": "synthetic",
   "issue": 505,
+  "pending_issue": 598,
   "config": {
     "comfort_heat": 68,
     "comfort_cool": 74,
@@ -85,7 +86,8 @@
   "notes": [
     "Direct vacation-mode mirror of tools/simulations/golden/cancel_override_then_resume.json (the AWAY-mode version of this exact sequence, which already passes). There was no vacation equivalent prior to Issue #505 — the coverage gap tracked the code gap exactly.",
     "Revert test: with the automation.py:1513 DEFER_OCCUPANCY-VACATION branch reverted to its pre-fix log-and-return form, the 07:43:10 assertion fails (no setback_applied event fires — event_log ends at override cleared/grace expired). Confirms this assertion genuinely depends on the fix, not a coincidental re-apply.",
-    "override_confirm_seconds/manual_grace_seconds mirror cancel_override_then_resume.json's values for the same reason (short wall-clock span; grace long enough that the explicit cancel_override event — not an auto-expiry — is what's under test)."
+    "override_confirm_seconds/manual_grace_seconds mirror cancel_override_then_resume.json's values for the same reason (short wall-clock span; grace long enough that the explicit cancel_override event — not an auto-expiry — is what's under test).",
+    "Issue #598 (found during #593): the 13:54:10 assertion was passing by coincidence, not because the claimed cancel_override reapply was actually exercised. Direct inspection of run_production_scenario()'s real event_log/action_log shows the harness stops advancing after the scheduled 04:00 wake_time trigger — none of the later explicit events (thermostat_state_changed, cancel_override, the final temp_update) are ever dispatched. Before #593's unrelated morning_wakeup_skipped fix, the 22:30 bedtime-reapply decision (also 82F) was the last one in the truncated log and happened to match the expected value. Marked pending_issue until the harness truncation is diagnosed and fixed."
   ],
   "use_coordinator": true,
   "skip_startup_coalesce": true


### PR DESCRIPTION
## Summary

Block 4 of the #584 investigation's plan — closes out the remaining, non-lifecycle payload-completeness gaps identified in the original full event-type audit (item K), the pre_cool_suppressed_nat_vent control-flow decision (item L), and legacy dead-renderer cleanup (item M).

- **K1** `classification_applied`: adds `trend_magnitude` and the exact threshold/margin that produced the day type. `classify_day()` now returns `applied_threshold_f`/`threshold_margin_f` alongside `day_type`.
- **K2** `setpoint_rejected`/`setpoint_nudge`: adds `reject_streak`.
- **K3** `startup_coalesced`: adds `indoor_f`/`outdoor_f`/`fan_archetype`.
- **K4** `thermal_learning_no_observations`: adds `thermal_session_count`.
- **K5** `fan_untracked_cleared` renderer: uses `fan_device` from the payload instead of a hardcoded `"fan: off"`.
- **K6** `incident_detected` renderer: uses `incident_id` and the comfort-band comparison values the payload already carried.
- **K7** `handle_morning_wakeup()`'s `DEFER_OCCUPANCY` branch: now emits `morning_wakeup_skipped` — previously silent, unlike its `DEFER_OVERRIDE`/`DEFER_PAUSED` siblings and `handle_bedtime()`'s equivalent branch.
- **L** `pre_cool_suppressed_nat_vent`'s `active_session` branch: `pre_cool_target` is now computed up front (pure config + modifier, no gate dependency) instead of after the branch that needed it, so the deferral event can show indoor/target like its `achieved` sibling.
- **M** Four renderer functions confirmed to have zero current emitters (`nat_vent_sleep_ceiling_reached`, `warm_day_setback_applied`, `warm_day_state_confirmed`, `warm_day_comfort_gap`) are now explicitly commented as historical-log-only.

No decision/HVAC logic changed anywhere in this PR — every change either adds a field to an existing payload or improves how an existing field renders, except K7's new emit call and L's control-flow reorder (both narration-only; the reorder doesn't change what `pre_cool_target` evaluates to).

## Golden scenario changes (explicit user sign-off obtained)

K7 makes `handle_morning_wakeup()` emit an event it previously didn't, which broke 2 locked golden scenarios (`away_morning_wakeup_skipped_assertion`, `morning_wakeup_skipped_away_occupancy`) written to assert "no event, last known decision carries forward" as correct. Per project policy this required explicit confirmation before touching golden files — obtained, then both scenarios' assertions/notes/verdict updated to expect `morning_wakeup_skipped` and re-signed via `python tools/simulate.py --sign`. `--check-integrity` passes; all 74 golden scenarios pass unchanged otherwise.

## Unrelated pre-existing bug found and filed separately (#598)

Investigating a pending-scenario failure surfaced that `tools/simulations/pending/vacation_occupancy_override_cleared.json`'s 13:54:10 assertion was passing by coincidence, not because the real cancel_override reapply mechanism was exercised — `run_production_scenario()`'s real event_log/action_log stop advancing at the scenario's 04:00 scheduled wakeup trigger, before or after this PR. Filed as #598 and marked the scenario `pending_issue: 598` so it correctly xfails instead of silently passing or blocking this PR.

## Test plan

- [x] `ruff check` / `ruff format` clean
- [x] Full suite: 3748 passed, 1 xfailed (the pre-existing #598 gap)
- [x] 74/74 golden scenarios pass
- [x] `tools/simulate.py --check-integrity` clean
- [x] New unit tests for every K/L item (renderer tests in `test_activity_renderers.py`, `classify_day()` threshold tests in `test_classifier.py`, emit-site tests in `test_occupancy_automation.py`/`test_pre_cool.py`/`test_startup_coalesce.py`)
- [x] Version bump: 0.5.60 → 0.5.61 (const.py VERSION + RELEASE_NOTES + KNOWN_FIXES[593], manifest.json, CHANGELOG.md) — `test_version_sync.py` passes