### PR TITLE
Fix #641: WHF rapid on/off cycling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.16] — 2026-08-15
+
+- Fix #641: the whole-house fan could rapidly cycle on and off (roughly once a minute) when a predicted-floor or ceiling-threshold exit fired while a window was still open — the very next check immediately turned it back on, repeating indefinitely. Two nat-vent exit conditions now correctly hold off reactivation for 5 minutes after exiting, matching how the outdoor-air-reversal exit already behaved. As a second layer of protection, CA will never toggle the fan faster than once every 5 minutes going forward, regardless of cause — any future situation that would have caused rapid cycling is now blocked outright and logged as an incident instead of hitting the fan.
+
 ## [0.6.15] — 2026-08-14
 
 - Feat #639: internal refactor only, no user-visible behavior change — Block 5 Phase 3 (the final phase) builds the unified override/grace transition table, completing the diagnostic-only shadow comparison series started by 0.6.13's nat-vent FSM and 0.6.14's door/window FSM. Confirmed via a new test scenario that a second, different override arriving while a prior override's grace period is still running is correctly treated as a fresh override rather than ignored. Purely observational — nothing it computes is ever acted on.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -64,6 +64,7 @@ from .const import (
     ECONOMIZER_MORNING_END_HOUR,
     ECONOMIZER_MORNING_START_HOUR,
     ECONOMIZER_TEMP_DELTA,
+    FAN_MIN_TOGGLE_INTERVAL_S,
     FAN_MODE_BOTH,
     FAN_MODE_DISABLED,
     FAN_MODE_HVAC,
@@ -676,6 +677,22 @@ class AutomationEngine:
         self._write_seq: int = 0  # monotonic counter: validation callbacks skip if a newer write has superseded them
         self._hvac_command_time: datetime | None = None  # last system-initiated HVAC command timestamp
         self._fan_command_time: datetime | None = None  # last system-initiated fan command timestamp (race guard)
+        # Issue #641: last time _activate_fan()/_deactivate_fan() issued a REAL fan
+        # state-changing command — deliberately separate from _fan_command_time above.
+        # _fan_command_time is also stamped by bookkeeping-only echo-tracking commands
+        # that don't represent a real physical toggle (e.g. _reconcile_fan_physical_drift()'s
+        # corrective "sync the stuck control entity" off-command, Issue #449/#482 — the
+        # physical fan was already off, only the entity's stale belief changes), and that
+        # method's docstring explicitly documents an immediately-following same-tick
+        # recycle-on as correct, expected behavior. Rate-limiting against the shared field
+        # would misfire on that documented sequence. Only _activate_fan/_deactivate_fan's
+        # own command sites touch this field.
+        self._fan_toggle_command_time: datetime | None = None
+        # Issue #641: set whenever a fan toggle is suppressed by the rate-limit backstop
+        # (_fan_toggle_rate_limited) — the timestamp the suppression will lift. None when
+        # no toggle is currently suppressed. Status-tab surfacing only, not read by any
+        # decision path — mirrors the pattern of other diagnostic-only fields.
+        self._fan_rate_limited_until: datetime | None = None
         # Issue #482: id of the HA Context CA attached to its most recent outgoing WHF
         # fan-entity service call (see _command_whf_control_entity). When the resulting
         # state-changed Event's own event.context.id (or parent_id) matches this value,
@@ -3391,12 +3408,23 @@ class AutomationEngine:
                                 ),
                             },
                         )
+                    # Issue #641: set_outdoor_exit_time=True — without this, a monitored
+                    # sensor left open hands this exit straight into the _paused_by_door
+                    # reactivation block below with no lockout armed. Since the instant
+                    # reactivation gate (outdoor < indoor - hysteresis) is a *different,
+                    # non-predictive* condition than this exit's own time-to-floor
+                    # prediction, indoor/outdoor barely move tick-to-tick, so the gate is
+                    # almost always still satisfied on the very next tick — guaranteeing
+                    # immediate reactivation, another proactive exit, and a repeating
+                    # on/off flip-flop (the WHF fast-cycling incident). Arming the same
+                    # lockout the outdoor-rise exit already uses closes this gap.
                     await self._exit_nat_vent(
                         reason=(
                             f"nat-vent proactive floor exit: indoor {indoor:.1f}°F"
                             f" predicted to reach comfort_heat {comfort_heat_now:.1f}°F"
                             f" in {time_to_floor:.2f}h"
-                        )
+                        ),
+                        set_outdoor_exit_time=True,
                     )
                     return
 
@@ -3411,8 +3439,10 @@ class AutomationEngine:
                             "nat_vent_outdoor_rise_exit",
                             {"outdoor": outdoor, "indoor": indoor, "fan_device": _fan_device_label(self.config)},
                         )
-                    # set_outdoor_exit_time=True: this is the only exit path whose
-                    # _nat_vent_outdoor_exit_time is consumed by the reactivation lockout below.
+                    # set_outdoor_exit_time=True: the original exit reason this lockout was
+                    # built for (Issue #115/#411). Issue #641 later extended the same
+                    # treatment to PROACTIVE_FLOOR and CEILING_THRESHOLD above/below, once
+                    # both were found to hand off into the identical paused-reactivation race.
                     await self._exit_nat_vent(
                         reason=(f"nat vent exit: outdoor {outdoor:.1f}°F > indoor {indoor:.1f}°F — airflow reversed"),
                         set_outdoor_exit_time=True,
@@ -3429,8 +3459,13 @@ class AutomationEngine:
                         outdoor,
                         threshold,
                     )
+                    # Issue #641: same lockout gap and same fix as the proactive-floor exit
+                    # above — the reactivation gate's own ceiling_ok = outdoor < threshold
+                    # check is the exact complementary boundary, so outdoor hovering near
+                    # threshold can flip-flop this exit against reactivation identically.
                     await self._exit_nat_vent(
-                        reason=f"natural vent exit: outdoor {outdoor:.1f}°F > threshold {threshold:.1f}°F"
+                        reason=f"natural vent exit: outdoor {outdoor:.1f}°F > threshold {threshold:.1f}°F",
+                        set_outdoor_exit_time=True,
                     )
                     return
 
@@ -3893,7 +3928,16 @@ class AutomationEngine:
                             "fan_device": _fan_device_label(self.config),
                         },
                     )
-            await self._exit_nat_vent(reason=f"fan thermostat check — {stop_reason}")
+            # Issue #641: same treatment as STOP_VIA_NAT_VENT_EXIT above and
+            # check_natural_vent_conditions()'s OUTDOOR_RISE exit — this branch's own
+            # docstring already documents it as "the exact same boundary condition,"
+            # just reached via the tick-level Check 1 path instead of the 30-min cycle.
+            # Arm the same lockout so outdoor hovering near the indoor boundary can't
+            # flip-flop this exit against reactivation any more than its sibling can.
+            await self._exit_nat_vent(
+                reason=f"fan thermostat check — {stop_reason}",
+                set_outdoor_exit_time=True,
+            )
             return
 
         # outcome is STOP_COOLED_TO_FLOOR
@@ -5306,10 +5350,16 @@ class AutomationEngine:
 
         Args:
             reason: Human-readable reason passed through to ``_deactivate_fan``.
-            set_outdoor_exit_time: Only the outdoor-reversal exit passes True. Records
-                ``_nat_vent_outdoor_exit_time`` for the paused-by-door reactivation
-                lockout. Other exit paths must not set this as a side effect of this
-                refactor (Issue #411 blast-radius finding).
+            set_outdoor_exit_time: Records ``_nat_vent_outdoor_exit_time`` for the
+                paused-by-door reactivation lockout. Originally only the outdoor-reversal
+                exit passed True (Issue #411); Issue #641 extended this to the
+                proactive-floor and ceiling-threshold exits too, after both were found to
+                exhibit the identical flip-flop against the instant reactivation gate
+                whenever they hand off into a sensor-still-open pause. Any exit reason
+                that can route through this pause branch should arm the lockout unless
+                it's independently proven immune to immediate re-satisfaction by the
+                instant gate (comfort-floor and away-ceiling exits don't route through
+                this function at all, so they're exempt by construction, not by omission).
         """
         self._natural_vent_active = False
         self._nat_vent_soft_start = False
@@ -5810,6 +5860,63 @@ class AutomationEngine:
             for cid, ts in self._recent_fan_command_context_ids
         )
 
+    def _fan_toggle_rate_limited(self, *, action: str, reason: str) -> bool:
+        """Hard safety backstop against rapid fan on/off/on cycling (Issue #641).
+
+        Returns True (and suppresses the caller's command) if this toggle would reverse
+        the fan's state within ``FAN_MIN_TOGGLE_INTERVAL_S`` of CA's own last command.
+        Defense-in-depth: independent of any specific root cause, protects the physical
+        WHF/HVAC-fan relay from rapid cycling regardless of which upstream decision logic
+        produced the reversal (the WHF fast-cycling incident that motivated this — a
+        proactive-floor exit immediately followed by reactivation — is fixed at its own
+        root cause elsewhere, but this backstop holds even if a different, future gap
+        produces the same physical symptom).
+
+        Only ever compares against ``self._fan_toggle_command_time`` — stamped
+        exclusively by ``_activate_fan``/``_deactivate_fan``'s own command sites, not
+        the broader ``_fan_command_time`` echo-tracking field (see that attribute's
+        declaration for why the two must stay separate: an internal bookkeeping-only
+        stamp with no real physical toggle must not poison this guard). A genuine
+        user/RF-remote fan action never reaches this check either way, since both
+        callers already return early when ``self._fan_override_active`` is set.
+
+        isinstance guard: several call sites across the codebase (e.g. the fan-mode
+        assertion inside ``_set_hvac_mode``) stamp fan-related timestamps from
+        ``dt_util.now()`` without the caller having patched a real clock in tests,
+        leaving a ``MagicMock`` rather than a ``datetime`` — matching the defensive
+        pattern this codebase already uses elsewhere for mocked-engine timestamp reads
+        (see ``_format_grace_remaining()``). Treat anything that isn't a real timestamp
+        as "no prior command", never raise.
+        """
+        if not isinstance(self._fan_toggle_command_time, datetime):
+            return False
+        elapsed = (dt_util.now() - self._fan_toggle_command_time).total_seconds()
+        if elapsed >= FAN_MIN_TOGGLE_INTERVAL_S:
+            return False
+
+        _LOGGER.warning(
+            "Fan toggle suppressed: rate limit (%.0fs since last change, min %ds) — %s (%s)",
+            elapsed,
+            FAN_MIN_TOGGLE_INTERVAL_S,
+            action,
+            reason,
+        )
+        self._fan_rate_limited_until = self._fan_toggle_command_time + timedelta(seconds=FAN_MIN_TOGGLE_INTERVAL_S)
+        if self._emit_event_callback:
+            self._emit_event_callback(
+                "incident_detected",
+                {
+                    "incident_class": "fan_rapid_cycling",
+                    "incident_id": dt_util.now().isoformat(),
+                    "attempted_action": action,
+                    "attempted_reason": reason,
+                    "seconds_since_last_command": round(elapsed, 1),
+                    "min_interval_s": FAN_MIN_TOGGLE_INTERVAL_S,
+                    "fan_device": _fan_device_label(self.config),
+                },
+            )
+        return True
+
     async def _activate_fan(self, *, reason: str, emit_event: bool = True) -> None:
         """Activate fan based on configured fan_mode.
 
@@ -5834,11 +5941,15 @@ class AutomationEngine:
             _LOGGER.debug("_activate_fan: already active — no-op (%s)", reason)
             return
 
+        if self._fan_toggle_rate_limited(action="activate", reason=reason):
+            return
+
         if self.dry_run:
             _LOGGER.info("[DRY RUN] Would activate fan — %s", reason)
             return
 
         self._fan_command_time = dt_util.now()
+        self._fan_toggle_command_time = self._fan_command_time
         self._fan_command_pending = True
         try:
             if fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
@@ -6262,11 +6373,15 @@ class AutomationEngine:
                 _LOGGER.debug("_deactivate_fan: already inactive — no-op (%s)", reason)
             return
 
+        if self._fan_toggle_rate_limited(action="deactivate", reason=reason):
+            return
+
         if self.dry_run:
             _LOGGER.info("[DRY RUN] Would deactivate fan — %s", reason)
             return
 
         self._fan_command_time = dt_util.now()
+        self._fan_toggle_command_time = self._fan_command_time
         self._fan_command_pending = True
         try:
             if fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.15"
+VERSION = "0.6.16"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.16": [
+        "Fix #641: the whole-house fan could rapidly cycle on and off (roughly once a"
+        " minute) when a predicted-floor or ceiling-threshold exit fired while a window"
+        " was still open — the very next check immediately turned it back on, repeating"
+        " indefinitely. Two nat-vent exit conditions now correctly hold off reactivation"
+        " for 5 minutes after exiting, matching how the outdoor-air-reversal exit already"
+        " behaved. As a second layer of protection, CA will never toggle the fan faster"
+        " than once every 5 minutes going forward, regardless of cause — any future"
+        " situation that would have caused rapid cycling is now blocked outright and"
+        " logged as an incident instead of hitting the fan.",
+    ],
     "0.6.15": [
         "Feat #639: internal refactor only, no user-visible behavior change — Block 5"
         " Phase 3 (the final phase) builds the unified override/grace transition table"
@@ -1760,6 +1771,47 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    641: {
+        "version_fixed": "0.6.16",
+        "title": (
+            "WHF rapid on/off cycling — proactive-floor/ceiling-threshold exits didn't arm the reactivation lockout"
+        ),
+        "scope_covered": (
+            "automation.py: PROACTIVE_FLOOR and CEILING_THRESHOLD exits inside"
+            " check_natural_vent_conditions(), plus fan_thermostat_check()'s STOP_DEACTIVATE"
+            " branch (found during the same audit — its own comment already called it 'the"
+            " exact same boundary condition' as its already-armed sibling"
+            " STOP_VIA_NAT_VENT_EXIT) — all three now pass set_outdoor_exit_time=True to"
+            " _exit_nat_vent(), arming the existing 300s NAT_VENT_REACTIVATION_LOCKOUT_S the"
+            " same way the original outdoor-rise exit always has. Root cause: PROACTIVE_FLOOR"
+            " is a predictive time-to-floor check independent of the instant reactivation"
+            " gate it hands off into when a monitored sensor is still open — indoor/outdoor"
+            " barely move tick-to-tick, so the instant gate is almost always still satisfied"
+            " immediately after the predictive exit fires, guaranteeing reactivation next"
+            " tick and repeating. New tests/test_nat_vent_exit_lockout_coverage.py AST-scans"
+            " every _exit_nat_vent() call site (11 total, including on_fan_turned_off, found"
+            " during the audit) and requires each to be classified 'arms lockout' /"
+            " 'exempted: <reason>', with a positive control checking the classification"
+            " against the actual set_outdoor_exit_time argument — a new call site added later"
+            " without a classification fails immediately, preventing this bug class from"
+            " silently recurring a fourth time. Separately, as defense-in-depth independent"
+            " of root cause: new AutomationEngine._fan_toggle_rate_limited() hard-floors any"
+            " CA-issued fan reversal to no faster than FAN_MIN_TOGGLE_INTERVAL_S (300s,"
+            " const.py) inside _activate_fan()/_deactivate_fan(), logging a WARNING and"
+            " raising a new proactive fan_rapid_cycling incident class"
+            " (docs/incident-classes.md) on suppression; surfaced on the WHF status-tab card"
+            " via a '(rate-limited Xs ago)' suffix. Deliberately compares against a new,"
+            " separate _fan_toggle_command_time field rather than the pre-existing"
+            " _fan_command_time echo-tracking field (Issue #482) — found during testing that"
+            " _reconcile_fan_physical_drift()'s corrective control-entity-sync command"
+            " legitimately stamps the latter immediately before an intentional same-tick"
+            " recycle-on, which the shared field would have wrongly rate-limited."
+            " desired_state.py's decide_fan_cycle_on()/decide_fan_cycle_off() (the"
+            " fan_min_runtime_per_hour feature) now floor their computed on/off phase"
+            " durations at the same 300s minimum so a configured value outside ~[5, 55]"
+            " minutes can't schedule its own off/on command inside the rate-limit window."
+        ),
+    },
     639: {
         "version_fixed": "0.6.15",
         "title": (
@@ -6715,6 +6767,13 @@ NAT_VENT_REACTIVATION_LOCKOUT_S = 300
 
 CONF_NAT_VENT_HYSTERESIS_F = "nat_vent_hysteresis_f"
 CONF_NAT_VENT_REACTIVATION_LOCKOUT_S = "nat_vent_reactivation_lockout_s"
+
+# Issue #641: hard safety floor on CA-issued fan (WHF/HVAC-fan) toggle frequency —
+# defense-in-depth against ANY future oscillation bug (not tied to one root cause),
+# protecting the physical relay from rapid on/off/on cycling. A plain internal safety
+# constant, not a CONF_* option (matching NAT_VENT_HYSTERESIS_F/MIN_VIABLE_NAT_VENT_HOURS
+# precedent) — not something a user should be able to weaken below what the hardware needs.
+FAN_MIN_TOGGLE_INTERVAL_S = 300
 
 # Nat-vent soft-start sub-mode (Issue #540, scoped from #533): WHF-purge/comfort activation
 # at outdoor/indoor parity once today's outdoor temp is confirmed past its peak and

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -130,6 +130,7 @@ from .const import (
     ECONOMIZER_MORNING_END_HOUR,
     ECONOMIZER_TEMP_DELTA,
     EVENT_LOG_CAP,
+    FAN_MIN_TOGGLE_INTERVAL_S,
     FAN_MODE_BOTH,
     FAN_MODE_DISABLED,
     FAN_MODE_HVAC,
@@ -7726,27 +7727,49 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             return None
         physical_on = self._get_fan_physical_state()
         if ae._fan_override_active:
-            if ae._fan_active or physical_on is True:
-                return "running (manual override)"
-            return "off (manual override)"
-        if ae._fan_active:
+            status = "running (manual override)" if ae._fan_active or physical_on is True else "off (manual override)"
+        elif ae._fan_active:
             if physical_on is False:
                 if self._is_recent_fan_command(threshold_seconds=30.0):
-                    return "active (unconfirmed)"
-                _LOGGER.warning("WHF _fan_active=True but physical state=off — possible stale flag after manual stop")
-                return "inactive"
-            return "active"
-        if ae._natural_vent_active:
+                    status = "active (unconfirmed)"
+                else:
+                    _LOGGER.warning(
+                        "WHF _fan_active=True but physical state=off — possible stale flag after manual stop"
+                    )
+                    status = "inactive"
+            else:
+                status = "active"
+        elif ae._natural_vent_active:
             if physical_on is True:
                 _LOGGER.info(
                     "WHF nat-vent session flag stale but physical state confirms running — "
                     "displaying running (untracked) instead of trusting the session flag"
                 )
-                return "running (untracked)"
-            return "nat-vent (session active, fan idle)"
-        if physical_on is True:
-            return resolve_untracked_fan_status(recent_fan_command=self._is_recent_fan_command(threshold_seconds=30.0))
-        return "inactive"
+                status = "running (untracked)"
+            else:
+                status = "nat-vent (session active, fan idle)"
+        elif physical_on is True:
+            status = resolve_untracked_fan_status(
+                recent_fan_command=self._is_recent_fan_command(threshold_seconds=30.0)
+            )
+        else:
+            status = "inactive"
+        return status + self._whf_rate_limit_suffix(ae)
+
+    def _whf_rate_limit_suffix(self, ae: AutomationEngine) -> str:
+        """Append '(rate-limited Xs ago)' to the WHF status while a toggle is still
+        within the Issue #641 cooldown window — Status Card Ontology rule: extend the
+        existing card's value string, don't add a new one. Returns "" once the cooldown
+        has elapsed; never raises on a mocked/partial engine (isinstance guard, matching
+        _format_grace_remaining()'s existing defensive pattern for the same reason)."""
+        until = getattr(ae, "_fan_rate_limited_until", None)
+        if not isinstance(until, datetime):
+            return ""
+        remaining = (until - dt_util.now()).total_seconds()
+        if remaining <= 0:
+            return ""
+        suppressed_ago = FAN_MIN_TOGGLE_INTERVAL_S - remaining
+        return f" (rate-limited {suppressed_ago:.0f}s ago)"
 
     def _compute_hvac_fan_status(self) -> str | None:
         """Return HVAC-fan-blower-specific status, or None when HVAC fan is not configured.

--- a/custom_components/climate_advisor/desired_state.py
+++ b/custom_components/climate_advisor/desired_state.py
@@ -284,6 +284,17 @@ def decide_fan_thermo_backstop(
 _FAN_MODE_DISABLED = "disabled"  # mirrors const.FAN_MODE_DISABLED — duplicated locally per the
 # same import-independence convention nat_vent_gate.py/fan_thermostat_decision.py already use.
 
+# Issue #641: mirrors const.FAN_MIN_TOGGLE_INTERVAL_S (same import-independence convention as
+# above). CONF_FAN_MIN_RUNTIME_PER_HOUR's config-flow selector allows 1-59 minutes, but values
+# below 5 (short ON segment) or above 55 (short OFF segment) would otherwise compute an on/off
+# phase duration shorter than the hard safety floor _activate_fan()/_deactivate_fan() now
+# enforce — every such off/on command would be silently suppressed by that backstop, stranding
+# the fan on far longer than the configured cycle intended. Flooring both phase durations here
+# keeps this feature's own schedule always compatible with the safety floor, for both new and
+# already-persisted configurations, without needing a config-flow-only fix that could only
+# protect configs saved after the fix shipped.
+_FAN_MIN_TOGGLE_INTERVAL_S = 300.0
+
 
 class FanCycleOutcome(Enum):
     """The real outcomes _fan_cycle_on() can produce."""
@@ -325,7 +336,10 @@ def decide_fan_cycle_on(
     if not fan_active:
         if min_runtime_minutes >= 60:
             return FanCycleOutcome.ACTIVATE_ALWAYS_ON, None
-        return FanCycleOutcome.ACTIVATE_WITH_OFF_TIMER, min_runtime_minutes * 60.0
+        # Issue #641: floor the ON-phase duration so the scheduled off-command is never
+        # itself suppressed by the fan-toggle rate-limit backstop (see module-level
+        # _FAN_MIN_TOGGLE_INTERVAL_S comment above).
+        return FanCycleOutcome.ACTIVATE_WITH_OFF_TIMER, max(_FAN_MIN_TOGGLE_INTERVAL_S, min_runtime_minutes * 60.0)
     return FanCycleOutcome.RETRY_LATER, 60.0 * 60.0
 
 
@@ -338,8 +352,12 @@ def decide_fan_cycle_off(*, fan_min_runtime_active: bool, min_runtime_minutes: f
     guard — the shell calls _deactivate_fan() only when True. wait_seconds (the
     "on" phase re-check delay) is ALWAYS returned, matching the real method's
     unconditional final `async_call_later` call.
+
+    Issue #641: floored at _FAN_MIN_TOGGLE_INTERVAL_S (same reasoning as
+    decide_fan_cycle_on's ACTIVATE_WITH_OFF_TIMER delay) so the subsequent on-command
+    is never itself suppressed by the rate-limit backstop.
     """
-    wait_seconds = max(0.0, (60.0 - min_runtime_minutes) * 60.0)
+    wait_seconds = max(_FAN_MIN_TOGGLE_INTERVAL_S, (60.0 - min_runtime_minutes) * 60.0)
     return fan_min_runtime_active, wait_seconds
 
 

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.15"
+  "version": "0.6.16"
 }

--- a/docs/incident-classes.md
+++ b/docs/incident-classes.md
@@ -6,7 +6,7 @@
 
 | Question | Short answer (<= 2 sentences) | -> Full answer |
 |---|---|---|
-| Which incident class is proactive (fires at command time)? | Only `setpoint_mode_inconsistency` is proactive -- it fires inside automation.py _set_temperature() before the HA service call. All other classes are reactive and fire post-cycle in coordinator._detect_and_emit_incidents. | [Proactive vs. Reactive column below](#incident-class-reference) |
+| Which incident classes are proactive (fire at command time)? | Two: `setpoint_mode_inconsistency` -- fires inside automation.py _set_temperature() before the HA service call; and `fan_rapid_cycling` (Issue #641) -- fires inside automation.py _activate_fan()/_deactivate_fan() when the rate-limit backstop suppresses a command. All other classes are reactive and fire post-cycle in coordinator._detect_and_emit_incidents. | [Proactive vs. Reactive column below](#incident-class-reference) |
 | What is the `incident_detected` event payload schema? | `type`, `time`, `incident_class`, `incident_id`, `indoor_f`, `outdoor_f`, `hvac_mode`, `comfort_cool`, `comfort_heat`, plus class-specific fields (`nat_vent_active`, `manual_override_active`, `occupancy_mode`, `setpoint_f`). | [Event Payload](#event-payload) |
 | Does `comfort_violation`/`comfort_undertemp` require a sustained 15-min deviation? | No -- both are a **point-in-time** check (>0.5 F past the comfort band edge) with a 30-min incident-dedup window, not a duration tracker; as of Issue #411 they also skip emission when the deviation is within nat-vent-cycling tolerance (`coordinator._is_nat_vent_tolerated_deviation()`). | [Incident Class Reference below](#incident-class-reference) |
 | Which classes were added for bugs #220-222? | Four new classes: `setpoint_mode_inconsistency` (#222 -- silent wrong setpoint), `rapid_override_after_automation` (#221 -- false override detection), `occupancy_transition` (#220 -- coverage gap), `override_active_on_occupancy` (compound condition at occupancy change). | [Bug Motivation column below](#incident-class-reference) |
@@ -28,6 +28,7 @@
 | `rapid_override_after_automation` | `override_detected` event within 60s of any automation decision event in event_log | Reactive | Integration | **HIGH** | #221 -- automation-driven setpoint change falsely flagged as manual override |
 | `occupancy_transition` | Any `occupancy_change` event in event_log during the last cycle | Reactive | Both | Medium | #220 -- near-zero occupancy transition coverage in golden suite |
 | `override_active_on_occupancy` | `manual_override_active=True` at the time of an `occupancy_change` event | Reactive | Integration | Medium | Compound condition exposed by #220 investigation |
+| `fan_rapid_cycling` | `_fan_toggle_rate_limited()` suppresses a CA-issued fan activate/deactivate within `FAN_MIN_TOGGLE_INTERVAL_S` (300s) of CA's own last fan command | **Proactive** | Integration | **HIGH** | #641 -- WHF cycled on/off ~every minute (proactive-floor exit vs. instant reactivation-gate flip-flop); a suppressed command silently diverges commanded vs. physical fan state |
 
 ---
 
@@ -74,6 +75,7 @@ All numeric fields are in Fahrenheit regardless of the user's display unit setti
 | Class | Where it fires | Code location |
 |---|---|---|
 | `setpoint_mode_inconsistency` | Before HA service call | `automation.py _set_temperature()` |
+| `fan_rapid_cycling` | At the suppressed command, before any HA service call | `automation.py _fan_toggle_rate_limited()`, called from `_activate_fan()`/`_deactivate_fan()` |
 | All others | Post-cycle | `coordinator.py _detect_and_emit_incidents()` |
 
 The `incident_detected` event is appended to `coordinator._event_log` in both cases. It is visible in the event log API at `GET /api/climate_advisor/event_log`.

--- a/docs/nat-vent-lifecycle-spec.md
+++ b/docs/nat-vent-lifecycle-spec.md
@@ -8,10 +8,12 @@
 |---|---|---|
 | What are the 4 nat-vent session states and how do they map to flags? | `INACTIVE`, `ACTIVE_FULL_GATE`, `ACTIVE_SOFT_START`, `PAUSED_REACTIVATION_LOCKOUT` — derived purely from `_natural_vent_active`/`_nat_vent_soft_start`/`_paused_by_door`/`_nat_vent_outdoor_exit_time`. | [State Transitions](#state-transitions) |
 | Where is the derivation computed, and is it load-bearing? | `nat_vent_lifecycle.py::derive_nat_vent_lifecycle_state()`, exposed read-only via `AutomationEngine.nat_vent_lifecycle_state`. Purely observational — not called from any production decision path. | [Scope](#scope) |
-| Does every nat-vent exit hand off through the same choke point? | No — `_exit_nat_vent()` is the choke point for most exits (9 call sites), but the comfort-floor exit inside `check_natural_vent_conditions()`, the away-mode ceiling exit, the ODE ceiling-escalation exit, and two reconcile/bedtime paths mutate the flags directly instead. | [Exit Paths](#exit-paths-not-unified-through-a-single-function) |
-| What is the reactivation lockout and how long is it? | 300s default (`NAT_VENT_REACTIVATION_LOCKOUT_S`), only armed by the outdoor-warm-rise exit (the only exit that sets `_nat_vent_outdoor_exit_time`). | [State Transitions](#state-transitions) |
+| Does every nat-vent exit hand off through the same choke point? | No — `_exit_nat_vent()` is the choke point for most exits (10 call sites, per `tests/test_nat_vent_exit_lockout_coverage.py`'s AST scan), but the comfort-floor exit inside `check_natural_vent_conditions()`, the away-mode ceiling exit, the ODE ceiling-escalation exit, and two reconcile/bedtime paths mutate the flags directly instead. | [Exit Paths](#exit-paths-not-unified-through-a-single-function) |
+| What is the reactivation lockout and how long is it? | 300s default (`NAT_VENT_REACTIVATION_LOCKOUT_S`). Originally armed only by the outdoor-warm-rise exit; Issue #641 extended arming to the proactive-floor, ceiling-threshold, and fan_thermostat_check's tick-level direction-reversal exits, once all three were found to hand off into the same paused-reactivation race the lockout exists to prevent. | [State Transitions](#state-transitions) |
 | What happens when nat-vent exits and the sensor is still open — pause or grace? | `_exit_nat_vent()` forks: sensor still open → hands off into the pause lifecycle; sensors closed → hands off into the grace lifecycle. See `grace-periods-spec.md` for what happens next in either lifecycle. | [Handoff to Pause/Grace](#handoff-to-pausegrace) |
 | How was this spec's accuracy verified? | Differential replay: `derive_nat_vent_lifecycle_state()` run against the real final engine flags from all 74 golden + 4 pending scenarios (Issue #606), plus 3 hand-reasoned ground-truth scenarios. | [Verification](#verification) |
+| Is every `_exit_nat_vent()` call site's lockout-arming decision enforced, not just documented? | Yes — `tests/test_nat_vent_exit_lockout_coverage.py` AST-scans every call site and requires each to be explicitly classified `"arms lockout"` / `"exempted: <reason>"`, with a positive control that checks the claim against the actual `set_outdoor_exit_time=True` argument (Issue #641). | [Incident: WHF fast-cycling](#incident-whf-fast-cycling-proactive-floor-exit-vs-instant-reactivation-issue-641) |
+| Is there a hard floor on how fast CA can physically toggle the fan, independent of any exit/reactivation logic? | Yes — `AutomationEngine._fan_toggle_rate_limited()` (Issue #641), a defense-in-depth backstop inside `_activate_fan()`/`_deactivate_fan()`: any reversal within `FAN_MIN_TOGGLE_INTERVAL_S` (300s) of CA's own last real toggle command is suppressed, logged at WARNING, and raised as a proactive `fan_rapid_cycling` incident (`docs/incident-classes.md`). Never affects genuine user/RF-remote fan actions. | [Incident: WHF fast-cycling](#incident-whf-fast-cycling-proactive-floor-exit-vs-instant-reactivation-issue-641) |
 | Does `check_natural_vent_conditions()`'s exit chain always decide WHY a session ends? | No — confirmed by direct experiment (Issue #608): `nat_vent_temperature_check()` and `fan_thermostat_check()` (both dispatched from the same `temp_update`/thermostat-attribute-change trigger, both already pure-extracted by Issue #441) run FIRST and independently implement equivalent comfort-floor and outdoor-rise-style stops — they win the race and exit the session before `check_natural_vent_conditions()`'s chain ever evaluates, for every golden scenario tested. | [Known Duplicate-Logic Race](#known-duplicate-logic-race-issue-608-finding) |
 | Has a shadow engine instance been proven safe to construct alongside production, offline? | Yes — `tools/sim_harness/shadow_engine_pair.py` (Issue #611) proves, across 60 offline-eligible golden+pending scenarios, that a dry_run=True shadow instance never issues a real action AND never changes what production itself does. | [Offline Whole-Engine Shadow-Pair Validation](#offline-whole-engine-shadow-pair-validation-issue-611-subtask-o) |
 | Is there a real, live shadow engine running inside the coordinator today, and is its coverage complete? | Yes to both — `coordinator.shadow_automation_engine` (Issue #613), permanently `dry_run=True`, mirrors all 13 real nat-vent entry points, the 3 input-data attributes they depend on (Issue #615), and the 7 grace/override lifecycle-gate fields plus companions (Issue #631) — enforced by an AST-based coverage registry test so new gaps can't ship silently. Zero occupant/HVAC impact; surfaced via a diagnostic sensor, not any Status-tab card. | [Live Shadow Engine](#live-shadow-engine-issue-613-subtask-q) |
@@ -49,7 +51,7 @@
 | `ACTIVE_SOFT_START` | Full gate independently clears | `ACTIVE_FULL_GATE` | `_nat_vent_may_reactivate()` | `~L3125` — label-only, fan/HVAC untouched |
 | `INACTIVE` | Fan already physically running at startup/reconcile, eligible | `ACTIVE_FULL_GATE` | `reconcile_fan_on_startup()` eligibility check | `~L3955` |
 
-**Exit transitions via the `_exit_nat_vent()` choke point** (`automation.py:5098-5138`, Issue #411/#417/#418): 9 call sites (`~L1198, 2917, 3287, 3311, 3328, 3493, 3547, 3744, 4040`), covering door/window-closed, outdoor-rise, ceiling-threshold, and RF-timer-boundary exits. Always sets `_natural_vent_active=False, _nat_vent_soft_start=False`; only the outdoor-rise-exit caller passes `set_outdoor_exit_time=True`, which is the sole path that can produce `PAUSED_REACTIVATION_LOCKOUT`.
+**Exit transitions via the `_exit_nat_vent()` choke point** (`automation.py:5312-5367`, Issue #411/#417/#418): 10 call sites (door/window-closed, proactive-floor, outdoor-rise, ceiling-threshold, nat-vent-temperature-check's session-force-close and hard-floor, fan_thermostat_check's outdoor-rise and direction-reversal-stop and cooled-to-floor, reconcile-on-startup, and RF-timer-boundary-settle in `on_fan_turned_off`). Always sets `_natural_vent_active=False, _nat_vent_soft_start=False`. Originally only the outdoor-rise-exit caller passed `set_outdoor_exit_time=True` (the sole path able to produce `PAUSED_REACTIVATION_LOCKOUT`); Issue #641 found and fixed two more call sites (proactive-floor, ceiling-threshold in `check_natural_vent_conditions()`) plus a third (`fan_thermostat_check()`'s tick-level direction-reversal stop) that handed into the same paused-reactivation race without arming it — see [Incident: WHF fast-cycling](#incident-whf-fast-cycling-proactive-floor-exit-vs-instant-reactivation-issue-641) below. Every call site's arming decision is now enforced by `tests/test_nat_vent_exit_lockout_coverage.py`'s AST coverage registry, not just documented — a new call site added later without an explicit classification fails that test immediately.
 
 **Exit transitions that bypass `_exit_nat_vent()` entirely** — go directly to `INACTIVE`, never touch `_paused_by_door`/`_nat_vent_outdoor_exit_time`:
 
@@ -163,6 +165,60 @@ A full audit (every setter of the 7 grace/override fields, cross-referenced agai
 
 **Cleanup**: `coordinator.async_shutdown()` calls `shadow_automation_engine.cleanup()` alongside production's — the shadow engine schedules its own real `async_call_later` timers (grace, fan min-cycle, thermo backstop) directly on the real HA event loop regardless of `dry_run` (which only guards the service-call choke points), so it needs the same timer cancellation at shutdown.
 
+### Incident: WHF fast-cycling, proactive-floor exit vs. instant reactivation (Issue #641)
+
+Reported 2026-08-15: the whole-house fan cycled on/off roughly once a minute for
+several minutes (06:35-06:39) before the user disabled automation entirely. Root
+cause, confirmed by direct code reading (cross-checked by an independent second
+read): the log's "Nat-vent proactive exit — floor in 0.98 hr" is the `PROACTIVE_FLOOR`
+exit reason (`nat_vent_exit.py`), which calls `_exit_nat_vent()` **without**
+`set_outdoor_exit_time=True`. With a monitored sensor still open, `_exit_nat_vent()`
+hands off into `_paused_by_door=True` with no lockout timestamp armed — so the very
+next tick's paused-reactivation block (the same `_nat_vent_may_reactivate()` instant
+check the entry gate always uses) finds no lockout and immediately reactivates,
+producing another `PROACTIVE_FLOOR` exit next tick, repeating indefinitely. This is
+deterministic, not occasional: `PROACTIVE_FLOOR` is a *predictive* check
+(`time_to_floor_hr < 1.0`, driven by `k_passive`) independent of the *instant* gate
+condition (`outdoor < indoor - hysteresis`) it hands off into — indoor/outdoor barely
+move tick-to-tick, so if the instant gate was true just before the predictive exit
+fired, it is almost always still true immediately after.
+
+The same audit (not assumption — every `_exit_nat_vent()` call site read by hand)
+found two more exit reasons with the identical structural gap: `CEILING_THRESHOLD`
+(`check_natural_vent_conditions()`) and `fan_thermostat_check()`'s `STOP_DEACTIVATE`
+branch — the latter's own existing code comment already called it "the exact same
+boundary condition" as its sibling `STOP_VIA_NAT_VENT_EXIT`, which was already armed.
+All three now pass `set_outdoor_exit_time=True`, reusing the existing 300s lockout
+mechanism rather than inventing a new one.
+
+**Root-cause fix alone was judged insufficient** — the occupant impact (rapid relay
+cycling, forced to disable automation) demanded a backstop that holds even if a
+*different*, future gap in this exit/entry logic reproduces the same physical
+symptom. `AutomationEngine._fan_toggle_rate_limited()` is a hard floor inside
+`_activate_fan()`/`_deactivate_fan()`: any reversal within `FAN_MIN_TOGGLE_INTERVAL_S`
+(300s, `const.py`) of CA's own last real toggle command is suppressed, logged at
+WARNING, and raised as a proactive `fan_rapid_cycling` incident
+(`docs/incident-classes.md`) — visible through the existing incident pipeline with no
+new plumbing. Deliberately compares against a **separate** `_fan_toggle_command_time`
+field, not the pre-existing `_fan_command_time` echo-tracking field also used for
+provenance attribution (Issue #482) — found during this fix's own testing that
+`_reconcile_fan_physical_drift()`'s corrective "sync the stuck control entity"
+off-command legitimately stamps `_fan_command_time` immediately before an
+intentional same-tick recycle-on (that method's own docstring already documents this
+sequence), which the shared field would have wrongly rate-limited.
+
+**Prevention, not a one-time patch**: `tests/test_nat_vent_exit_lockout_coverage.py`
+AST-scans every `_exit_nat_vent()` call site and requires each to be explicitly
+classified `"arms lockout"` / `"exempted: <reason>"`, with a positive control checking
+the classification against the actual `set_outdoor_exit_time=True` argument in code —
+the same enforcement shape as `tests/test_shadow_engine_coverage.py`'s registry. A new
+exit reason added later without a classification fails immediately. Separately,
+`CONF_FAN_MIN_RUNTIME_PER_HOUR`'s cycling decisions (`desired_state.py`'s
+`decide_fan_cycle_on`/`decide_fan_cycle_off`) now floor their computed on/off phase
+durations at the same 300s minimum — a configured value outside roughly [5, 55]
+minutes would otherwise schedule its own off/on command inside the rate-limit window,
+stranding the fan far longer than the configured cycle intended.
+
 ## Code Reference
 
 - [`derive_nat_vent_lifecycle_state`](../custom_components/climate_advisor/nat_vent_lifecycle.py) — pure derivation
@@ -171,6 +227,8 @@ A full audit (every setter of the 7 grace/override fields, cross-referenced agai
 - [`_exit_nat_vent`](../custom_components/climate_advisor/automation.py#L5098) — the primary (not sole) exit choke point
 - [`decide_nat_vent_gate`, `decide_nat_vent_soft_start_gate`](../custom_components/climate_advisor/nat_vent_gate.py) — entry gates
 - [`is_reactivation_locked_out`](../custom_components/climate_advisor/nat_vent_reactivation_lockout.py) — lockout predicate
+- [`AutomationEngine._fan_toggle_rate_limited`](../custom_components/climate_advisor/automation.py) — hard fan-toggle rate-limit backstop, independent of exit/reactivation logic (Issue #641)
+- [`tests/test_nat_vent_exit_lockout_coverage.py`](../tests/test_nat_vent_exit_lockout_coverage.py) — AST-based coverage registry for every `_exit_nat_vent()` call site's lockout-arming decision (Issue #641)
 - [`run_shadow_pair_scenario`](../tools/sim_harness/shadow_engine_pair.py) — offline whole-engine shadow-pair comparator (Issue #611)
 - [`ClimateAdvisorCoordinator._mirror_to_shadow`, `_build_shadow_automation_callbacks`, `_update_shadow_engine_diagnostic`](../custom_components/climate_advisor/coordinator.py) — live shadow engine wiring (Issue #613)
 - [`ClimateAdvisorCoordinator._sync_shadow_inputs`](../custom_components/climate_advisor/coordinator.py) — input-data parity, full-coverage decision mirroring (Issue #615), extended to grace/override state (Issue #631)

--- a/tests/test_desired_state.py
+++ b/tests/test_desired_state.py
@@ -298,6 +298,15 @@ class TestDecideFanCycleOn:
         assert outcome == FanCycleOutcome.ACTIVATE_WITH_OFF_TIMER
         assert delay == 20 * 60.0
 
+    def test_off_timer_delay_floored_at_300s_for_short_on_phase(self):
+        """Issue #641: min_runtime=2 -> raw on-phase delay would be 2*60=120s, well under
+        the 300s fan-toggle rate-limit floor — the scheduled off-command would otherwise
+        be silently suppressed by _fan_toggle_rate_limited(), stranding the fan on far
+        longer than the configured 2-min-on cycle intended."""
+        outcome, delay = decide_fan_cycle_on(**self._inputs(min_runtime_minutes=2))
+        assert outcome == FanCycleOutcome.ACTIVATE_WITH_OFF_TIMER
+        assert delay == 300.0
+
     def test_retry_later_when_fan_already_active(self):
         outcome, delay = decide_fan_cycle_on(**self._inputs(fan_active=True))
         assert outcome == FanCycleOutcome.RETRY_LATER
@@ -316,11 +325,26 @@ class TestDecideFanCycleOff:
         assert should_deactivate is False
         assert wait_seconds > 0  # next "on" phase is always scheduled regardless
 
-    def test_wait_seconds_clamped_to_zero_when_min_runtime_exceeds_60(self):
-        """max(0, ...) guard: an (invalid but possible) min_runtime > 60 must not produce
-        a negative wait."""
+    def test_wait_seconds_clamped_to_floor_when_min_runtime_exceeds_60(self):
+        """Issue #641: an (invalid but possible) min_runtime > 60 would otherwise produce
+        a negative wait — floored at the same 300s safety minimum as every other
+        short-duration case, not 0 (0 would itself be unsafe: an immediate on-command
+        right after the off-command would be suppressed by the rate-limit backstop)."""
         _, wait_seconds = decide_fan_cycle_off(fan_min_runtime_active=True, min_runtime_minutes=90.0)
-        assert wait_seconds == 0.0
+        assert wait_seconds == 300.0
+
+    def test_wait_seconds_floored_at_300s_for_short_off_phase(self):
+        """Issue #641: min_runtime=58 -> raw off-phase wait would be (60-58)*60=120s, well
+        under the 300s fan-toggle rate-limit floor — the scheduled reactivation would
+        otherwise be silently suppressed by _fan_toggle_rate_limited(), stranding the fan
+        off far longer than the configured 58-min-on/2-min-off cycle intended."""
+        _, wait_seconds = decide_fan_cycle_off(fan_min_runtime_active=True, min_runtime_minutes=58.0)
+        assert wait_seconds == 300.0
+
+    def test_wait_seconds_unaffected_when_already_above_floor(self):
+        """Control case: a normal, already-safe configuration is untouched by the floor."""
+        _, wait_seconds = decide_fan_cycle_off(fan_min_runtime_active=True, min_runtime_minutes=20.0)
+        assert wait_seconds == (60 - 20) * 60.0
 
 
 class TestDecideScheduledBandGate:

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -1843,6 +1843,23 @@ class TestFanThermostatCheck:
         events = [c.args[0] for c in engine._emit_event_callback.call_args_list]
         assert "nat_vent_outdoor_rise_exit" not in events
 
+    def test_stop_deactivate_arms_reactivation_lockout(self):
+        """Issue #641: STOP_DEACTIVATE (this branch, the non-nat-vent-specific direction-
+        reversal stop) is documented in its own code comment as 'the exact same boundary
+        condition' as STOP_VIA_NAT_VENT_EXIT — found during this issue's coverage audit to
+        be missing the same set_outdoor_exit_time=True lockout its sibling already has,
+        letting outdoor hover near the indoor boundary flip-flop this exit against
+        reactivation. Fixed to match its sibling."""
+        engine = self._engine()
+        engine._natural_vent_active = False
+        engine._fan_active = True
+
+        asyncio.run(engine.fan_thermostat_check(indoor=72.0, outdoor=73.0, trigger="test"))
+
+        assert engine._nat_vent_outdoor_exit_time is not None, (
+            "STOP_DEACTIVATE must arm the same reactivation lockout as its sibling STOP_VIA_NAT_VENT_EXIT branch"
+        )
+
     def test_noop_when_override_active(self):
         """Manual fan override in effect → fast loop is a no-op (user has control)."""
         engine = self._engine()
@@ -3429,6 +3446,49 @@ class TestDualFanStatus:
             climate_fan_mode="auto",
         )
         assert coord._compute_hvac_fan_status() == "inactive"
+
+
+class TestWhfStatusRateLimitSuffix:
+    """Issue #641: _compute_whf_status() must surface an active rate-limit suppression
+    via a suffix on the existing status string, per the Status Card Ontology rule
+    (extend the existing card's value, don't add a new one)."""
+
+    def test_suffix_shown_while_within_cooldown(self):
+        coord = _make_coordinator_for_fan_status(
+            fan_mode=FAN_MODE_WHOLE_HOUSE,
+            fan_active=False,
+            physical_state=False,
+        )
+        now = datetime(2026, 8, 15, 6, 41, 0)
+        coord.automation_engine._fan_rate_limited_until = now + timedelta(seconds=120)
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=now):
+            result = coord._compute_whf_status()
+        assert result == "inactive (rate-limited 180s ago)"
+
+    def test_suffix_absent_once_cooldown_elapses(self):
+        coord = _make_coordinator_for_fan_status(
+            fan_mode=FAN_MODE_WHOLE_HOUSE,
+            fan_active=False,
+            physical_state=False,
+        )
+        now = datetime(2026, 8, 15, 6, 41, 0)
+        coord.automation_engine._fan_rate_limited_until = now - timedelta(seconds=1)  # already lifted
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=now):
+            result = coord._compute_whf_status()
+        assert result == "inactive"
+
+    def test_suffix_absent_when_never_rate_limited(self):
+        """MagicMock's default unset-attribute truthiness must not be mistaken for an
+        active cooldown — the isinstance(until, datetime) guard is load-bearing here,
+        matching this codebase's established mocked-engine defensive pattern."""
+        coord = _make_coordinator_for_fan_status(
+            fan_mode=FAN_MODE_WHOLE_HOUSE,
+            fan_active=True,
+            physical_state=True,
+        )
+        # coord.automation_engine is a bare MagicMock() — _fan_rate_limited_until was
+        # never set, so accessing it returns a truthy MagicMock, not None.
+        assert coord._compute_whf_status() == "active"
 
 
 class TestCommandWhfControlEntity:

--- a/tests/test_fan_rate_limit.py
+++ b/tests/test_fan_rate_limit.py
@@ -1,0 +1,224 @@
+"""Tests for Issue #641: hard safety floor on CA-issued fan toggle frequency.
+
+Defense-in-depth backstop, independent of the specific root cause fixed elsewhere
+(see tests/test_nat_vent_activation.py::TestIssue641ExitReactivationFlipFlop) —
+_activate_fan()/_deactivate_fan() must refuse to reverse the fan's state within
+FAN_MIN_TOGGLE_INTERVAL_S (300s) of CA's own last command, regardless of which
+upstream decision logic asked for the reversal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.climate_advisor.automation import AutomationEngine
+from custom_components.climate_advisor.const import (
+    CONF_FAN_ENTITY,
+    CONF_FAN_MODE,
+    FAN_MIN_TOGGLE_INTERVAL_S,
+    FAN_MODE_WHOLE_HOUSE,
+)
+
+_DT_NOW_PATH = "custom_components.climate_advisor.automation.dt_util.now"
+
+
+def _consume_coroutine(coro):
+    coro.close()
+
+
+def _make_engine() -> AutomationEngine:
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+    hass.states = MagicMock()
+
+    config = {
+        "comfort_heat": 68.0,
+        "comfort_cool": 74.0,
+        "setback_heat": 60,
+        "setback_cool": 80,
+        "notify_service": "notify.notify",
+        CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+        CONF_FAN_ENTITY: "fan.attic",
+    }
+    engine = AutomationEngine(
+        hass=hass,
+        climate_entity="climate.thermostat",
+        weather_entity="weather.forecast_home",
+        door_window_sensors=["binary_sensor.front_door"],
+        notify_service=config["notify_service"],
+        config=config,
+    )
+    return engine
+
+
+def _get_service_calls(engine, domain: str, service: str) -> list:
+    return [c for c in engine.hass.services.async_call.call_args_list if c[0][0] == domain and c[0][1] == service]
+
+
+class TestFanToggleRateLimitSuppression:
+    """A reversal within the cooldown window must be suppressed, logged, and
+    flagged as a fan_rapid_cycling incident — never silent."""
+
+    def test_reactivate_within_window_is_suppressed(self):
+        """Fan turned on, legitimately deactivated after the cooldown has elapsed
+        (so the deactivate itself isn't also caught by the guard), then a too-soon
+        reactivate attempt must no-op — the exact WHF fast-cycling symptom,
+        independent of whatever upstream logic asked for the reversal."""
+        engine = _make_engine()
+        t0 = datetime(2026, 8, 15, 6, 36, 0)
+        with patch(_DT_NOW_PATH, return_value=t0):
+            asyncio.run(engine._activate_fan(reason="initial activation"))
+        assert engine._fan_active is True
+        assert len(_get_service_calls(engine, "fan", "turn_on")) == 1
+
+        # Deactivate after the cooldown has elapsed — a legitimate, correctly-spaced
+        # exit, not itself subject to the guard.
+        t1 = t0 + timedelta(seconds=FAN_MIN_TOGGLE_INTERVAL_S + 1)
+        with patch(_DT_NOW_PATH, return_value=t1):
+            asyncio.run(engine._deactivate_fan(reason="exit"))
+        assert engine._fan_active is False
+        assert len(_get_service_calls(engine, "fan", "turn_off")) == 1
+
+        # Reactivate 10s after the deactivate — well within the 300s floor — must
+        # be suppressed (this is the reported incident's actual sequence).
+        t2 = t1 + timedelta(seconds=10)
+        events: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: events.append((name, payload))
+        with patch(_DT_NOW_PATH, return_value=t2), patch("custom_components.climate_advisor.automation._LOGGER") as log:
+            asyncio.run(engine._activate_fan(reason="reactivation attempt"))
+
+        assert engine._fan_active is False, "rate limit must suppress the reactivation"
+        assert len(_get_service_calls(engine, "fan", "turn_on")) == 1, "no second turn_on call issued"
+        log.warning.assert_called_once()
+        assert "rate limit" in log.warning.call_args.args[0].lower()
+
+        incidents = [e for e in events if e[0] == "incident_detected"]
+        assert len(incidents) == 1
+        assert incidents[0][1]["incident_class"] == "fan_rapid_cycling"
+        assert incidents[0][1]["attempted_action"] == "activate"
+        assert incidents[0][1]["min_interval_s"] == FAN_MIN_TOGGLE_INTERVAL_S
+
+    def test_deactivate_within_window_is_suppressed(self):
+        """Symmetric case: activate, then a too-soon deactivate attempt is suppressed."""
+        engine = _make_engine()
+        t0 = datetime(2026, 8, 15, 6, 36, 0)
+        with patch(_DT_NOW_PATH, return_value=t0):
+            asyncio.run(engine._activate_fan(reason="initial activation"))
+        assert engine._fan_active is True
+
+        t1 = t0 + timedelta(seconds=30)
+        events: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: events.append((name, payload))
+        with patch(_DT_NOW_PATH, return_value=t1):
+            asyncio.run(engine._deactivate_fan(reason="too-soon exit attempt"))
+
+        assert engine._fan_active is True, "rate limit must suppress the too-soon deactivation"
+        assert len(_get_service_calls(engine, "fan", "turn_off")) == 0
+        incidents = [e for e in events if e[0] == "incident_detected"]
+        assert incidents[0][1]["attempted_action"] == "deactivate"
+
+    def test_suppression_sets_fan_rate_limited_until(self):
+        """_fan_rate_limited_until is set to command_time + interval — the field the
+        status-tab suffix (_whf_rate_limit_suffix) reads."""
+        engine = _make_engine()
+        t0 = datetime(2026, 8, 15, 6, 36, 0)
+        with patch(_DT_NOW_PATH, return_value=t0):
+            asyncio.run(engine._activate_fan(reason="initial activation"))
+
+        t1 = t0 + timedelta(seconds=1)
+        with patch(_DT_NOW_PATH, return_value=t1):
+            asyncio.run(engine._deactivate_fan(reason="suppressed"))
+
+        assert engine._fan_rate_limited_until == t0 + timedelta(seconds=FAN_MIN_TOGGLE_INTERVAL_S)
+
+
+class TestFanToggleRateLimitAllowsSpacedToggles:
+    """A toggle spaced >= 300s from the last command must NOT be throttled — this
+    guard must never suppress ordinary, correctly-spaced fan cycling."""
+
+    def test_reactivate_after_window_elapses_is_allowed(self):
+        engine = _make_engine()
+        t0 = datetime(2026, 8, 15, 6, 36, 0)
+        with patch(_DT_NOW_PATH, return_value=t0):
+            asyncio.run(engine._activate_fan(reason="initial activation"))
+
+        t1 = t0 + timedelta(seconds=FAN_MIN_TOGGLE_INTERVAL_S + 1)
+        with patch(_DT_NOW_PATH, return_value=t1):
+            asyncio.run(engine._deactivate_fan(reason="exit"))
+        assert engine._fan_active is False
+
+        t2 = t1 + timedelta(seconds=FAN_MIN_TOGGLE_INTERVAL_S + 1)
+        with patch(_DT_NOW_PATH, return_value=t2):
+            asyncio.run(engine._activate_fan(reason="legitimate reactivation"))
+
+        assert engine._fan_active is True
+        assert len(_get_service_calls(engine, "fan", "turn_on")) == 2
+
+    def test_first_ever_activation_is_never_rate_limited(self):
+        """_fan_command_time is None before any CA command — must never be treated as
+        'elapsed < window' (that would permanently block the very first activation)."""
+        engine = _make_engine()
+        assert engine._fan_command_time is None
+        asyncio.run(engine._activate_fan(reason="first activation"))
+        assert engine._fan_active is True
+        assert len(_get_service_calls(engine, "fan", "turn_on")) == 1
+
+
+class TestFanToggleRateLimitNeverBlocksManualOverride:
+    """A genuine user/RF-remote fan action must never be throttled — both
+    _activate_fan/_deactivate_fan already return before reaching the rate-limit
+    check when an override is active, so CA's own rate limiter is structurally
+    inert for manual actions."""
+
+    def test_override_active_skips_rate_limit_check_entirely(self):
+        engine = _make_engine()
+        t0 = datetime(2026, 8, 15, 6, 36, 0)
+        with patch(_DT_NOW_PATH, return_value=t0):
+            asyncio.run(engine._activate_fan(reason="initial activation"))
+
+        engine._fan_override_active = True
+        t1 = t0 + timedelta(seconds=1)  # well within the cooldown window
+        with (
+            patch(_DT_NOW_PATH, return_value=t1),
+            patch.object(engine, "_fan_toggle_rate_limited") as rate_limit_spy,
+        ):
+            asyncio.run(engine._deactivate_fan(reason="manual override active"))
+
+        rate_limit_spy.assert_not_called()
+
+
+class TestFanToggleRateLimitIgnoresBookkeepingOnlyStamps:
+    """Found and fixed during this issue's own implementation:
+    _reconcile_fan_physical_drift()'s Issue #449/#482 corrective "sync the stuck
+    control entity" command stamps the shared _fan_command_time echo-tracking field
+    (used for provenance/manual-vs-CA attribution) without representing a real
+    physical toggle — the fan was already off; only the control entity's stale
+    belief changes. That method's own docstring documents an immediately-following
+    same-tick recycle-on as correct, expected behavior. _fan_toggle_rate_limited()
+    must key off the separate _fan_toggle_command_time field (stamped only by
+    _activate_fan/_deactivate_fan's own real command sites) so this legitimate
+    reconcile-then-recycle sequence is never mistaken for the flip-flop this guard
+    exists to catch."""
+
+    def test_bookkeeping_only_command_time_stamp_does_not_block_real_toggle(self):
+        engine = _make_engine()
+        now = datetime(2026, 8, 15, 6, 40, 0)
+        # Simulate a bookkeeping-only stamp (e.g. the drift-reconciliation echo
+        # command) WITHOUT going through _activate_fan/_deactivate_fan — mirrors
+        # automation.py's _reconcile_fan_physical_drift() stamping _fan_command_time
+        # directly, right before its own _command_whf_control_entity() call.
+        engine._fan_command_time = now
+        assert engine._fan_toggle_command_time is None
+
+        with patch(_DT_NOW_PATH, return_value=now):
+            asyncio.run(engine._activate_fan(reason="nat_vent_cycling_on"))
+
+        assert engine._fan_active is True, (
+            "a bookkeeping-only _fan_command_time stamp (no prior real toggle) must not "
+            "block the very next real _activate_fan() call, even at the same instant"
+        )
+        assert len(_get_service_calls(engine, "fan", "turn_on")) == 1

--- a/tests/test_nat_vent_activation.py
+++ b/tests/test_nat_vent_activation.py
@@ -1076,6 +1076,138 @@ class TestProactiveFloorExit:
 
 
 # ---------------------------------------------------------------------------
+# Issue #641 — WHF fast-cycling: proactive-floor / ceiling-threshold exits must
+# arm the reactivation lockout when they hand off into a sensor-open pause,
+# otherwise the very next tick's instant reactivation gate immediately undoes
+# the exit, producing a repeating on/off flip-flop (occupant impact: the WHF
+# relay cycled roughly once a minute until the user disabled automation).
+# ---------------------------------------------------------------------------
+
+
+class TestIssue641ExitReactivationFlipFlop:
+    """Permanent regression coverage for the exact incident sequence: an exit that
+    hands off into `_paused_by_door=True` must be immediately followed by a
+    reactivation attempt at the SAME clock time remaining blocked, not flipping
+    straight back on. Proven load-bearing (not incidentally passing) by first
+    confirming the sensor-open exit still pauses as expected, matching
+    TestProactiveFloorExit's existing sensor-open coverage."""
+
+    def _make_active_nat_vent_engine(
+        self,
+        indoor_f: float = 71.0,
+        outdoor_f: float = 65.0,
+        k_passive: float = -0.5,
+        confidence: str = "medium",
+        comfort_heat: float = 70.0,
+        comfort_cool: float = 72.0,
+        nat_vent_delta: float = 3.0,
+    ) -> AutomationEngine:
+        engine = _make_engine(
+            comfort_heat=comfort_heat, comfort_cool=comfort_cool, nat_vent_delta=nat_vent_delta, indoor_f=indoor_f
+        )
+        engine._last_outdoor_temp = outdoor_f
+        engine._natural_vent_active = True
+        engine._paused_by_door = False
+        engine._fan_override_active = False
+        engine._thermal_model = {"confidence": confidence, "k_passive": k_passive}
+        engine._hourly_forecast_temps = []
+        engine._sensor_check_callback = lambda: True  # monitored sensor still open, per the reported incident
+        return engine
+
+    def test_proactive_floor_exit_arms_lockout_and_blocks_immediate_reactivation(self):
+        """Reproduces the reported incident's own numbers: indoor 69F, outdoor 58.6F,
+        k_passive=-0.0977 -> time_to_floor ~0.98hr, comfort_heat=68F. The exit tick and
+        the very next reactivation-check tick both run at the SAME timestamp (worst
+        case — production ticks can land seconds apart, not just minutes), matching how
+        tight the real incident's log timestamps were.
+        """
+        engine = self._make_active_nat_vent_engine(
+            indoor_f=69.0, outdoor_f=58.6, k_passive=-0.0977, comfort_heat=68.0, comfort_cool=74.0
+        )
+        events: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: events.append((name, payload))
+        now = datetime(2026, 8, 15, 6, 36, 0)
+
+        with patch(_DT_NOW_PATH, return_value=now):
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        # Sanity: this really is the proactive-floor exit, matching the incident's own log line.
+        assert any(e[0] == "nat_vent_predicted_floor_exit" for e in events)
+        assert engine._natural_vent_active is False
+        assert engine._paused_by_door is True
+        assert engine._nat_vent_outdoor_exit_time == now, (
+            "Issue #641: proactive-floor exit must arm the reactivation lockout "
+            "(_nat_vent_outdoor_exit_time) when it hands off into a sensor-open pause — "
+            "without this, nothing stops the very next tick from reactivating immediately"
+        )
+
+        # Same instant reactivation attempt the real incident's next log line shows
+        # ("Fan activated -- natural vent activated..."). Indoor/outdoor unchanged,
+        # same clock tick — before the fix this reactivated every single time.
+        with patch(_DT_NOW_PATH, return_value=now):
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False, (
+            "reactivation must be blocked by the lockout immediately after a proactive-floor exit"
+        )
+        assert engine._paused_by_door is True
+
+    def test_proactive_floor_exit_reactivates_normally_once_lockout_expires(self):
+        """Control case: the lockout is temporary, not permanent — once
+        NAT_VENT_REACTIVATION_LOCKOUT_S has elapsed, reactivation proceeds normally
+        if conditions still warrant it (matching TestReactivationLockout's existing
+        outdoor-rise-exit control case)."""
+        engine = self._make_active_nat_vent_engine(
+            indoor_f=69.0, outdoor_f=58.6, k_passive=-0.0977, comfort_heat=68.0, comfort_cool=74.0
+        )
+        exit_time = datetime(2026, 8, 15, 6, 36, 0)
+        with patch(_DT_NOW_PATH, return_value=exit_time):
+            asyncio.run(engine.check_natural_vent_conditions())
+        assert engine._natural_vent_active is False
+
+        # Indoor recovers slightly above the floor by the time the lockout expires,
+        # so the reactivation isn't itself blocked by anything except the lockout.
+        _set_engine_indoor(engine, 69.0)
+        late = exit_time + timedelta(seconds=NAT_VENT_REACTIVATION_LOCKOUT_S + 1)
+        with patch(_DT_NOW_PATH, return_value=late):
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True
+        assert engine._paused_by_door is False
+
+    def test_ceiling_threshold_exit_pauses_and_arms_lockout(self):
+        """Sibling gap found in the same audit: CEILING_THRESHOLD exit
+        (outdoor > comfort_cool + nat_vent_delta) has the identical structural gap as
+        the proactive-floor exit — it also hands off into _exit_nat_vent() and must
+        arm the same lockout when the sensor is still open. threshold = 72 + 3 = 75;
+        outdoor=75.5 triggers the exit (outdoor-rise doesn't fire first since
+        outdoor(75.5) < indoor(76) is false... actually outdoor > indoor too, so
+        outdoor-rise wins priority — use indoor=76.5 so outdoor(75.5) < indoor and
+        only the ceiling check fires).
+        """
+        engine = self._make_active_nat_vent_engine(
+            indoor_f=76.5, outdoor_f=75.5, comfort_heat=68.0, comfort_cool=72.0, nat_vent_delta=3.0
+        )
+        # No thermal model confidence -> proactive-floor check is skipped, isolating
+        # this test to the ceiling-threshold exit specifically.
+        engine._thermal_model = {"confidence": "none", "k_passive": None}
+        events: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: events.append((name, payload))
+        now = datetime(2026, 8, 15, 14, 0, 0)
+
+        with patch(_DT_NOW_PATH, return_value=now):
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False
+        assert engine._paused_by_door is True
+        assert engine._nat_vent_outdoor_exit_time == now, (
+            "Issue #641: ceiling-threshold exit must arm the same reactivation lockout as "
+            "proactive-floor and outdoor-rise — outdoor hovering near the threshold can "
+            "flip-flop identically without it"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Bug #313 Fix — equal outdoor==indoor should NOT exit nat vent
 # ---------------------------------------------------------------------------
 

--- a/tests/test_nat_vent_exit_lockout_coverage.py
+++ b/tests/test_nat_vent_exit_lockout_coverage.py
@@ -1,0 +1,197 @@
+"""Issue #641 prevention: registry-enforced coverage of every ``_exit_nat_vent()`` call
+site's reactivation-lockout arming decision.
+
+The WHF fast-cycling incident's root cause was a scoping decision made once, at Issue
+#411/#608, that was correct for 3 of 4 reactivation-gate call sites and silently wrong
+for a 4th (``PROACTIVE_FLOOR``) — nothing forced a re-check of that assumption when new
+exit reasons were added later. During this fix's own audit, two more previously-unnoticed
+sibling gaps surfaced (``CEILING_THRESHOLD`` and ``fan_thermostat_check()``'s
+``STOP_DEACTIVATE`` branch) purely from reading every call site by hand.
+
+This module is the durable fix for "how do we know this scoping decision stays correct
+as new exit reasons get added": it AST-scans ``automation.py`` for every
+``self._exit_nat_vent(...)`` call and requires each to be explicitly classified in
+``_COVERAGE_REGISTRY`` as ``"arms lockout"`` or ``"exempted: <reason>"`` — the same
+enforcement shape as ``tests/test_shadow_engine_coverage.py``'s ``_TRACKED_FIELDS``
+registry and ``tests/test_executor_offload.py``'s ``_BLOCKING_METHODS`` registry. A new
+call site added later without a classification fails immediately, instead of silently
+repeating this bug class a fourth time.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parent.parent
+_AUTOMATION_PY = _REPO_ROOT / "custom_components" / "climate_advisor" / "automation.py"
+
+# Key: (enclosing method name, 1-based ordinal of the _exit_nat_vent() call within that
+# method's source order). Ordinal keying (not line numbers) stays stable across edits
+# elsewhere in the file, matching this project's documented convention of treating line
+# numbers as a navigation aid, not a contract (nat-vent-lifecycle-spec.md).
+#
+# Classification meanings:
+#   "arms lockout"   — passes set_outdoor_exit_time=True. Required whenever the exit
+#                       reason's own condition is NOT self-complementary with the
+#                       instant reactivation gate's condition at a fixed indoor/outdoor
+#                       reading — i.e. the exit and re-entry conditions could both be
+#                       satisfied by the same (or a barely-changed) reading, the way
+#                       PROACTIVE_FLOOR's independent time-to-floor prediction can.
+#   "exempted: <reason>" — deliberately does not arm the lockout, with a specific reason
+#                       (never a bare "not needed").
+_COVERAGE_REGISTRY: dict[tuple[str, int], str] = {
+    ("handle_all_doors_windows_closed", 1): (
+        "exempted: fires only when _any_monitored_sensor_open() is False (all sensors just "
+        "closed) — _exit_nat_vent() always takes the sensors-closed grace-period branch here, "
+        "which never consults the paused-reactivation lockout at all"
+    ),
+    ("check_natural_vent_conditions", 1): (
+        "arms lockout — Issue #641 (PROACTIVE_FLOOR): a predictive time-to-floor check "
+        "computed independently of the instant reactivation gate; almost always still "
+        "satisfied on the very next tick without this lockout (the reported incident)"
+    ),
+    ("check_natural_vent_conditions", 2): (
+        "arms lockout — original outdoor-rise exit (Issue #115/#411), the lockout mechanism's "
+        "first and originally-only use case"
+    ),
+    ("check_natural_vent_conditions", 3): (
+        "arms lockout — Issue #641 (CEILING_THRESHOLD): outdoor hovering near "
+        "comfort_cool + nat_vent_delta can cross the boundary tick-to-tick from sensor/weather "
+        "noise, flip-flopping against the reactivation gate's own outdoor < threshold check"
+    ),
+    ("nat_vent_temperature_check", 1): (
+        "exempted: guarded by an explicit `not self._any_monitored_sensor_open()` "
+        "precondition (session force-closed because sensors are already closed) — always "
+        "takes the sensors-closed grace-period branch, lockout never consulted"
+    ),
+    ("nat_vent_temperature_check", 2): (
+        "exempted: hard-floor exit (indoor <= comfort floor) shares the same comparison "
+        "quantity as the reactivation gate's own comfort_heat floor check — self-complementary "
+        "at a fixed reading, cannot both be satisfied by the same indoor temperature the way "
+        "PROACTIVE_FLOOR's independent predictive math could"
+    ),
+    ("fan_thermostat_check", 1): (
+        "arms lockout — STOP_VIA_NAT_VENT_EXIT, the tick-level twin of "
+        "check_natural_vent_conditions()'s OUTDOOR_RISE exit (same boundary condition, "
+        "different dispatch path); already correctly armed since Issue #411/#418"
+    ),
+    ("fan_thermostat_check", 2): (
+        "arms lockout — Issue #641: STOP_DEACTIVATE (Check 1's non-nat-vent-specific "
+        "direction-reversal stop) is documented in its own comment as 'the exact same "
+        "boundary condition' as STOP_VIA_NAT_VENT_EXIT above, just without the "
+        "nat-vent-active gate — found unarmed during this issue's own coverage audit"
+    ),
+    ("fan_thermostat_check", 3): (
+        "exempted: STOP_COOLED_TO_FLOOR (Check 2) — same self-complementary-floor reasoning "
+        "as nat_vent_temperature_check's hard-floor exit above"
+    ),
+    ("_reconcile_fan_on_startup_locked", 1): (
+        "exempted: startup/periodic reconciliation, not a per-tick decision path — runs at "
+        "most once per restart or 30-min backstop, structurally incapable of the sub-minute "
+        "repeating cadence this lockout exists to prevent"
+    ),
+    ("on_fan_turned_off", 1): (
+        "exempted: fires once per real fan-off state-change event (RF timer boundary settle "
+        "reconciliation), not a periodic re-evaluation — cannot self-trigger repeatedly the "
+        "way a per-tick predictive/instant check can; any resulting reactivation attempt is "
+        "separately covered by the Issue #641 rate-limit backstop (Part B, "
+        "_fan_toggle_rate_limited())"
+    ),
+}
+
+
+def _find_exit_nat_vent_call_sites() -> list[tuple[str, int]]:
+    """AST-scan AutomationEngine for every ``self._exit_nat_vent(...)`` call, keyed by
+    (enclosing method name, 1-based ordinal within that method's source order)."""
+    tree = ast.parse(_AUTOMATION_PY.read_text(encoding="utf-8"))
+    engine_class = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and node.name == "AutomationEngine"
+    )
+    sites: list[tuple[str, int]] = []
+    for node in engine_class.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        calls = [
+            sub
+            for sub in ast.walk(node)
+            if isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Attribute)
+            and sub.func.attr == "_exit_nat_vent"
+            and isinstance(sub.func.value, ast.Name)
+            and sub.func.value.id == "self"
+        ]
+        calls.sort(key=lambda c: (c.lineno, c.col_offset))
+        for ordinal, _call in enumerate(calls, start=1):
+            sites.append((node.name, ordinal))
+    return sites
+
+
+def _find_calls_with_lockout_flag() -> dict[tuple[str, int], bool]:
+    """Same scan as above, but also records whether each call passes
+    set_outdoor_exit_time=True — lets the registry's "arms lockout" claim be checked
+    against the actual code, not just trusted."""
+    tree = ast.parse(_AUTOMATION_PY.read_text(encoding="utf-8"))
+    engine_class = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and node.name == "AutomationEngine"
+    )
+    result: dict[tuple[str, int], bool] = {}
+    for node in engine_class.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        calls = [
+            sub
+            for sub in ast.walk(node)
+            if isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Attribute)
+            and sub.func.attr == "_exit_nat_vent"
+            and isinstance(sub.func.value, ast.Name)
+            and sub.func.value.id == "self"
+        ]
+        calls.sort(key=lambda c: (c.lineno, c.col_offset))
+        for ordinal, call in enumerate(calls, start=1):
+            arms = any(
+                kw.arg == "set_outdoor_exit_time" and isinstance(kw.value, ast.Constant) and kw.value.value is True
+                for kw in call.keywords
+            )
+            result[(node.name, ordinal)] = arms
+    return result
+
+
+class TestExitNatVentLockoutCoverageRegistry:
+    def test_every_call_site_is_registered(self) -> None:
+        found = set(_find_exit_nat_vent_call_sites())
+        unregistered = found - set(_COVERAGE_REGISTRY)
+        assert not unregistered, (
+            f"New _exit_nat_vent() call site(s) found but not classified in "
+            f"_COVERAGE_REGISTRY: {sorted(unregistered)}. Add each as "
+            f'"arms lockout" or "exempted: <reason>" — see Issue #641. Ask: could this '
+            f"exit reason's own condition be re-satisfied by the reactivation gate on the "
+            f"very next tick, at the same or barely-changed indoor/outdoor reading?"
+        )
+
+    def test_registry_has_no_stale_entries(self) -> None:
+        """Catches a registry entry left behind after its call site was removed or
+        moved to a different method — a stale entry would otherwise silently hide a
+        real coverage gap forever."""
+        found = set(_find_exit_nat_vent_call_sites())
+        stale = set(_COVERAGE_REGISTRY) - found
+        assert not stale, f"Registry references call site(s) that no longer exist: {sorted(stale)}. Update it."
+
+    def test_arms_lockout_claims_match_the_actual_code(self) -> None:
+        """Positive control: every registry entry claiming "arms lockout" must actually
+        pass set_outdoor_exit_time=True in the real code, and every entry NOT claiming
+        it must NOT pass it — catches the registry drifting from reality in either
+        direction (a claimed-but-unarmed site would silently ship this bug class again;
+        an armed-but-unclaimed site means the registry's own documentation is wrong)."""
+        actual = _find_calls_with_lockout_flag()
+        for key, classification in _COVERAGE_REGISTRY.items():
+            claims_armed = classification.startswith("arms lockout")
+            really_armed = actual.get(key)
+            assert really_armed is not None, f"{key} in registry but not found by the call-site scan"
+            assert really_armed == claims_armed, (
+                f"{key} registry classification says "
+                f"{'armed' if claims_armed else 'exempted'} but the actual code "
+                f"{'arms' if really_armed else 'does not arm'} the lockout — registry and "
+                f"code have drifted apart"
+            )

--- a/tools/simulations/pending/issue-641-whf-proactive-exit-reactivation-flip-flop.json
+++ b/tools/simulations/pending/issue-641-whf-proactive-exit-reactivation-flip-flop.json
@@ -1,0 +1,73 @@
+{
+  "name": "issue_641_whf_proactive_exit_reactivation_flip_flop",
+  "description": "Reproduces the reported WHF fast-cycling incident (2026-08-15, 06:35-06:39): a proactive-floor exit fires while a monitored window is still open, and the very next re-evaluation tick — with indoor/outdoor essentially unchanged — must NOT immediately reactivate nat-vent. Before the Issue #641 fix, the paused-reactivation block's instant gate (outdoor < indoor - hysteresis) re-satisfied every single tick because the proactive-floor exit never armed the reactivation lockout, producing a repeating on/off flip-flop until the user disabled automation.",
+  "source": "production_incident",
+  "issue": 641,
+  "notes": [
+    "Numbers match the real incident's own log line as closely as the scenario schema allows: indoor 69F, outdoor 58.6F, k_passive=-0.0977, comfort_heat=68F -> time_to_floor ~0.98hr, just under the 1.0hr MIN_VIABLE_NAT_VENT_HOURS threshold.",
+    "The second temp_update event repeats the SAME indoor/outdoor reading on purpose -- production's real ticks landed seconds apart with essentially no change in either value, which is exactly what makes this bug deterministic rather than occasional.",
+    "paused_by_door (final engine_state) is the correct assertion type here, not an event-type match -- nat_vent_predicted_floor_exit is a production-only, intentionally-unmapped event (see outcomes.py UNMAPPED_PRODUCTION_EVENTS), so this scenario asserts the observable BEHAVIORAL RESULT of the fix (still paused, not reactivated) rather than the internal event.",
+    "Occupant framing: before the fix, the WHF relay would have been commanded on again at this exact point, repeating every cycle; after the fix, it stays off until either the 300s lockout expires with conditions still favorable, or (more likely here, since indoor is genuinely 1F above the floor) the real comfort-floor exit ends the session properly on its own."
+  ],
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 74,
+    "setback_heat": 60,
+    "setback_cool": 80,
+    "natural_vent_delta": 3.0,
+    "fan_mode": "whole_house_fan",
+    "fan_entity": "fan.whole_house"
+  },
+  "thermal_model": {
+    "confidence": "medium",
+    "k_passive": -0.0977
+  },
+  "events": [
+    {
+      "time": "2026-08-15T06:00:00",
+      "type": "temp_update",
+      "indoor_f": 70.0,
+      "outdoor_f": 60.0,
+      "note": "Overnight baseline: indoor 70F, outdoor 60F -- favorable for nat-vent, well above the 68F floor."
+    },
+    {
+      "time": "2026-08-15T06:00:01",
+      "type": "classification",
+      "day_type": "warm",
+      "hvac_mode": "off",
+      "windows_recommended": true,
+      "note": "Warm-day classification with HVAC off -- nat-vent is the primary control mechanism overnight."
+    },
+    {
+      "time": "2026-08-15T06:00:02",
+      "type": "sensor_open",
+      "entity": "binary_sensor.bedroom_window",
+      "note": "Window open overnight (matches the real incident's paused-by-door precondition). outdoor(60) < indoor(70) - hysteresis(1), indoor > comfort_heat(68), outdoor < threshold -- nat-vent activates, WHF turns on, HVAC suppressed."
+    },
+    {
+      "time": "2026-08-15T06:35:00",
+      "type": "temp_update",
+      "indoor_f": 69.0,
+      "outdoor_f": 58.6,
+      "note": "Indoor has drifted down to 69F overnight. time_to_floor = (69-68) / (0.0977*(69-58.6)) = 0.98hr < 1.0hr -- PROACTIVE_FLOOR exit fires. Window still open (never closed) -> _exit_nat_vent() pauses rather than restoring HVAC, and (Issue #641 fix) arms the 300s reactivation lockout."
+    },
+    {
+      "time": "2026-08-15T06:35:05",
+      "type": "temp_update",
+      "indoor_f": 69.0,
+      "outdoor_f": 58.6,
+      "note": "Next re-evaluation tick, 5s later, same reading -- matches the real incident's near-instant repeat. Before the fix: the paused-reactivation block's instant gate (outdoor 58.6 < indoor 69 - hysteresis) is still satisfied, so nat-vent reactivates immediately -- the flip-flop. After the fix: the lockout armed on the prior tick blocks this reactivation outright."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-08-15T06:35:05",
+      "expect": "paused_by_door",
+      "reason": "The reactivation lockout armed by the proactive-floor exit at 06:35:00 must still be blocking reactivation 5s later -- reactivating here would reproduce the reported rapid on/off WHF cycling."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "A proactive-floor exit with a window still open correctly stays paused through the very next re-evaluation tick instead of immediately reactivating and repeating -- the WHF fast-cycling incident this issue reported."
+  }
+}


### PR DESCRIPTION
## Summary
- Root cause: `PROACTIVE_FLOOR`/`CEILING_THRESHOLD` exits (and `fan_thermostat_check()`'s `STOP_DEACTIVATE`) handed off into the paused-reactivation block without arming the existing 300s reactivation lockout, letting the very next tick immediately reverse the exit — the reported once-a-minute WHF cycling. All three now arm the lockout the same way the outdoor-rise exit already did.
- Defense-in-depth: new `_fan_toggle_rate_limited()` hard-floors any CA-issued fan reversal to 300s regardless of cause, logs a WARNING, and raises a new proactive `fan_rapid_cycling` incident. Surfaced on the WHF status card.
- `fan_min_runtime_per_hour`'s cycling decisions now floor their phase durations at the same 300s minimum so a short-configured cycle can't collide with the new rate limit.
- New AST coverage-registry test (`tests/test_nat_vent_exit_lockout_coverage.py`) enforces every `_exit_nat_vent()` call site's lockout-arming decision going forward.

## Test plan
- [x] Full unit suite: 4479 passed, 6 skipped
- [x] Golden simulation suite: 81/81 passed
- [x] Pending simulation suite: 6/6 passed, including a new reproduction scenario for this incident (positive-controlled: confirmed to fail against pre-fix code)
- [x] `ruff check` / `ruff format` clean
- [x] `test_version_sync.py` passed (0.6.15 → 0.6.16)

Closes #641