### PR TITLE
Fix #647: shadow/FSM event-coverage gap caused chronic diagnostic disagreements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.19] — 2026-08-16
+
+- Fix #647: internal refactor only, no user-visible behavior change — the diagnostic-only shadow/FSM comparisons from the Block 5 series (0.6.13–0.6.17) were disagreeing with production on nearly every automation cycle, not just occasionally. A wiring gap left each FSM's tracked state stuck once a real manual override, grace period, or certain nat-vent exits occurred, instead of resetting once each finished. Fixed by feeding each FSM from every real production transition, not just the ones already replayed to the shadow engine. Purely observational — nothing it computes is ever acted on.
+
 ## [0.6.18] — 2026-08-15
 
 - Fix #645: after a redeploy or restart, the dashboard could briefly show HVAC mode 'cool' next to 'windows open (as planned)' — a monitored window/door sensor blipping unavailable-then-on during startup reset its change timestamp, which made the automation's debounce check treat the window as still settling and skip the guard that normally refuses to command an active HVAC mode through an open window. The compressor never actually ran in the reported case (the target temperature was still above the indoor reading), but on a warmer morning this could have let real cooling run with windows open. The guard now always blocks arming an active mode while a monitored window is open, regardless of that startup timing race.

--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -598,6 +598,7 @@ class ClimateAdvisorCancelOverrideView(HomeAssistantView):
         if not cancelled:
             return self.json({"status": "ok", "message": "No active override to cancel"})
 
+        coordinator._feed_override_grace_fsm_cancelled()  # Issue #647
         _schedule_reclassify_after_cancel(hass, coordinator, ae)
 
         return self.json(
@@ -657,6 +658,7 @@ class ClimateAdvisorCancelFanOverrideView(HomeAssistantView):
         if not cancelled:
             return self.json({"status": "ok", "message": "No active fan override to cancel."})
 
+        coordinator._feed_override_grace_fsm_cancelled()  # Issue #647
         _schedule_reclassify_after_cancel(hass, coordinator, ae)
 
         return self.json({"status": "ok", "message": "Fan override cleared."})

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,19 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.18"
+VERSION = "0.6.19"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.19": [
+        "Fix #647: the internal diagnostic that shadows automation decisions to verify"
+        " an in-progress refactor (added in #613/#633/#637/#639, most recently touched"
+        " by #643) was disagreeing with the real automation on nearly every cycle — a"
+        " wiring gap left it permanently stuck once a real manual override, grace"
+        " period, or certain nat-vent exits occurred, instead of resetting once each"
+        " finished. No occupant-visible behavior change — this only affects an internal"
+        " diagnostic used to validate the automation-engine refactor before any of it"
+        " goes live.",
+    ],
     "0.6.18": [
         "Fix #645: after a redeploy or restart, the dashboard could briefly show HVAC mode"
         " 'cool' next to 'windows open (as planned)' — a monitored window/door sensor blipping"
@@ -1790,6 +1800,48 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    647: {
+        "version_fixed": "0.6.19",
+        "title": "Shadow-engine/FSM diagnostics (#613/#633/#637/#639) disagreed with production on nearly every cycle",
+        "scope_covered": (
+            "coordinator.py: the three lifecycle FSM diagnostics (nat-vent #633, door/window"
+            " #637, override/grace #639) each carry their own tracked state across calls, but"
+            " the 'which production call site re-evaluates the FSM' coverage was far narrower"
+            " than the actual set of production functions mutating the tracked fields. Root"
+            " cause traced via live logs + code, not guessed: (1) override/grace — #643 wired"
+            " the entry event (handle_fan_manual_override -> OVERRIDE_DETECTED) but zero exit"
+            " events (confirm/self-resolve/cancel/grace-expiry) had any trigger at all, so the"
+            " very first real fan override after #643 shipped pushed the FSM into 'pending'"
+            " permanently; (2) door/window — _exit_nat_vent()'s sensor-still-open branch"
+            " (reached via the already-mirrored check_natural_vent_conditions) could set"
+            " _paused_by_door=True with no door/window FSM re-evaluation; (3) nat-vent — audited"
+            " all 10 production call paths mutating _natural_vent_active/_nat_vent_soft_start;"
+            " 9 were already mirrored to the shadow engine but only 1 (check_natural_vent_"
+            " conditions) re-ran the FSM. Fix decouples 'feed the FSM' from 'mirror to shadow':"
+            " _evaluate_override_grace_fsm() now takes an explicit OverrideGraceFsmEventKind"
+            " instead of deriving one from a mirror method name; automation.py's existing"
+            " _emit_event_callback stream (already fired at nearly every real transition) now"
+            " also feeds the FSMs via _feed_lifecycle_fsms_from_event(), reusing named events"
+            " that were verified emitted AFTER their state mutation completes (override_"
+            " cleared was deliberately excluded from this hook — it fires BEFORE the clear, so"
+            " cancel_override()/clear_manual_override()'s ~4 real coordinator.py/api.py call"
+            " sites instead call _feed_override_grace_fsm_cancelled() directly, post-return)."
+            " door_window_fsm.py's pre-existing but never-wired NAT_VENT_EXITED_SENSOR_STILL_"
+            "OPEN event kind is now fired, gated on a live any_monitored_sensor_open() read"
+            " (not the not-yet-updated _paused_by_door flag) to avoid forcing an incorrect"
+            " pause on a clean nat-vent exit. nat-vent's trigger set widened to also include"
+            " reconcile_fan_on_startup/on_fan_turned_off (both share the same decide_nat_vent_"
+            "gate() gate the FSM already models, unlike apply_classification's periodic/"
+            "incidental trigger, which remains deliberately excluded). Zero production HVAC"
+            " impact: the shadow engine's dry_run is permanently True and none of this FSM"
+            " state is ever written back to a decision path — confirmed by inspection, not"
+            " assumption. New regression coverage:"
+            " tests/test_shadow_engine_coverage.py::TestOverrideGraceFsmEventCoverage (an"
+            " AST/regex registry asserting every OverrideGraceFsmEventKind member is fed from"
+            " a real coordinator.py call site — the specific check that would have caught"
+            " #643's asymmetric entry-only wiring)."
+        ),
+    },
     645: {
         "version_fixed": "0.6.18",
         "title": "Sensor reconnect blip during restart made _sensor_debounce_pending() bypass the open-window guard",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, Final
 if TYPE_CHECKING:
     from .ai_skills import AISkillRegistry
     from .claude_api import ClaudeAPIClient
+    from .override_grace_fsm import OverrideGraceFsmEventKind
 
 from homeassistant.const import EVENT_CALL_SERVICE, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
@@ -386,6 +387,107 @@ _OVERRIDE_GRACE_FSM_EVENT_KINDS: dict[str, str] = {
     "resume_from_pause": "dashboard_resume",
     "handle_fan_manual_override": "override_detected",
 }
+
+# Issue #647: the mirror-name-keyed dicts above only ever covered FSM *entry* paths —
+# every FSM *exit* path (override confirmed/self-resolved/cleared/cancelled, grace
+# naturally expiring) has no `_mirror_to_shadow()` call site at all (see the block
+# comment above) and was therefore silently unreachable, leaving each FSM's carried
+# state permanently stuck once it entered a non-idle state. `automation.py` already
+# emits a named event via `_emit_event_callback` at every one of these transitions —
+# that stream reaches `_emit_event()` (below) regardless of shadow-mirror status, so
+# `_feed_lifecycle_fsms_from_event()` hooks there instead of adding new dedicated call
+# sites. `OverrideGraceFsmEventKind` values are looked up dynamically (not hardcoded
+# here) to avoid importing the FSM module at coordinator import time.
+_OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP: dict[str, str] = {
+    # _confirm_override_expired() closure (automation.py) — both branches resolve the
+    # same pending confirm window; the FSM re-derives which branch from its own fresh
+    # inputs, so one event kind covers both. Both branches emit AFTER their respective
+    # state mutation completes, so `self.automation_engine`'s live flags are already
+    # correct when `_feed_lifecycle_fsms_from_event()` reads them.
+    "override_confirmed": "override_confirm_expired",
+    "override_self_resolved": "override_confirm_expired",
+    # _on_grace_expired() — "adopted" is a distinct emitted event type for the one
+    # branch that returns early without also emitting "grace_expired"; both are the
+    # same underlying grace-timer-expiry transition from the FSM's point of view. Both
+    # emit only after `clear_manual_override()` has fully returned, same
+    # already-correct-by-the-time-we-read-it reasoning as above.
+    "grace_expired": "grace_timer_expired",
+    "override_adopted": "grace_timer_expired",
+    # Deliberately NOT "override_cleared": clear_manual_override() emits it *before*
+    # clearing `_manual_override_active` (the event payload needs the pre-clear
+    # was_mode/active_since values) — feeding the FSM there would read stale
+    # still-active state. cancel_override()/clear_manual_override() are called from a
+    # handful of real coordinator.py/api.py sites instead; those are fed directly,
+    # post-return, via `_feed_override_grace_fsm_cancelled()` below.
+}
+
+# Issue #647: `check_natural_vent_conditions` was, until now, the ONLY mirrored method
+# name that re-evaluated the nat-vent FSM — deliberately excluding `apply_classification`
+# (its own trigger is periodic/incidental, not gate/exit-adjacent — see
+# `_evaluate_nat_vent_fsm()`'s docstring and `test_nat_vent_fsm_shadow_wiring.py`'s
+# `test_not_triggered_by_unrelated_mirrored_call`, both left unchanged). `reconcile_fan_on_startup`
+# and `on_fan_turned_off` are added here because both mutate `_natural_vent_active` with
+# NO adjacent `_emit_event_callback` call `_feed_lifecycle_fsms_from_event()` could hook
+# instead (confirmed by inspection — `reconcile_fan_on_startup`'s "fan confirmed off"
+# branch and `on_fan_turned_off`'s `_clear_fan_flags_and_start_grace()` call are both
+# silent), AND both use the same shared `_nat_vent_may_reactivate()` -> `decide_nat_vent_gate()`
+# gate the FSM already models (automation.py:4160/Issue #417's consolidation) — unlike
+# `apply_classification`, these are genuine (if less common) instances of the same
+# gate/exit chain, not an unrelated periodic trigger. Both run production's real mutation
+# to completion before `_mirror_to_shadow()`'s finally block runs (production is always
+# called before its mirror), so there is no staleness risk reading `self.automation_engine`
+# here, unlike the event-type-driven hooks below.
+_NAT_VENT_FSM_TRIGGER_METHODS: frozenset[str] = frozenset(
+    {"check_natural_vent_conditions", "reconcile_fan_on_startup", "on_fan_turned_off"}
+)
+
+# Issue #647: nat-vent's own exit events (already emitted at every one of the 6 real
+# exit paths — see `_emit_event()`'s own #437-follow-up comment) are exactly the
+# moments `_natural_vent_active`/`_nat_vent_soft_start` change — re-running the TICK
+# re-evaluation here is not the "evaluating at a moment production never would" trap
+# `_evaluate_nat_vent_fsm()`'s docstring warns about (that was about periodic,
+# untied-to-a-transition triggers like `apply_classification`'s mirror); these are
+# 1:1 with a genuine production transition.
+_NAT_VENT_FSM_EVENT_TYPES: frozenset[str] = frozenset(
+    {
+        "nat_vent_soft_start_entered",
+        "nat_vent_comfort_floor_exit",
+        "nat_vent_away_ceiling_exit",
+        "nat_vent_predicted_floor_exit",
+        "nat_vent_outdoor_rise_exit",
+        "nat_vent_reconcile_exit",
+        "sensor_all_closed",
+        "fan_activated",
+        "fan_deactivated",
+        # handle_door_window_open()'s nat-vent-activation branch (automation.py:2968-2979)
+        "sensor_opened",
+        # apply_classification()'s ODE ceiling-guard escalation branch
+        # (automation.py:2120-2132) — a 7th real nat-vent exit path not covered by the
+        # canonical 6 listed in `_emit_event()`'s own #437-follow-up comment.
+        "nat_vent_ceiling_escalation",
+        # handle_bedtime()'s nat-vent-clearing branches (automation.py:4937/4964) —
+        # emitted unconditionally at the end of handle_bedtime() regardless of whether
+        # the clear branch fired; harmless extra evaluation when it didn't.
+        "bedtime_setback",
+    }
+)
+
+# Issue #647: `_exit_nat_vent()`'s sensor-still-open branch sets `_paused_by_door=True`
+# (automation.py:5390) — reachable from any of nat-vent's 5 real exit events. The
+# door/window FSM already has a purpose-built event kind for exactly this
+# (`NAT_VENT_EXITED_SENSOR_STILL_OPEN`, see door_window_fsm.py) that was never wired
+# to any trigger. Fired unconditionally on these event types — `transition()` reads
+# live sensor/pause state fresh each time and no-ops correctly when the sensor-open
+# branch wasn't the one actually taken.
+_DOOR_WINDOW_NAT_VENT_EXIT_EVENT_TYPES: frozenset[str] = frozenset(
+    {
+        "nat_vent_comfort_floor_exit",
+        "nat_vent_away_ceiling_exit",
+        "nat_vent_predicted_floor_exit",
+        "nat_vent_outdoor_rise_exit",
+        "nat_vent_reconcile_exit",
+    }
+)
 
 
 class ClimateAdvisorCoordinator(DataUpdateCoordinator):
@@ -810,7 +912,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 exc,
             )
         finally:
-            if method_name == "check_natural_vent_conditions":
+            if method_name in _NAT_VENT_FSM_TRIGGER_METHODS:
                 try:
                     self._evaluate_nat_vent_fsm()
                 except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
@@ -828,7 +930,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     )
             if method_name in _OVERRIDE_GRACE_FSM_EVENT_KINDS:
                 try:
-                    self._evaluate_override_grace_fsm(method_name)
+                    from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
+                    self._evaluate_override_grace_fsm(_OGFEventKind(_OVERRIDE_GRACE_FSM_EVENT_KINDS[method_name]))
                 except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
                     _LOGGER.warning(
                         "Override/grace FSM evaluation failed (isolated, no production impact): %s",
@@ -850,15 +954,24 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         mirror (see ``_mirror_to_shadow()``'s call site) — the one mirrored method
         that is unambiguously nat-vent's own periodic gate/exit re-evaluation point
         (``nat_vent_exit.py``'s own docstring: this is exactly the chain it
-        replaces). Deliberately NOT also triggered from ``apply_classification``/
-        ``reconcile_fan_on_startup``'s mirrors — neither actually runs the gate/exit
-        chain in production, so evaluating the FSM there would create a disagreement
-        from evaluating at a moment production itself never would (the exact class of
+        replaces). Issue #647 widened the trigger set (see
+        ``_NAT_VENT_FSM_TRIGGER_METHODS``) to also include ``reconcile_fan_on_startup``
+        and ``on_fan_turned_off`` — both genuine, if less common, instances of the same
+        shared ``decide_nat_vent_gate()`` chain (automation.py:4160), not the periodic/
+        incidental trigger ``apply_classification`` remains deliberately excluded for:
+        evaluating there would create a disagreement from evaluating at a moment
+        production itself never runs the gate/exit chain (the exact class of
         test-premise mistake caught and removed from this module's own differential
-        validation — see ``tests/test_nat_vent_fsm.py``'s in-test comment). Other
-        real gate/exit-adjacent call sites (``handle_door_window_open``,
-        ``nat_vent_temperature_check``, ``fan_thermostat_check``) are additional,
-        separately-scoped future work, not this increment.
+        validation — see ``tests/test_nat_vent_fsm.py``'s in-test comment, and
+        ``test_nat_vent_fsm_shadow_wiring.py``'s
+        ``test_not_triggered_by_unrelated_mirrored_call``, unchanged). Issue #647 also
+        added a second, event-driven trigger for this FSM — see
+        ``_feed_lifecycle_fsms_from_event()`` — for nat-vent's own named exit/activation
+        events, covering the remaining mutating call sites (``apply_classification``'s
+        ceiling-escalation branch, ``handle_door_window_open``, ``handle_bedtime``,
+        ``check_natural_vent_conditions``'s other exit branches) without re-running the
+        FSM on every unrelated ``apply_classification`` cycle the way a blanket
+        method-name trigger would.
 
         The FSM's own tracked state (``self._nat_vent_fsm_state``) is never written
         back onto either engine — this is a third, independent computation, purely
@@ -905,6 +1018,35 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         result = transition(self._nat_vent_fsm_state, event)
         self._nat_vent_fsm_state = result.to_state
 
+    def _door_window_fsm_inputs(self, ae: AutomationEngine, now: datetime, config: dict[str, Any]) -> Any:
+        """Build ``DoorWindowFsmInputs`` from production's current live readings.
+
+        Issue #647: extracted from ``_evaluate_door_window_fsm()`` so
+        ``_feed_lifecycle_fsms_from_event()``'s event-driven trigger (nat-vent exit
+        events) can build the identical inputs without duplicating this construction
+        — one source of truth for "what production state does this FSM read."
+        """
+        from .door_window_fsm import DoorWindowFsmInputs
+
+        return DoorWindowFsmInputs(
+            hvac_mode=self._current_hvac_mode(),
+            outdoor=ae._last_outdoor_temp,
+            indoor=ae._get_indoor_temp_f(),
+            comfort_heat=ae._nat_vent_reactivation_floor(),
+            comfort_cool=float(config.get("comfort_cool", DEFAULT_COMFORT_COOL)),
+            nat_vent_delta=float(config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA)),
+            fan_mode=str(config.get(CONF_FAN_MODE, "whole_house_fan")),
+            aggressive_savings=bool(config.get("aggressive_savings", False)),
+            within_planned_window=ae._is_within_planned_window_period(),
+            any_sensor_open=ae._any_monitored_sensor_open(),
+            sensor_debounce_pending=bool(ae._sensor_debounce_pending),
+            override_matches_current_decision=ae._override_matches_current_decision(ae._current_classification),
+            grace_source=ae._last_resume_source or "automation",
+            natural_vent_active=bool(ae._natural_vent_active),
+            whf_owns_hvac=bool(ae._whf_owns_hvac()),
+            now=now,
+        )
+
     def _evaluate_door_window_fsm(self, method_name: str) -> None:
         """Run the unified door/window pause/grace FSM (Issue #637) against
         production's current live readings and track its own independently-
@@ -918,8 +1060,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         comparison against production's real derived state. Isolated the same
         way: any exception here is logged and swallowed by the caller, never
         allowed to affect production.
+
+        Issue #647 adds a second, event-driven trigger for this same FSM — see
+        ``_feed_lifecycle_fsms_from_event()`` — for the ``NAT_VENT_EXITED_SENSOR_STILL_OPEN``
+        event kind, which no mirrored method name corresponds to.
         """
-        from .door_window_fsm import DoorWindowFsmEvent, DoorWindowFsmEventKind, DoorWindowFsmInputs, transition
+        from .door_window_fsm import DoorWindowFsmEvent, DoorWindowFsmEventKind, transition
 
         ae = self.automation_engine
         now = dt_util.now()
@@ -927,41 +1073,34 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
         event = DoorWindowFsmEvent(
             kind=DoorWindowFsmEventKind(_DOOR_WINDOW_FSM_EVENT_KINDS[method_name]),
-            inputs=DoorWindowFsmInputs(
-                hvac_mode=self._current_hvac_mode(),
-                outdoor=ae._last_outdoor_temp,
-                indoor=ae._get_indoor_temp_f(),
-                comfort_heat=ae._nat_vent_reactivation_floor(),
-                comfort_cool=float(config.get("comfort_cool", DEFAULT_COMFORT_COOL)),
-                nat_vent_delta=float(config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA)),
-                fan_mode=str(config.get(CONF_FAN_MODE, "whole_house_fan")),
-                aggressive_savings=bool(config.get("aggressive_savings", False)),
-                within_planned_window=ae._is_within_planned_window_period(),
-                any_sensor_open=ae._any_monitored_sensor_open(),
-                sensor_debounce_pending=bool(ae._sensor_debounce_pending),
-                override_matches_current_decision=ae._override_matches_current_decision(ae._current_classification),
-                grace_source=ae._last_resume_source or "automation",
-                natural_vent_active=bool(ae._natural_vent_active),
-                whf_owns_hvac=bool(ae._whf_owns_hvac()),
-                now=now,
-            ),
+            inputs=self._door_window_fsm_inputs(ae, now, config),
         )
         result = transition(self._door_window_fsm_state, event)
         self._door_window_fsm_state = result.to_state
 
-    def _evaluate_override_grace_fsm(self, method_name: str) -> None:
+    def _evaluate_override_grace_fsm(self, event_kind: OverrideGraceFsmEventKind) -> None:
         """Run the unified override/grace joint-lifecycle FSM (Issue #639) against
         production's current live readings and track its own independently-
         derived state.
 
-        v1 scope, narrowed to the 2 event kinds a mirrored method exists for today
-        (see ``_OVERRIDE_GRACE_FSM_EVENT_KINDS``) — same precedent as
-        ``_evaluate_door_window_fsm()``'s own v1 scope note. The FSM's own tracked
-        state (``self._override_grace_fsm_state``) is never written back onto
-        either engine — a third, independent computation, purely for comparison
-        against production's real derived state. Isolated the same way: any
-        exception here is logged and swallowed by the caller, never allowed to
-        affect production.
+        Issue #647: takes an explicit ``event_kind`` rather than deriving one from a
+        ``_mirror_to_shadow()`` method name — the FSM reads its inputs fresh from
+        **production** ``self.automation_engine`` every call (see below), never from
+        the shadow engine, so it has no actual dependency on whether the triggering
+        production call site also happens to replay onto the shadow engine. Coupling
+        "does this feed the FSM" to "does this have a mirror call site" (the original
+        v1 design) is what left every override/grace *exit* path — confirm, cancel,
+        clear, grace-timer-expiry — permanently unreachable, since none of those have
+        (or need) a shadow replay. Callers now pass the event kind explicitly: the 3
+        original mirrored entry points still resolve theirs via
+        ``_OVERRIDE_GRACE_FSM_EVENT_KINDS`` at the ``_mirror_to_shadow()`` call site;
+        the new exit-path callers (``_feed_lifecycle_fsms_from_event()``, driven by
+        ``_emit_event()``'s already-comprehensive event stream) resolve theirs via
+        ``_OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP``. The FSM's own tracked state
+        (``self._override_grace_fsm_state``) is never written back onto either engine
+        — a third, independent computation, purely for comparison against
+        production's real derived state. Isolated the same way: any exception here is
+        logged and swallowed by the caller, never allowed to affect production.
 
         ``current_setpoint_f``/``target_setpoint_f`` are resolved inline via the
         same ``select_comfort_band()`` + ``to_fahrenheit()`` sequence
@@ -972,7 +1111,6 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         """
         from .override_grace_fsm import (
             OverrideGraceFsmEvent,
-            OverrideGraceFsmEventKind,
             OverrideGraceFsmInputs,
         )
         from .override_grace_fsm import (
@@ -1008,7 +1146,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             target_setpoint_f = None
 
         event = OverrideGraceFsmEvent(
-            kind=OverrideGraceFsmEventKind(_OVERRIDE_GRACE_FSM_EVENT_KINDS[method_name]),
+            kind=event_kind,
             inputs=OverrideGraceFsmInputs(
                 confirm_seconds=float(config.get(CONF_OVERRIDE_CONFIRM_PERIOD, DEFAULT_OVERRIDE_CONFIRM_SECONDS)),
                 setpoint_override=bool(ae._override_confirm_source == "setpoint"),
@@ -1029,6 +1167,30 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         )
         result = _override_grace_transition(self._override_grace_fsm_state, event)
         self._override_grace_fsm_state = result.to_state
+
+    def _feed_override_grace_fsm_cancelled(self) -> None:
+        """Feed the override/grace FSM an ``OVERRIDE_CANCELLED`` event (Issue #647).
+
+        ``cancel_override()``/``clear_manual_override()`` emit their own
+        ``"override_cleared"`` event *before* clearing ``_manual_override_active``
+        (the event payload needs the pre-clear values), so
+        ``_feed_lifecycle_fsms_from_event()`` deliberately does not hook that event
+        type — it would read stale, still-active state. Call this instead, after the
+        real ``cancel_override()``/``clear_manual_override()`` call has fully
+        returned, at each of the handful of real coordinator.py/api.py call sites —
+        by then ``self.automation_engine``'s flags are correctly cleared. Isolated the
+        same way every other FSM-feed call site is: an exception here is logged and
+        swallowed, never allowed to affect production.
+        """
+        try:
+            from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
+            self._evaluate_override_grace_fsm(_OGFEventKind.OVERRIDE_CANCELLED)
+        except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
+            _LOGGER.warning(
+                "Override/grace FSM evaluation (cancel-driven) failed (isolated, no production impact): %s",
+                fsm_exc,
+            )
 
     def _current_hvac_mode(self) -> str | None:
         """Live thermostat mode read, shared by the door/window FSM evaluation
@@ -2384,6 +2546,19 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         )
         _grace_end = ae._grace_end_time
         ae._cancel_grace_timers()
+        # Issue #647: this clears `_grace_active` directly via `_cancel_grace_timers()`,
+        # not via `clear_manual_override()`/`_on_grace_expired()` — a distinct mutation
+        # path with no other FSM feed. Closest semantic match is GRACE_TIMER_EXPIRED
+        # (grace ending with nothing left to protect).
+        try:
+            from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
+            self._evaluate_override_grace_fsm(_OGFEventKind.GRACE_TIMER_EXPIRED)
+        except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
+            _LOGGER.warning(
+                "Override/grace FSM evaluation (orphaned-grace-driven) failed (isolated, no production impact): %s",
+                fsm_exc,
+            )
         self._emit_event(
             "stuck_grace_recovered",
             {"grace_end_time": _grace_end, "reason": "grace_without_override"},
@@ -2681,6 +2856,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     _stale_mode = _ae._manual_override_mode
                     _stale_since = _ae._manual_override_time
                     _ae.clear_manual_override(reason="stuck_grace_recovery")
+                    self._feed_override_grace_fsm_cancelled()
                     self._emit_event(
                         "stuck_grace_recovered",
                         {
@@ -4268,6 +4444,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 self.automation_engine._manual_override_mode,
             )
             self.automation_engine.clear_manual_override(reason="new_override_during_grace")
+            # Issue #647: only feeds OVERRIDE_CANCELLED for the clear half of this
+            # clear-then-reopen sequence — `handle_manual_override()` right below has
+            # no FSM entry wiring yet (same follow-up class as #643's
+            # `handle_fan_manual_override`, tracked separately, not this issue's scope).
+            # Still strictly better than leaving the FSM stuck on the just-cleared
+            # override's stale state.
+            self._feed_override_grace_fsm_cancelled()
             self.automation_engine.handle_manual_override(
                 old_mode=old_state.state,
                 new_mode=new_state.state,
@@ -7332,6 +7515,70 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         if getattr(self, "_nat_vent_was_active", False) and not _nat_vent_active_now:
             self._maybe_reschedule_pre_cool_on_nat_vent_exit()
         self._nat_vent_was_active = _nat_vent_active_now
+
+        self._feed_lifecycle_fsms_from_event(event_type)
+
+    def _feed_lifecycle_fsms_from_event(self, event_type: str) -> None:
+        """Re-evaluate the lifecycle FSMs whose tracked state this event just changed
+        in production (Issue #647).
+
+        Production-only — this is called from ``_emit_event`` (the real
+        ``AutomationEngine``'s callback), never from ``_on_shadow_emit_event`` (the
+        shadow engine's own event sink), matching every other ``_evaluate_*_fsm()``
+        call site's convention of reading ``self.automation_engine`` (production),
+        never the shadow engine. Each branch is isolated exactly like
+        ``_mirror_to_shadow()``'s own finally block: an exception here is logged and
+        swallowed, never allowed to affect production.
+        """
+        if event_type in _NAT_VENT_FSM_EVENT_TYPES:
+            try:
+                self._evaluate_nat_vent_fsm()
+            except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
+                _LOGGER.warning(
+                    "Nat-vent FSM evaluation (event-driven) failed (isolated, no production impact): %s",
+                    fsm_exc,
+                )
+        if event_type in _DOOR_WINDOW_NAT_VENT_EXIT_EVENT_TYPES:
+            try:
+                from .door_window_fsm import DoorWindowFsmEvent, DoorWindowFsmEventKind
+                from .door_window_fsm import transition as _door_window_transition
+
+                ae = self.automation_engine
+                # NAT_VENT_EXITED_SENSOR_STILL_OPEN's transition() unconditionally
+                # pauses (door_window_fsm.py:255-261) — it does not itself re-check
+                # any_sensor_open, so this event kind must only be sent when the
+                # sensor really is open, or every nat-vent exit (including a clean
+                # one) would incorrectly force a pause the FSM never should have
+                # entered. Read live sensor state directly rather than
+                # `ae._paused_by_door` — `_exit_nat_vent()` (which sets that flag)
+                # runs *after* the exit event these event types are emitted for
+                # (automation.py's own "caller emits its own specific event before
+                # calling this method" convention), so `_paused_by_door` is still
+                # last-cycle's stale value at this point; the live sensor read isn't.
+                if ae._any_monitored_sensor_open():
+                    now = dt_util.now()
+                    config = self.config
+                    event = DoorWindowFsmEvent(
+                        kind=DoorWindowFsmEventKind.NAT_VENT_EXITED_SENSOR_STILL_OPEN,
+                        inputs=self._door_window_fsm_inputs(ae, now, config),
+                    )
+                    result = _door_window_transition(self._door_window_fsm_state, event)
+                    self._door_window_fsm_state = result.to_state
+            except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
+                _LOGGER.warning(
+                    "Door/window FSM evaluation (event-driven) failed (isolated, no production impact): %s",
+                    fsm_exc,
+                )
+        if event_type in _OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP:
+            try:
+                from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
+                self._evaluate_override_grace_fsm(_OGFEventKind(_OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP[event_type]))
+            except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
+                _LOGGER.warning(
+                    "Override/grace FSM evaluation (event-driven) failed (isolated, no production impact): %s",
+                    fsm_exc,
+                )
 
     def _resolve_active_comfort_band(self) -> tuple[float | None, float | None]:
         """Resolve the currently-active (comfort_heat, comfort_cool) band.

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.18"
+  "version": "0.6.19"
 }

--- a/tests/test_override_grace_fsm_shadow_wiring.py
+++ b/tests/test_override_grace_fsm_shadow_wiring.py
@@ -2,13 +2,15 @@
 joint-lifecycle FSM live against production's real readings, tracked as a third
 comparison point alongside the existing production/shadow mirror comparison.
 
-v1 scope, deliberately narrow (see ``coordinator._evaluate_override_grace_fsm()``'s
-own docstring and ``_OVERRIDE_GRACE_FSM_EVENT_KINDS``): only triggered from the 2
-mirrored methods with an unambiguous override/grace FSM event-kind correspondence
-(``handle_manual_override_during_pause``, ``resume_from_pause``) — of the 7
-``OverrideGraceFsmEventKind`` members, the other 5 have no ``_mirror_to_shadow(...)``
-call site today (see ``_sync_shadow_inputs()``'s own docstring and
-``tests/test_shadow_engine_coverage.py``'s registry). Mirrors
+Issue #647: ``_evaluate_override_grace_fsm()`` now takes an explicit
+``OverrideGraceFsmEventKind`` rather than deriving one from a mirrored method name —
+see its own docstring and ``_OVERRIDE_GRACE_FSM_EVENT_KINDS``/
+``_OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP``. The 3 originally-mirrored entry points
+(``handle_manual_override_during_pause``, ``resume_from_pause``,
+``handle_fan_manual_override``) still resolve their event kind via the mirror-name
+dict at the ``_mirror_to_shadow()`` call site; every override/grace *exit* path
+(confirm/self-resolve/cancel/grace-expiry) is now also reachable — see
+``tests/test_shadow_engine_coverage.py``'s registry. Mirrors
 ``tests/test_door_window_fsm_shadow_wiring.py``'s structure.
 """
 
@@ -17,6 +19,7 @@ from __future__ import annotations
 import logging
 
 from custom_components.climate_advisor.const import CONF_OVERRIDE_CONFIRM_PERIOD
+from custom_components.climate_advisor.override_grace_fsm import OverrideGraceFsmEventKind
 from custom_components.climate_advisor.override_grace_lifecycle import GraceState, OverrideConfirmState
 from tools.sim_harness._loop import run_coro
 from tools.sim_harness.build_coordinator import build_headless_coordinator
@@ -37,8 +40,8 @@ def _noop_shadow_methods(coordinator, *names: str) -> None:
 class TestFsmEvaluationScoping:
     def test_not_triggered_by_unrelated_mirrored_call(self) -> None:
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
-        called: list[str] = []
-        coordinator._evaluate_override_grace_fsm = lambda method_name: called.append(method_name)  # type: ignore[method-assign]
+        called: list[OverrideGraceFsmEventKind] = []
+        coordinator._evaluate_override_grace_fsm = lambda event_kind: called.append(event_kind)  # type: ignore[method-assign]
 
         _noop_shadow_methods(coordinator, "apply_classification")
         _run(coordinator._mirror_to_shadow("apply_classification", None))
@@ -46,8 +49,8 @@ class TestFsmEvaluationScoping:
 
     def test_not_triggered_by_door_window_only_mirrored_call(self) -> None:
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
-        called: list[str] = []
-        coordinator._evaluate_override_grace_fsm = lambda method_name: called.append(method_name)  # type: ignore[method-assign]
+        called: list[OverrideGraceFsmEventKind] = []
+        coordinator._evaluate_override_grace_fsm = lambda event_kind: called.append(event_kind)  # type: ignore[method-assign]
 
         _noop_shadow_methods(coordinator, "handle_door_window_open")
         _run(coordinator._mirror_to_shadow("handle_door_window_open", "binary_sensor.test"))
@@ -55,21 +58,21 @@ class TestFsmEvaluationScoping:
 
     def test_triggered_by_handle_manual_override_during_pause(self) -> None:
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
-        called: list[str] = []
-        coordinator._evaluate_override_grace_fsm = lambda method_name: called.append(method_name)  # type: ignore[method-assign]
+        called: list[OverrideGraceFsmEventKind] = []
+        coordinator._evaluate_override_grace_fsm = lambda event_kind: called.append(event_kind)  # type: ignore[method-assign]
 
         _noop_shadow_methods(coordinator, "handle_manual_override_during_pause")
         _run(coordinator._mirror_to_shadow("handle_manual_override_during_pause"))
-        assert called == ["handle_manual_override_during_pause"]
+        assert called == [OverrideGraceFsmEventKind.MANUAL_OVERRIDE_DURING_PAUSE]
 
     def test_triggered_by_resume_from_pause(self) -> None:
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
-        called: list[str] = []
-        coordinator._evaluate_override_grace_fsm = lambda method_name: called.append(method_name)  # type: ignore[method-assign]
+        called: list[OverrideGraceFsmEventKind] = []
+        coordinator._evaluate_override_grace_fsm = lambda event_kind: called.append(event_kind)  # type: ignore[method-assign]
 
         _noop_shadow_methods(coordinator, "resume_from_pause")
         _run(coordinator._mirror_to_shadow("resume_from_pause"))
-        assert called == ["resume_from_pause"]
+        assert called == [OverrideGraceFsmEventKind.DASHBOARD_RESUME]
 
 
 class TestFsmStateTracking:

--- a/tests/test_shadow_engine_coverage.py
+++ b/tests/test_shadow_engine_coverage.py
@@ -228,3 +228,85 @@ class TestShadowEngineCoverageRegistry:
         found = {"a_totally_new_method_not_in_registry"}
         unregistered = found - set(_COVERAGE_REGISTRY)
         assert unregistered == {"a_totally_new_method_not_in_registry"}
+
+
+# Issue #647: a second, independent registry — this one for whether each
+# OverrideGraceFsmEventKind (the FSM's own tracked-state re-evaluation trigger, distinct
+# from the shadow-mirror registry above) is actually reachable from coordinator.py/api.py.
+# #643 wired the entry kind (OVERRIDE_DETECTED) without wiring any exit kind, leaving the
+# FSM permanently stuck once a real fan override occurred — an asymmetric wiring change
+# that shipped with no test catching the imbalance. This registry is that test.
+#
+# "unreachable: <reason>" is for FSM event kinds that exist in the enum but have no real
+# production trigger today (documented, not silently missing).
+_OVERRIDE_GRACE_EVENT_KIND_REGISTRY: dict[str, str] = {
+    "OVERRIDE_DETECTED": "reachable",
+    "MANUAL_OVERRIDE_DURING_PAUSE": "reachable",
+    "DASHBOARD_RESUME": "reachable",
+    "OVERRIDE_CONFIRM_EXPIRED": "reachable",
+    "OVERRIDE_CANCELLED": "reachable",
+    "GRACE_TIMER_EXPIRED": "reachable",
+    "OVERRIDE_SUPERSEDED": (
+        "unreachable: no production code path emits this distinct kind today — the "
+        "closest real case (a mode change arriving during an active override grace, "
+        "coordinator.py's 'new_override_during_grace' branch) is fed OVERRIDE_CANCELLED "
+        "instead, since handle_manual_override()'s own FSM entry wiring is a separate, "
+        "already-tracked follow-up, not this issue's scope"
+    ),
+}
+
+
+class TestOverrideGraceFsmEventCoverage:
+    def test_every_event_kind_is_registered(self) -> None:
+        from custom_components.climate_advisor.override_grace_fsm import OverrideGraceFsmEventKind
+
+        all_kinds = {member.name for member in OverrideGraceFsmEventKind}
+        unregistered = all_kinds - set(_OVERRIDE_GRACE_EVENT_KIND_REGISTRY)
+        assert not unregistered, (
+            f"New OverrideGraceFsmEventKind member(s) aren't in "
+            f"_OVERRIDE_GRACE_EVENT_KIND_REGISTRY: {sorted(unregistered)}. Classify each "
+            f'as "reachable" (and wire a real trigger in coordinator.py/api.py) or '
+            f'"unreachable: <reason>" — see Issue #647.'
+        )
+
+    def test_registry_entries_reference_real_members(self) -> None:
+        from custom_components.climate_advisor.override_grace_fsm import OverrideGraceFsmEventKind
+
+        all_kinds = {member.name for member in OverrideGraceFsmEventKind}
+        unknown = set(_OVERRIDE_GRACE_EVENT_KIND_REGISTRY) - all_kinds
+        assert not unknown, (
+            f"Registry references OverrideGraceFsmEventKind member(s) that no longer "
+            f"exist (renamed or removed?): {sorted(unknown)}. Update the registry."
+        )
+
+    def test_every_reachable_kind_has_a_real_trigger(self) -> None:
+        """Positive control: every 'reachable' entry must appear as a value somewhere
+        coordinator.py actually feeds the FSM from — either of the two mirror-name-keyed
+        dicts, the event-type map, or a direct OverrideGraceFsmEventKind.<X> reference at
+        a real call site (e.g. _feed_override_grace_fsm_cancelled()). Catches the
+        registry claiming coverage that doesn't actually exist in code — this is the
+        specific check that would have caught #643 shipping OVERRIDE_DETECTED without
+        any exit kind wired."""
+        combined = _COORDINATOR_PY.read_text(encoding="utf-8")
+        for name, classification in _OVERRIDE_GRACE_EVENT_KIND_REGISTRY.items():
+            if classification != "reachable":
+                continue
+            # Matches either a dict value like "override_cancelled" (snake_case enum
+            # value, used by the two method-name/event-type-keyed dicts) or a direct
+            # member reference — coordinator.py imports OverrideGraceFsmEventKind under
+            # a local alias (`_OGFEventKind`) at every direct-call-site import, so match
+            # any `<name ending in EventKind or aliased>.MEMBER` shape rather than the
+            # literal unaliased class name.
+            value_pattern = re.compile(r'"' + re.escape(name.lower()) + r'"')
+            member_pattern = re.compile(r"\b\w*(?:EventKind|OGFEventKind)\." + re.escape(name) + r"\b")
+            assert value_pattern.search(combined) or member_pattern.search(combined), (
+                f'{name} is marked "reachable" but no dict value or direct '
+                f"OverrideGraceFsmEventKind.{name} reference was found in coordinator.py"
+            )
+
+    def test_positive_control_unregistered_kind_is_caught(self) -> None:
+        """Proves test_every_event_kind_is_registered actually fails on a genuinely
+        unregistered member, not just passing vacuously."""
+        all_kinds = {"A_TOTALLY_NEW_KIND_NOT_IN_REGISTRY"}
+        unregistered = all_kinds - set(_OVERRIDE_GRACE_EVENT_KIND_REGISTRY)
+        assert unregistered == {"A_TOTALLY_NEW_KIND_NOT_IN_REGISTRY"}


### PR DESCRIPTION
## Summary
- The nat-vent (#613/#633), door/window (#637), and override/grace (#639) shadow/FSM diagnostics were disagreeing with production on nearly every automation cycle, not occasionally — root-caused via live logs + code (five-whys writeup in the working plan), not guessed.
- `#643` shipped an asymmetric fix for this exact gap class: it wired the override/grace *entry* event but no *exit* event, so the very first real fan override after deploy pushed the FSM into `pending` and it never recovered.
- Fix decouples "feed the FSM" from "mirror to shadow" — `_evaluate_override_grace_fsm()` now takes an explicit event kind; `automation.py`'s existing per-transition `_emit_event_callback` stream now also feeds all three FSMs, with direct call sites for the couple of paths whose emitted event fires *before* the state mutation completes (verified per-path, not assumed).
- Adds a registry-enforced regression test (`test_shadow_engine_coverage.py::TestOverrideGraceFsmEventCoverage`) asserting every `OverrideGraceFsmEventKind` has a real trigger in `coordinator.py` — the specific check that would have caught #643's asymmetric wiring.

## Blast radius
Zero production impact — the shadow engine's `dry_run` is permanently `True` and none of this FSM state is ever written back to a decision path (confirmed by inspection). Only visible effect is the developer-facing "Shadow Engine" diagnostic sensor, which should now read `agree` during normal quiescent operation instead of chronically `disagree`.

## Test plan
- [x] Full test suite: 4487 passed, 6 skipped, 3 pre-existing/unrelated deselected (confirmed identical failures on `main` before this branch)
- [x] `ruff check`/`ruff format` clean
- [x] `tools/validate.py` clean
- [x] New `TestOverrideGraceFsmEventCoverage` registry test passes and was verified to actually catch the #643-class gap (sanity-checked the regex against the code)
- [ ] Live: watch `python tools/ha_logs.py` for a real nat-vent activate→exit cycle and a real fan-override→expiry cycle post-deploy, confirm zero disagreement warnings across each