### PR TITLE
Fix #602 + #598: daily record no longer depends on a single, retry-less briefing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.66] — 2026-08-08
+
+- Fix #602: the daily learning record (which gates manual-override detection for setpoint-only changes, HVAC runtime tracking, comfort-violation minutes, occupancy-away minutes, door/window pause counts, and the thermal-learning watchdog) was only ever created once a day by the morning briefing — if the weather integration happened to be unavailable at that one fixed moment, all of that silently stopped working for the rest of the day, with no warning. It now also gets created by the regular classification cycle, which already retries weather forever — the gap shrinks from up to 24 hours to about 30 minutes. Fix #598: a test scenario covering Issue #505's vacation-override-cleared fix was passing by coincidence rather than exercising the real behavior — this fix gives it real coverage.
+
 ## [0.5.65] — 2026-08-08
 
 - Fix #600: after an HA restart or grace-period expiry with the whole-house fan already running for natural ventilation, the Activity Record no longer shows the same "Fan activated" adoption logged 2-3 times in the same minute — the fan itself only ever turned on once; only the redundant log/event entries are gone. Also fixes the displayed nat-vent session start time silently jumping forward on each redundant re-confirmation.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,22 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.65"
+VERSION = "0.5.66"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.66": [
+        "Fix #602: the daily learning record (which gates manual-override detection for"
+        " setpoint-only changes, HVAC runtime tracking, comfort-violation minutes,"
+        " occupancy-away minutes, door/window pause counts, and the thermal-learning"
+        " watchdog) was only ever created once a day by the morning briefing — if the"
+        " weather integration happened to be unavailable at that one fixed moment, all of"
+        " that silently stopped working for the rest of the day, with no warning. It now"
+        " also gets created by the regular classification cycle, which already retries"
+        " weather forever — the gap shrinks from up to 24 hours to about 30 minutes."
+        " Fix #598: a test scenario covering Issue #505's vacation-override-cleared fix"
+        " was passing by coincidence rather than exercising the real behavior — this fix"
+        " gives it real coverage.",
+    ],
     "0.5.65": [
         "Fix #600: after an HA restart or grace-period expiry with the whole-house fan"
         " already running for natural ventilation, the Activity Record no longer shows"
@@ -1589,6 +1602,45 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    602: {
+        "version_fixed": "0.5.66",
+        "title": (
+            "self._today_record (coordinator.py) — which gates setpoint-only manual"
+            " override detection, HVAC runtime tracking, comfort-violation minutes,"
+            " occupancy-away minutes, door/window pause counts, and the thermal-learning"
+            " watchdog — was created in exactly one place: _async_send_briefing(), a"
+            " once-daily scheduled trigger with no retry, which bails out early whenever"
+            " the weather entity has no forecast at that one fixed moment. A weather"
+            " outage overlapping briefing_time silently blacked out all of the above for"
+            " the rest of that calendar day, unlike the classification/comfort-band"
+            " forecast dependency (Issue #588), which already retries every 30-minute"
+            " regular cycle forever. Found while root-causing Issue #598 (a pending test"
+            " scenario passing by coincidence because this exact gap silently disabled"
+            " the override detection it was meant to exercise)."
+        ),
+        "scope_covered": (
+            "coordinator.py: new _ensure_today_record(classification) method, extracting"
+            " the existing DailyRecord creation/counter-preservation logic verbatim out"
+            " of _async_send_briefing() (which now calls it instead of inlining"
+            " creation). Also called from the regular classification cycle"
+            " (_async_update_data_impl(), immediately after a successful classify_day())"
+            " — the same self-healing, every-30-min path Issue #588 already proved"
+            " retries forecast forever, so the gap shrinks from up to 24 hours to about"
+            " 30 minutes. Idempotent: no-ops when a record for today already exists, so"
+            " calling it every cycle cannot reset same-day accumulated counters (unlike"
+            " the pre-existing once-daily rebuild, which only mattered once a day)."
+            " tools/sim_harness/run_production.py: the harness's classification-event"
+            " dispatch now mirrors the same real production hook. Issue #598's pending"
+            " scenario (tools/simulations/pending/vacation_occupancy_override_cleared.json)"
+            " now passes for real — needed one added reconfirmation classification event"
+            " after the midnight day-rollover (the harness has no periodic auto-tick the"
+            " way production does) and manual_grace_seconds raised from 3600 to 7200 (the"
+            " original 1-hour grace was auto-expiring 11 minutes before the scenario's"
+            " own explicit cancel_override event, once override detection actually"
+            " started working — so the assertion was at risk of passing via grace-expiry"
+            " instead of the cancel-override path it exists to test)."
+        ),
+    },
     600: {
         "version_fixed": "0.5.65",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1769,6 +1769,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 "threshold_cool": self.config.get(CONF_THRESHOLD_COOL, DEFAULT_THRESHOLD_COOL),
             }
             self._current_classification = classify_day(forecast, previous_day_type=prev_type, **_thresh)
+            # Issue #602: ensure today's DailyRecord exists on this already-resilient,
+            # every-30-min classification path — not only the once-daily briefing_time
+            # trigger, which has no retry and previously left setpoint-override detection
+            # (and every other _today_record-gated bookkeeping counter) silently dark for
+            # the rest of the day whenever weather was unavailable at that one moment.
+            self._ensure_today_record(self._current_classification)
             # record_history=True here; the 5-min tick (Issue #511) always passes False
             # so _outdoor_temp_history keeps its existing 30-min cadence.
             self._apply_outdoor_temp(forecast.current_outdoor_temp, record_history=True)
@@ -2841,6 +2847,46 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         )
         return generate_briefing(**briefing_kwargs), generate_briefing(**briefing_kwargs, verbosity="tldr_only")
 
+    def _ensure_today_record(self, classification: DayClassification) -> None:
+        """Create or roll over today's ``DailyRecord`` if needed (Issue #602).
+
+        Extracted verbatim from ``_async_send_briefing()`` so it can also be called
+        from the regular (every-30-min, self-healing per Issue #588) classification
+        cycle, not only from the once-daily ``briefing_time`` trigger. Previously
+        ``_today_record`` was created ONLY inside ``_async_send_briefing()``, which
+        bails out early whenever the weather entity has no forecast at that one
+        fixed daily moment — silently blocking manual-override detection and every
+        other ``_today_record``-gated bookkeeping counter for the rest of that day.
+        Idempotent: no-ops when a record for today already exists.
+        """
+        _today_str = dt_util.now().strftime("%Y-%m-%d")
+        if self._today_record is not None and self._today_record.date == _today_str:
+            return
+        _prev = self._today_record if (self._today_record and self._today_record.date == _today_str) else None
+        self._today_record = DailyRecord(
+            date=_today_str,
+            day_type=classification.day_type,
+            trend_direction=classification.trend_direction,
+            windows_recommended=classification.windows_recommended,
+            window_open_time=(classification.window_open_time.isoformat() if classification.window_open_time else None),
+            window_close_time=(
+                classification.window_close_time.isoformat() if classification.window_close_time else None
+            ),
+            hvac_mode_recommended=classification.hvac_mode,
+            hvac_runtime_minutes=_prev.hvac_runtime_minutes if _prev else 0.0,
+            comfort_violations_minutes=_prev.comfort_violations_minutes if _prev else 0.0,
+            manual_overrides=_prev.manual_overrides if _prev else 0,
+            thermal_session_count=_prev.thermal_session_count if _prev else 0,
+            occupancy_away_minutes=_prev.occupancy_away_minutes if _prev else 0.0,
+            windows_opened=_prev.windows_opened if _prev else False,
+            window_open_actual_time=_prev.window_open_actual_time if _prev else None,
+            override_details=list(_prev.override_details) if _prev else [],
+        )
+        # Capture raw forecast high/low for weather bias learning
+        if self.config.get("learning_enabled", True):
+            self._today_record.forecast_high_f = classification.today_high
+            self._today_record.forecast_low_f = classification.today_low
+
     async def _async_send_briefing(self, now: datetime) -> None:
         """Generate and send the daily briefing."""
         if self._briefing_sent_today:
@@ -2916,37 +2962,10 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         )
 
         # Initialize today's learning record, preserving any counters already accumulated
-        # today (e.g. after an HA restart mid-day that fires briefing again).
-        _today_str = dt_util.now().strftime("%Y-%m-%d")
-        _prev = self._today_record if (self._today_record and self._today_record.date == _today_str) else None
-        self._today_record = DailyRecord(
-            date=_today_str,
-            day_type=classification.day_type,
-            trend_direction=classification.trend_direction,
-            windows_recommended=classification.windows_recommended,
-            window_open_time=(classification.window_open_time.isoformat() if classification.window_open_time else None),
-            window_close_time=(
-                classification.window_close_time.isoformat() if classification.window_close_time else None
-            ),
-            hvac_mode_recommended=classification.hvac_mode,
-            hvac_runtime_minutes=_prev.hvac_runtime_minutes if _prev else 0.0,
-            comfort_violations_minutes=_prev.comfort_violations_minutes if _prev else 0.0,
-            manual_overrides=_prev.manual_overrides if _prev else 0,
-            thermal_session_count=_prev.thermal_session_count if _prev else 0,
-            occupancy_away_minutes=_prev.occupancy_away_minutes if _prev else 0.0,
-            windows_opened=_prev.windows_opened if _prev else False,
-            window_open_actual_time=_prev.window_open_actual_time if _prev else None,
-            override_details=list(_prev.override_details) if _prev else [],
-        )
-
-        # Capture raw forecast high/low for weather bias learning
-        if (
-            self.config.get("learning_enabled", True)
-            and self._today_record is not None
-            and self._current_classification
-        ):
-            self._today_record.forecast_high_f = self._current_classification.today_high
-            self._today_record.forecast_low_f = self._current_classification.today_low
+        # today (e.g. after an HA restart mid-day that fires briefing again). Issue #602:
+        # extracted to _ensure_today_record() so the regular classification cycle can also
+        # call it — this call site is now just the once-daily "make sure it's current" path.
+        self._ensure_today_record(classification)
 
         # Generate briefing text and track which suggestions were sent
         suggestions = self.learning.generate_suggestions()

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.65"
+  "version": "0.5.66"
 }

--- a/tests/test_daily_record_accuracy.py
+++ b/tests/test_daily_record_accuracy.py
@@ -584,3 +584,91 @@ class TestDailyRecordBriefingPreservation:
         # Yesterday's counters must NOT carry over — fresh day
         assert coord._today_record.hvac_runtime_minutes == 0.0
         assert coord._today_record.manual_overrides == 0
+
+
+# ---------------------------------------------------------------------------
+# TestEnsureTodayRecord — Issue #602
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureTodayRecord:
+    """_ensure_today_record() must be idempotent within a day and roll over correctly
+    across a date change — it's now called every ~30-min regular classification cycle,
+    not just once daily from _async_send_briefing(), so repeated same-day calls must
+    never reset accumulated counters.
+    """
+
+    def _make_coord(self, *, today_record=None):
+        ClimateAdvisorCoordinator = _get_coordinator_class()
+        coord = object.__new__(ClimateAdvisorCoordinator)
+        coord._today_record = today_record
+        coord.config = {"learning_enabled": False}
+        coord._ensure_today_record = types.MethodType(ClimateAdvisorCoordinator._ensure_today_record, coord)
+        return coord
+
+    def test_creates_record_when_none(self):
+        coord = self._make_coord(today_record=None)
+        cls = _make_classification(day_type="hot", hvac_mode="cool")
+        with patch("custom_components.climate_advisor.coordinator.dt_util") as mock_dt_util:
+            mock_dt_util.now.return_value = datetime(2026, 4, 5, 0, 30, 0)
+            coord._ensure_today_record(cls)
+        assert coord._today_record is not None
+        assert coord._today_record.date == "2026-04-05"
+        assert coord._today_record.day_type == "hot"
+
+    def test_repeated_same_day_calls_do_not_reset_counters(self):
+        """Simulates two 30-min regular cycles on the same day — accumulated
+        counters between calls must survive, matching Issue #176's existing
+        briefing-preservation guarantee."""
+        coord = self._make_coord(
+            today_record=_make_today_record(
+                date="2026-04-05",
+                hvac_runtime_minutes=19.8,
+                manual_overrides=3,
+                comfort_violations_minutes=12.0,
+                windows_opened=True,
+            )
+        )
+        cls = _make_classification(day_type="warm", hvac_mode="cool")
+        with patch("custom_components.climate_advisor.coordinator.dt_util") as mock_dt_util:
+            mock_dt_util.now.return_value = datetime(2026, 4, 5, 10, 0, 0)
+            coord._ensure_today_record(cls)
+        # Same-day call must be a true no-op — same object, nothing rebuilt.
+        assert coord._today_record.hvac_runtime_minutes == 19.8
+        assert coord._today_record.manual_overrides == 3
+        assert coord._today_record.comfort_violations_minutes == 12.0
+        assert coord._today_record.windows_opened is True
+
+    def test_rolls_over_on_new_day_preserving_no_counters(self):
+        coord = self._make_coord(
+            today_record=_make_today_record(
+                date="2026-04-04",  # yesterday
+                hvac_runtime_minutes=95.0,
+                manual_overrides=5,
+            )
+        )
+        cls = _make_classification(day_type="mild", hvac_mode="off")
+        with patch("custom_components.climate_advisor.coordinator.dt_util") as mock_dt_util:
+            mock_dt_util.now.return_value = datetime(2026, 4, 5, 0, 30, 0)
+            coord._ensure_today_record(cls)
+        assert coord._today_record.date == "2026-04-05"
+        assert coord._today_record.day_type == "mild"
+        assert coord._today_record.hvac_runtime_minutes == 0.0
+        assert coord._today_record.manual_overrides == 0
+
+    def test_idempotent_across_many_calls_same_day(self):
+        """Regression guard: calling _ensure_today_record() many times in one day
+        (mirroring ~48 real 30-min cycles) must never reset counters — this is the
+        exact failure mode that would silently reintroduce Issue #176 at 30-min
+        cadence instead of once-daily."""
+        coord = self._make_coord(today_record=None)
+        cls = _make_classification(day_type="hot", hvac_mode="cool")
+        with patch("custom_components.climate_advisor.coordinator.dt_util") as mock_dt_util:
+            mock_dt_util.now.return_value = datetime(2026, 4, 5, 0, 30, 0)
+            coord._ensure_today_record(cls)
+            coord._today_record.manual_overrides = 2
+            coord._today_record.hvac_runtime_minutes = 45.0
+            for _ in range(10):
+                coord._ensure_today_record(cls)
+        assert coord._today_record.manual_overrides == 2
+        assert coord._today_record.hvac_runtime_minutes == 45.0

--- a/tools/sim_harness/run_production.py
+++ b/tools/sim_harness/run_production.py
@@ -522,6 +522,13 @@ def _dispatch_event(
         # engine._current_classification) to know what mode CA expects.
         if coordinator is not None:
             coordinator._current_classification = classification
+            # Issue #602: mirrors the real production hook (coordinator.py's regular
+            # classification cycle) that ensures today's DailyRecord exists — without
+            # this, self._today_record stays None for the whole scenario (it's
+            # otherwise only created by the once-daily _async_send_briefing() trigger,
+            # which this harness never fires unless a scenario explicitly seeds
+            # weather), silently blocking setpoint-only override detection.
+            coordinator._ensure_today_record(classification)
         run_coro(engine.apply_classification(classification, indoor_temp=_cls_indoor_f))
 
     elif etype == "occupancy_away":

--- a/tools/simulations/pending/vacation_occupancy_override_cleared.json
+++ b/tools/simulations/pending/vacation_occupancy_override_cleared.json
@@ -3,7 +3,6 @@
   "description": "Vacation-mode mirror of cancel_override_then_resume: a manual override set during vacation (e.g. cleaners visiting) must have the deep vacation setback restored the moment it's cancelled, not left at the override's setpoint until the next unrelated event (Issue #505)",
   "source": "synthetic",
   "issue": 505,
-  "pending_issue": 598,
   "config": {
     "comfort_heat": 68,
     "comfort_cool": 74,
@@ -11,7 +10,7 @@
     "setback_cool": 79,
     "natural_vent_delta": 3.0,
     "override_confirm_seconds": 5,
-    "manual_grace_seconds": 3600,
+    "manual_grace_seconds": 7200,
     "wake_time": "04:00",
     "briefing_time": "04:15"
   },
@@ -34,6 +33,13 @@
       "indoor_f": 75.0,
       "outdoor_f": 82.0,
       "note": "Indoor still cooling toward the setback, outdoor hot."
+    },
+    {
+      "time": "2026-07-16T00:30:00",
+      "type": "classification",
+      "day_type": "warm",
+      "hvac_mode": "cool",
+      "note": "Issue #602: models the real production regular 30-min classification cycle re-confirming the (unchanged) classification after the midnight day rollover — this is what recreates coordinator._today_record for the new day (via _ensure_today_record()), the same way a real install's weather-retrying refresh cycle does. Without an event here, the harness (which doesn't auto-tick a periodic cycle the way production does) never recreates the day-2 record before the override below fires."
     },
     {
       "time": "2026-07-16T12:43:00",
@@ -85,9 +91,8 @@
   },
   "notes": [
     "Direct vacation-mode mirror of tools/simulations/golden/cancel_override_then_resume.json (the AWAY-mode version of this exact sequence, which already passes). There was no vacation equivalent prior to Issue #505 — the coverage gap tracked the code gap exactly.",
-    "Revert test: with the automation.py:1513 DEFER_OCCUPANCY-VACATION branch reverted to its pre-fix log-and-return form, the 07:43:10 assertion fails (no setback_applied event fires — event_log ends at override cleared/grace expired). Confirms this assertion genuinely depends on the fix, not a coincidental re-apply.",
-    "override_confirm_seconds/manual_grace_seconds mirror cancel_override_then_resume.json's values for the same reason (short wall-clock span; grace long enough that the explicit cancel_override event — not an auto-expiry — is what's under test).",
-    "Issue #598 (found during #593): the 13:54:10 assertion was passing by coincidence, not because the claimed cancel_override reapply was actually exercised. Direct inspection of run_production_scenario()'s real event_log/action_log shows the harness stops advancing after the scheduled 04:00 wake_time trigger — none of the later explicit events (thermostat_state_changed, cancel_override, the final temp_update) are ever dispatched. Before #593's unrelated morning_wakeup_skipped fix, the 22:30 bedtime-reapply decision (also 82F) was the last one in the truncated log and happened to match the expected value. Marked pending_issue until the harness truncation is diagnosed and fixed."
+    "Revert test: with the automation.py:1513 DEFER_OCCUPANCY-VACATION branch reverted to its pre-fix log-and-return form, the 13:54:10 assertion fails (no setback_applied event fires from the cancel-override path). Confirms this assertion genuinely depends on the fix, not a coincidental re-apply.",
+    "Issue #598/#602 (found during #593, root-caused and fixed together): the 13:54:10 assertion was passing by coincidence, not because the claimed cancel_override reapply was actually exercised. Root cause (NOT the originally-suspected clock-advance loop, which was disproven by direct instrumentation): coordinator.py's setpoint-only override-detection block requires self._today_record to be non-None, which was ONLY ever created by the once-daily _async_send_briefing() trigger — never reached by this weather-free scenario, and in production silently blocked by any weather outage overlapping that one fixed daily moment. Fixed at the root by Issue #602 (_ensure_today_record() now also runs on the resilient, already-self-healing regular classification cycle). Two consequences for this scenario once real override detection started working: (1) it needed an explicit reconfirmation classification event after the midnight day-rollover, since the harness (unlike production) does not auto-tick a periodic cycle — added at 2026-07-16T00:30:00; (2) manual_grace_seconds=3600 (copied from cancel_override_then_resume.json, whose override-to-cancel gap is only 1 minute) was too short for THIS scenario's 71-minute gap (12:43 confirm to 13:54 cancel) — grace was auto-expiring 11 minutes before the explicit cancel_override event, so the assertion was passing via grace-expiry, not the cancel-override path this scenario exists to test. Bumped to 7200s so the explicit cancel_override event is genuinely what's under test, matching the golden analog's actual intent."
   ],
   "use_coordinator": true,
   "skip_startup_coalesce": true


### PR DESCRIPTION
## Summary

- **#602 (new, production):** `self._today_record` — which gates setpoint-only manual-override detection, HVAC runtime tracking, comfort-violation minutes, occupancy-away minutes, door/window pause counts, and the thermal-learning watchdog — was only ever created once a day inside `_async_send_briefing()`, a fixed-time scheduled trigger with **no retry** that bails out early whenever the weather entity has no forecast at that one moment. A weather outage overlapping `briefing_time` silently blacked out all of the above for the rest of that calendar day, unlike the classification/comfort-band forecast dependency (#588), which already retries every 30-minute regular cycle forever.
- **#598 (test coverage):** root-caused as a direct consequence of the same gap. The pending scenario `vacation_occupancy_override_cleared.json` never seeds weather, so `_today_record` stayed `None` for its entire run and setpoint-only override detection silently never fired — the assertion was passing by coincidence (falling through to an unrelated, coincidentally-matching earlier decision), not because the cancel-override reapply path (#505) actually ran. This **disproves the issue's own filed hypothesis** ("the clock-advance loop stops making forward progress") — disproven via direct instrumented reproduction; the scheduler dispatches every event correctly with zero `callback_errors`.

## Fix

- New `coordinator._ensure_today_record(classification)`, extracting the existing creation/counter-preservation logic verbatim out of `_async_send_briefing()` (which now calls it instead of inlining creation). Idempotent — no-ops when a record for today already exists, so calling it every 30-min cycle cannot reset same-day accumulated counters.
- Called from the regular classification cycle (`_async_update_data_impl()`, right after a successful `classify_day()`) — the same self-healing path #588 already proved retries forecast forever. The gap shrinks from up to 24 hours to about 30 minutes.
- `tools/sim_harness/run_production.py`'s classification-event dispatch mirrors the same real hook, so the harness now faithfully exercises what production actually does.
- The pending scenario needed two small, well-justified adjustments once real override detection started working: an added reconfirmation `classification` event after the midnight day-rollover (the harness has no periodic auto-tick the way production does), and `manual_grace_seconds` raised from 3600 → 7200 (the original 1-hour grace was auto-expiring 11 minutes before the scenario's own explicit `cancel_override` event, so the assertion was at risk of passing via grace-expiry instead of the cancel-override path it exists to test).

## Verification

- Revert test: reverting the #505 DEFER_OCCUPANCY-VACATION branch makes the scenario's 13:54:10 assertion fail — confirms it's genuinely load-bearing.
- Revert test: removing the harness mirror hook alone makes the scenario fail (override never detected) — confirms the harness fix is necessary, not incidental.
- New coordinator-level tests (`TestEnsureTodayRecord`): creation-when-missing, same-day idempotency (including a 10x-repeated-call regression guard), and correct rollover across a date change.
- Full suite: 3858 passed, 0 failures, 0 xfails.
- Golden suite: 74/74. Pending suite: 4/4 (including the newly-real `vacation_occupancy_override_cleared`).
- Audited all ~10 `self._today_record` consumer sites in `coordinator.py` directly — all are plain `if self._today_record:` bookkeeping guards, none rely on its absence as a meaningful signal this change would disturb.
- Audited golden/pending scenarios spanning a day boundary (`issue-481-sleep-band-no-false-undertemp-incident`, `wakeup_preserves_whf_manual_override`) — both still pass unchanged.

Closes #602, closes #598.