### PR TITLE
Feat #633: nat-vent FSM Phase R prep — soft-start escalation modeled + opt-in cutover switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.22] — 2026-08-16
+
+- Feat #633 (Phase R prep): begins the cutover work for the nat-vent lifecycle FSM (Block 5 series, epic #594) — modeled the one remaining gap in its transition table (soft-start escalating to full free-cooling mid-session), and added an opt-in, off-by-default switch that lets the FSM's decision drive the real whole-house-fan/HVAC calls for nat-vent instead of the legacy inline computation. Proven behavior-identical to the legacy path across the full scenario library before this shipped. The switch defaults off and does not persist across a restart — no occupant-visible behavior change unless it is explicitly turned on.
+
 ## [0.6.21] — 2026-08-16
 
 - Fix #651: internal refactor only, no user-visible behavior change — two more gaps in the diagnostic-only shadow/FSM comparisons (Block 5 series, 0.6.13–0.6.20). A manual override made directly at the thermostat wasn't registering with the diagnostic at all (fan overrides already worked, since #643). A fan-only override cleared by the bedtime or morning-wakeup schedule now reflects immediately instead of self-correcting a cycle later. Purely observational — nothing it computes is ever acted on.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -766,6 +766,13 @@ class AutomationEngine:
         # coordinator's own persisted/restored history within one update cycle.
         self._outdoor_temp_today_peak: float | None = None
         self._outdoor_temp_today_sample_count: int = 0
+        # Issue #594 Phase R, Step 2: when True, the active-session portion of
+        # check_natural_vent_conditions() (soft-start escalation + exit-chain
+        # decision) routes through nat_vent_fsm.transition() as the single
+        # source of truth instead of a hand-duplicated inline computation.
+        # Default False — zero behavior change until a future per-lifecycle
+        # switch (Phase R, Step 4) flips it. Not yet exposed to config/switch.py.
+        self._natvent_fsm_authoritative: bool = False
 
         # Override confirmation period (Issue #76) — pending window before override is formally accepted
         self._override_confirm_pending: bool = False
@@ -3275,7 +3282,14 @@ class AutomationEngine:
             # session's outdoor/indoor delta independently clears the full bulk-cooling
             # gate, drop the qualifier — the session itself (fan, HVAC suppression, exit
             # hierarchy) is already running unchanged; only the status label changes.
-            if self._natural_vent_active and self._nat_vent_soft_start:
+            #
+            # Issue #594 Phase R, Step 2: when ``_natvent_fsm_authoritative`` is set,
+            # this upgrade check is skipped here and instead computed once, together
+            # with the exit-chain decision immediately below, via a single
+            # ``nat_vent_fsm.transition()`` call — the same pure escalation check
+            # (Issue #540, mirrored into ``nat_vent_fsm.py``), now read from one
+            # shared place instead of two independent copies of the same math.
+            if self._natural_vent_active and self._nat_vent_soft_start and not self._natvent_fsm_authoritative:
                 _indoor_upg = self._get_indoor_temp_f()
                 _comfort_heat_upg = self._nat_vent_reactivation_floor()
                 _hysteresis_upg = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
@@ -3319,6 +3333,37 @@ class AutomationEngine:
                     )
 
                 thermal = self._thermal_model or {}
+
+                # Issue #594 Phase R, Step 2: while FSM-authoritative, the
+                # soft-start escalation check (skipped above) is computed here via
+                # nat_vent_fsm.transition() instead of the hand-duplicated inline
+                # copy. The exit-chain decision immediately below is unchanged
+                # either way — it already called this same pure
+                # decide_nat_vent_exit() function directly, so there is nothing to
+                # swap there; the FSM's own transition() calls the identical
+                # function with the identical inputs (see tools/sim_harness's
+                # nat_vent_fsm_decision_compare.py for the equivalence proof).
+                if self._natvent_fsm_authoritative and self._nat_vent_soft_start:
+                    from .nat_vent_fsm import NatVentFsmEvent, NatVentFsmEventKind
+                    from .nat_vent_fsm import transition as _nat_vent_transition
+
+                    _fsm_current_state = self.nat_vent_lifecycle_state
+                    _fsm_inputs = self._build_nat_vent_fsm_inputs(now=dt_util.now(), indoor=indoor, outdoor=outdoor)
+                    _fsm_result = _nat_vent_transition(
+                        _fsm_current_state, NatVentFsmEvent(kind=NatVentFsmEventKind.TICK, inputs=_fsm_inputs)
+                    )
+                    if (
+                        _fsm_current_state == NatVentLifecycleState.ACTIVE_SOFT_START
+                        and _fsm_result.to_state == NatVentLifecycleState.ACTIVE_FULL_GATE
+                    ):
+                        self._nat_vent_soft_start = False
+                        _LOGGER.info(
+                            "Nat-vent soft-start upgraded to full free-cooling (FSM-authoritative):"
+                            " outdoor %.1f°F, indoor %.1f°F",
+                            outdoor if outdoor is not None else 0.0,
+                            indoor if indoor is not None else 0.0,
+                        )
+
                 exit_decision = decide_nat_vent_exit(
                     NatVentExitInputs(
                         indoor=indoor,
@@ -5490,6 +5535,42 @@ class AutomationEngine:
         if _in_sleep_window(dt_util.now(), self.config):
             return float(self.config.get(CONF_SLEEP_HEAT, comfort_heat))
         return comfort_heat
+
+    def _build_nat_vent_fsm_inputs(self, *, now: datetime, indoor: float | None, outdoor: float | None):
+        """Build the FSM's input snapshot from current engine state (Issue #594
+        Phase R, Step 2). Same field set ``coordinator._evaluate_nat_vent_fsm()``
+        already builds for the shadow-diagnostic comparison — kept as a single
+        definition callers on both sides can share rather than two independently
+        maintained copies of the same construction.
+        """
+        from .nat_vent_fsm import NatVentFsmInputs
+
+        comfort_heat_raw = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
+        thermal_model = self._thermal_model or {}
+        return NatVentFsmInputs(
+            indoor=indoor,
+            outdoor=outdoor,
+            comfort_heat_raw=comfort_heat_raw,
+            sleep_heat=float(self.config.get(CONF_SLEEP_HEAT, comfort_heat_raw)),
+            in_sleep_window=_in_sleep_window(now, self.config),
+            comfort_cool=float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL)),
+            nat_vent_delta=float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA)),
+            hysteresis=float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F)),
+            fan_mode=str(self.config.get(CONF_FAN_MODE, "whole_house_fan")),
+            aggressive_savings=bool(self.config.get("aggressive_savings", False)),
+            occupancy_mode=self._occupancy_mode,
+            thermal_confidence=thermal_model.get("confidence", "none"),
+            k_passive=thermal_model.get("k_passive"),
+            outdoor_today_peak=self._outdoor_temp_today_peak,
+            outdoor_sample_count=self._outdoor_temp_today_sample_count,
+            peak_decline_margin=PEAK_DECLINE_MARGIN_F,
+            paused_by_door=bool(self._paused_by_door),
+            outdoor_exit_time=self._nat_vent_outdoor_exit_time,
+            lockout_seconds=float(
+                self.config.get(CONF_NAT_VENT_REACTIVATION_LOCKOUT_S, NAT_VENT_REACTIVATION_LOCKOUT_S)
+            ),
+            now=now,
+        )
 
     @property
     def nat_vent_lifecycle_state(self) -> NatVentLifecycleState:

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.21"
+VERSION = "0.6.22"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.22": [
+        "Feat #633 (Phase R prep): begins the cutover work for the nat-vent lifecycle"
+        " FSM — modeled the one remaining gap in its transition table (soft-start"
+        " escalating to full free-cooling mid-session), and added an opt-in,"
+        " off-by-default switch that lets the FSM's decision drive the real"
+        " whole-house-fan/HVAC calls for nat-vent instead of the legacy inline"
+        " computation. Proven behavior-identical to the legacy path across the full"
+        " scenario library before this shipped. The switch defaults off and does not"
+        " persist across a restart — no occupant-visible behavior change unless it is"
+        " explicitly turned on.",
+    ],
     "0.6.21": [
         "Fix #651: closed two more gaps in the internal diagnostic that shadows"
         " automation decisions to verify an in-progress refactor (#613/#633/#637/#639,"
@@ -2089,16 +2100,20 @@ KNOWN_FIXES: dict[int, dict] = {
         ),
     },
     633: {
-        "version_fixed": "0.6.13",
+        "version_fixed": "0.6.22",
         "title": (
-            "Block 5 epic #594 Phase P completion: builds the unified nat-vent transition"
-            " table earlier Phase P sub-issues (#606/#607, #608/#609) deliberately left"
-            " unbuilt, plus a generic cross-lifecycle event dispatcher for coordinating"
-            " between the automation's independently-migrated behaviors going forward,"
-            " then wires the transition table to actually run live (0.6.13) as a third,"
-            " independent comparison point alongside the existing production/shadow"
-            " mirror. Purely observational at every stage — never wired into any"
-            " decision path that can act."
+            "Block 5 epic #594 Phase P completion (0.6.12-0.6.13), then Phase R prep"
+            " (0.6.22): builds the unified nat-vent transition table earlier Phase P"
+            " sub-issues (#606/#607, #608/#609) deliberately left unbuilt, plus a generic"
+            " cross-lifecycle event dispatcher for coordinating between the automation's"
+            " independently-migrated behaviors going forward, then wires the transition"
+            " table to actually run live (0.6.13) as a third, independent comparison point"
+            " alongside the existing production/shadow mirror. Purely observational through"
+            " 0.6.13. 0.6.22 begins the actual cutover work: models the transition table's"
+            " last documented gap (soft-start mid-session escalation) and adds an opt-in,"
+            " off-by-default switch letting the FSM's decision drive real HVAC/fan calls —"
+            " the first point in this epic capable of that, proven behavior-identical to"
+            " the legacy path before shipping."
         ),
         "scope_covered": (
             "0.6.12: New: lifecycle_events.py (cross-lifecycle event vocabulary), "
@@ -2117,7 +2132,23 @@ KNOWN_FIXES: dict[int, dict] = {
             "production). The FSM's tracked state is never written onto either engine. Surfaced "
             "via the existing ClimateAdvisorShadowEngineStatusSensor's nat_vent_fsm_state attribute, "
             "folded into its overall agree/disagree value. 10 new coordinator-level tests + 2 new "
-            "sensor tests."
+            "sensor tests. "
+            "0.6.22: nat_vent_fsm.py's _transition_from_active() now re-checks decide_nat_vent_gate() "
+            "while ACTIVE_SOFT_START, mirroring automation.py's own soft-start-upgrade block (Issue #540) "
+            "exactly. AutomationEngine._natvent_fsm_authoritative (default False, automation.py): when set, "
+            "check_natural_vent_conditions()'s soft-start-escalation read routes through "
+            "nat_vent_fsm.transition() instead of a hand-duplicated inline copy — the exit-chain decision "
+            "already called decide_nat_vent_exit() directly, so nothing changed there. New "
+            "tools/sim_harness/nat_vent_fsm_authoritative_compare.py + "
+            "tests/test_nat_vent_fsm_authoritative_compare.py (90 tests): full golden+pending corpus "
+            "decision-equivalence proof (entire event_log/action_log diff, not a state label) — found and "
+            "fixed a latent false-positive bug in tools/sim_harness/differential.py's action-log "
+            "canonicalization (a per-call random Context id was being compared as decision content). New "
+            "switch.climate_advisor_nat_vent_fsm_authoritative (switch.py) + "
+            "ClimateAdvisorCoordinator.set_natvent_fsm_authoritative()/natvent_fsm_authoritative "
+            "(coordinator.py), off by default, deliberately not persisted across restart. Surfaced on "
+            "ClimateAdvisorShadowEngineStatusSensor's existing attributes (sensor.py), not a new card. "
+            "4 new coordinator-plumbing tests."
         ),
     },
     631: {

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1383,6 +1383,29 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         )
         self.hass.async_create_task(self._async_save_state())
 
+    @property
+    def natvent_fsm_authoritative(self) -> bool:
+        """Whether the nat-vent lifecycle FSM (Issue #633) is authoritative for
+        the active-session soft-start-escalation + exit-chain read (Issue #594
+        Phase R, Step 4). False = legacy inline computation (default)."""
+        return bool(self.automation_engine._natvent_fsm_authoritative)
+
+    def set_natvent_fsm_authoritative(self, enabled: bool) -> None:
+        """Flip nat-vent FSM authority — Step 2's read-authority swap, live.
+
+        Deliberately NOT persisted across restart (unlike ``automation_enabled``
+        above): this is the epic's first switch capable of letting a bug in new
+        code reach real hardware (see epic #594's Phase R risk framing), so a
+        restart always comes back up on the proven legacy path — the owner must
+        explicitly re-enable it each time, rather than an unattended restart
+        silently carrying the FSM-authoritative choice forward.
+        """
+        self.automation_engine._natvent_fsm_authoritative = enabled
+        _LOGGER.warning(
+            "Nat-vent FSM %s for production decisions (Issue #594 Phase R)",
+            "made authoritative" if enabled else "reverted to legacy computation",
+        )
+
     async def async_setup(self) -> None:
         """Set up scheduled events and state listeners."""
 

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.21"
+  "version": "0.6.22"
 }

--- a/custom_components/climate_advisor/nat_vent_fsm.py
+++ b/custom_components/climate_advisor/nat_vent_fsm.py
@@ -24,21 +24,29 @@ event) alone — no hidden extra memory. This is why ``ACTIVE_SOFT_START`` and
 an out-of-band "how did we get here" flag (this precedent already exists in
 ``nat_vent_lifecycle.py``, reused here).
 
-**Explicit scope boundary — soft-start escalation, and the idle-open widening.**
-Two production behaviors are NOT modeled by this v1 table, on purpose, because
-neither is evidenced by the 3 existing pure pieces this module assembles (only
-production's own inline code has them, and folding them in here would silently
-introduce new, unvalidated behavior — the same discipline
-``nat_vent_exit.py``'s own docstring already applies to its excluded exit
-paths):
-  1. Escalation from ``ACTIVE_SOFT_START`` to ``ACTIVE_FULL_GATE`` mid-session
-     if full-gate conditions later become true while soft-start is active.
-  2. The ``_idle_open`` widening in ``check_natural_vent_conditions()``
-     (Issue #244/#402/#504/#620) — a contact-sensor-open-but-HVAC-idle
-     reactivation path with its own grace/debounce gating, layered on top of
-     (not part of) ``decide_nat_vent_gate()`` itself.
-Both are candidates for a future revision once evidenced by their own pure
-extraction, same as this module's own 3 building blocks were.
+**v2 (Phase R prep, Issue #594 follow-up): soft-start escalation now modeled.**
+``_transition_from_active()`` re-checks ``decide_nat_vent_gate()`` — the same
+pure function ``_transition_from_inactive()`` already calls — whenever the
+current state is ``ACTIVE_SOFT_START``, before running the exit chain. This
+mirrors production's own upgrade check at ``automation.py``'s
+"soft-start → full nat-vent upgrade" block (Issue #540), which independently
+re-evaluates the identical full-gate condition each active tick. No new
+decision logic was written — this reuses the one pure function already in
+scope, the same discipline every other piece of this module already follows.
+
+**Still-explicit scope boundary — the ``_idle_open`` widening.** Not modeled,
+but re-classified: this is not omitted decision logic, it's a **caller-side
+triggering precondition**. ``check_natural_vent_conditions()``
+(Issue #244/#402/#504/#620) only re-evaluates reactivation on a given tick if
+a contact sensor is open, HVAC is idle, debounce has settled, and grace isn't
+blocking it (or grace + over-ceiling). That gate decides *whether this FSM's
+entry logic runs at all this tick*, not what it should decide once run — the
+same relationship ``paused_by_door`` already has to this module (an external
+fact fed in, not re-derived here). Once Step 2's cutover work makes this FSM's
+``transition()`` the thing production's own call site invokes, it will
+naturally only fire when that same precondition already holds, since it's the
+same call site — no separate modeling needed inside the transition table
+itself.
 
 **Cross-lifecycle inputs.** ``paused_by_door`` is a state *read* from the
 door/window lifecycle (Issue #631's "communicating automata" design) — legacy
@@ -174,10 +182,19 @@ def _soft_start_inputs(inputs: NatVentFsmInputs, *, full_gate_active: bool) -> N
 
 
 def _transition_from_active(current_state: NatVentLifecycleState, event: NatVentFsmEvent) -> NatVentTransition:
+    # Issue #540 (mirrored, Phase R prep): while soft-started, re-check the full
+    # gate each tick — same pure function, same condition production's own
+    # upgrade block re-evaluates. Escalating doesn't change the exit-chain
+    # outcome below (decide_nat_vent_exit() treats soft-start and full-gate
+    # identically), it only changes what state a NONE-exit tick lands on.
+    escalated_state = current_state
+    if current_state == NatVentLifecycleState.ACTIVE_SOFT_START and decide_nat_vent_gate(_gate_inputs(event.inputs)):
+        escalated_state = NatVentLifecycleState.ACTIVE_FULL_GATE
+
     decision = decide_nat_vent_exit(_exit_inputs(event.inputs))
     if decision.reason == NatVentExitReason.NONE:
         return NatVentTransition(
-            from_state=current_state, to_state=current_state, event_kind=event.kind, at=event.inputs.now
+            from_state=current_state, to_state=escalated_state, event_kind=event.kind, at=event.inputs.now
         )
 
     # Only the outdoor-rise exit records an outdoor_exit_time in production

--- a/custom_components/climate_advisor/sensor.py
+++ b/custom_components/climate_advisor/sensor.py
@@ -501,4 +501,9 @@ class ClimateAdvisorShadowEngineStatusSensor(ClimateAdvisorBaseSensor):
             "shadow_state": diag["shadow_state"],
             "nat_vent_fsm_state": diag.get("nat_vent_fsm_state"),
             "checked_at": diag["checked_at"],
+            # Issue #594 Phase R, Step 4: whether the nat-vent FSM is currently
+            # authoritative for production decisions (vs. the legacy inline
+            # computation). Surfaced here rather than a new card/sensor, same
+            # "extend an existing diagnostic" rule this sensor itself follows.
+            "natvent_fsm_authoritative": self.coordinator.natvent_fsm_authoritative,
         }

--- a/custom_components/climate_advisor/switch.py
+++ b/custom_components/climate_advisor/switch.py
@@ -5,6 +5,9 @@ When turned off, all computation continues but thermostat and notification
 service calls are skipped and logged with a [DRY RUN] prefix.
 
 See: GitHub Issue #19
+
+Issue #594 Phase R, Step 4: also provides the per-lifecycle nat-vent
+FSM-authoritative toggle.
 """
 
 from __future__ import annotations
@@ -31,7 +34,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up Climate Advisor switch entities from a config entry."""
     coordinator: ClimateAdvisorCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([ClimateAdvisorAutomationSwitch(coordinator, entry)])
+    async_add_entities(
+        [
+            ClimateAdvisorAutomationSwitch(coordinator, entry),
+            ClimateAdvisorNatVentFsmAuthoritativeSwitch(coordinator, entry),
+        ]
+    )
 
 
 class ClimateAdvisorAutomationSwitch(CoordinatorEntity, SwitchEntity):
@@ -67,4 +75,49 @@ class ClimateAdvisorAutomationSwitch(CoordinatorEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable automation actions (enter observe-only mode)."""
         self.coordinator.set_automation_enabled(False)
+        self.async_write_ha_state()
+
+
+class ClimateAdvisorNatVentFsmAuthoritativeSwitch(CoordinatorEntity, SwitchEntity):
+    """Switch to make the nat-vent lifecycle FSM (Issue #633) authoritative for
+    the active-session soft-start-escalation + exit-chain decision, instead of
+    the legacy inline computation (Issue #594 Phase R, Step 4).
+
+    Default OFF. Unlike the automation-enable switch above, this is NOT
+    persisted across a Home Assistant restart — see
+    ``ClimateAdvisorCoordinator.set_natvent_fsm_authoritative()``'s docstring:
+    a restart always comes back up on the proven legacy path, and the owner
+    must explicitly re-enable this each time. This is the first switch in the
+    Block 5 migration capable of letting a bug in new code reach real
+    HVAC/fan hardware (every prior shadow-diagnostic phase was `dry_run=True`
+    by construction) — instantly reversible, but not something that should
+    silently persist through an unattended restart.
+    """
+
+    _attr_icon = "mdi:state-machine"
+    _attr_entity_category = None
+
+    def __init__(
+        self,
+        coordinator: ClimateAdvisorCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the nat-vent FSM-authoritative switch."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_natvent_fsm_authoritative"
+        self._attr_name = "Climate Advisor Nat-Vent FSM Authoritative"
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the nat-vent FSM is authoritative for production decisions."""
+        return self.coordinator.natvent_fsm_authoritative
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Make the nat-vent FSM authoritative."""
+        self.coordinator.set_natvent_fsm_authoritative(True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Revert to the legacy inline nat-vent computation."""
+        self.coordinator.set_natvent_fsm_authoritative(False)
         self.async_write_ha_state()

--- a/docs/nat-vent-lifecycle-spec.md
+++ b/docs/nat-vent-lifecycle-spec.md
@@ -17,6 +17,7 @@
 | Does `check_natural_vent_conditions()`'s exit chain always decide WHY a session ends? | No — confirmed by direct experiment (Issue #608): `nat_vent_temperature_check()` and `fan_thermostat_check()` (both dispatched from the same `temp_update`/thermostat-attribute-change trigger, both already pure-extracted by Issue #441) run FIRST and independently implement equivalent comfort-floor and outdoor-rise-style stops — they win the race and exit the session before `check_natural_vent_conditions()`'s chain ever evaluates, for every golden scenario tested. | [Known Duplicate-Logic Race](#known-duplicate-logic-race-issue-608-finding) |
 | Has a shadow engine instance been proven safe to construct alongside production, offline? | Yes — `tools/sim_harness/shadow_engine_pair.py` (Issue #611) proves, across 60 offline-eligible golden+pending scenarios, that a dry_run=True shadow instance never issues a real action AND never changes what production itself does. | [Offline Whole-Engine Shadow-Pair Validation](#offline-whole-engine-shadow-pair-validation-issue-611-subtask-o) |
 | Is there a real, live shadow engine running inside the coordinator today, and is its coverage complete? | Yes to both — `coordinator.shadow_automation_engine` (Issue #613), permanently `dry_run=True`, mirrors all 13 real nat-vent entry points, the 3 input-data attributes they depend on (Issue #615), and the 7 grace/override lifecycle-gate fields plus companions (Issue #631) — enforced by an AST-based coverage registry test so new gaps can't ship silently. Zero occupant/HVAC impact; surfaced via a diagnostic sensor, not any Status-tab card. | [Live Shadow Engine](#live-shadow-engine-issue-613-subtask-q) |
+| Can the nat-vent FSM actually drive real HVAC/fan hardware yet? | Not by default — `AutomationEngine._natvent_fsm_authoritative` (off by default, not persisted across restart) and its `switch.climate_advisor_nat_vent_fsm_authoritative` entity exist and are proven behavior-identical to the legacy path, but this is the first switch in the migration able to reach real hardware if flipped. | [Phase R prep](#phase-r-prep-soft-start-escalation-modeled--opt-in-cutover-switch-issue-633-epic-594) |
 
 ## Scope
 
@@ -285,7 +286,10 @@ they previously hardcoded the state-transition text unconditionally).
 - [`ClimateAdvisorCoordinator._sync_shadow_inputs`](../custom_components/climate_advisor/coordinator.py) — input-data parity, full-coverage decision mirroring (Issue #615), extended to grace/override state (Issue #631)
 - [`tests/test_shadow_engine_coverage.py`](../tests/test_shadow_engine_coverage.py) — AST-based coverage registry, durable enforcement (Issue #615, #631)
 - [`ClimateAdvisorShadowEngineStatusSensor`](../custom_components/climate_advisor/sensor.py) — diagnostic sensor (Issue #613)
-- [`nat_vent_fsm.transition`](../custom_components/climate_advisor/nat_vent_fsm.py) — the unified `(state, event) -> Transition` table assembling the 3 pieces above (Issue #633, Block 5 Phase P completion). See the module's own docstring for its declared scope boundaries (soft-start escalation, `_idle_open` widening — both deliberately out of v1).
+- [`nat_vent_fsm.transition`](../custom_components/climate_advisor/nat_vent_fsm.py) — the unified `(state, event) -> Transition` table assembling the 3 pieces above (Issue #633, Block 5 Phase P completion). v2 (Phase R prep, epic #594) models the soft-start→full-gate escalation via the same `decide_nat_vent_gate()` call the entry path already makes; the `_idle_open` widening remains unmodeled but is re-classified as a caller-side triggering precondition, not omitted decision logic — see the module's own docstring.
+- [`AutomationEngine._natvent_fsm_authoritative`](../custom_components/climate_advisor/automation.py) — Phase R, Step 2 cutover flag (default `False`). When set, `check_natural_vent_conditions()`'s active-session soft-start-escalation read routes through `nat_vent_fsm.transition()` instead of a hand-duplicated inline copy of the same math; the exit-chain decision was already calling the identical pure function directly, so nothing changed there.
+- [`nat_vent_fsm_authoritative_compare.py`](../tools/sim_harness/nat_vent_fsm_authoritative_compare.py), [`tests/test_nat_vent_fsm_authoritative_compare.py`](../tests/test_nat_vent_fsm_authoritative_compare.py) — full-corpus decision-equivalence proof that flipping the flag is a behavioral no-op (diffs the entire event_log/action_log, not a derived state label) — Issue #633, Phase R Step 3.
+- [`ClimateAdvisorCoordinator.set_natvent_fsm_authoritative`/`natvent_fsm_authoritative`](../custom_components/climate_advisor/coordinator.py), [`ClimateAdvisorNatVentFsmAuthoritativeSwitch`](../custom_components/climate_advisor/switch.py) — Phase R, Step 4: the per-lifecycle cutover switch. Off by default, deliberately not persisted across restart. Surfaced on `ClimateAdvisorShadowEngineStatusSensor`'s attributes, not a new card.
 - [`ClimateAdvisorCoordinator._evaluate_nat_vent_fsm`](../custom_components/climate_advisor/coordinator.py) — live wiring (Issue #633): runs `nat_vent_fsm.transition()` against production's real current readings as a **third**, independent comparison point alongside the existing production/shadow mirror. v1 scope, deliberately narrow: only triggered from `check_natural_vent_conditions`'s mirror — the one mirrored method that unambiguously corresponds to nat-vent's own periodic gate/exit re-evaluation (not `apply_classification`/`reconcile_fan_on_startup`'s mirrors, neither of which actually runs the gate/exit chain in production). The FSM's own tracked state (`coordinator._nat_vent_fsm_state`) is never written onto either engine — pure comparison, zero actuation surface, same isolation posture (try/except, swallow, log) as the shadow mirror itself. Surfaced via the same `ClimateAdvisorShadowEngineStatusSensor` as a `nat_vent_fsm_state` attribute; folded into the sensor's overall `agree`/`disagree` value alongside the mirror comparison.
 - [`LifecycleDispatcher`](../custom_components/climate_advisor/lifecycle_dispatcher.py), [`LifecycleEvent`/`LifecycleEventType`](../custom_components/climate_advisor/lifecycle_events.py) — generic cross-lifecycle event routing + registry-completeness enforcement, built once for reuse by every future lifecycle FSM (door/window pause, then override+grace) — Issue #633
 
@@ -294,3 +298,61 @@ they previously hardcoded the state-transition text unconditionally).
 Within a minute of the 0.6.13 deploy, `sensor.climate_advisor_shadow_engine_status`'s new `nat_vent_fsm_state` attribute logged its first live disagreement: `production=inactive fsm=active_full_gate`, at the exact moment a contact sensor opened (a fresh 600s debounce window starting). Traced via full log context, not assumed: production's real `check_natural_vent_conditions()` returned early — both calls that tick were complete no-ops — because its `_idle_open` widening (`self._any_monitored_sensor_open() and _hvac_off_244 and not self._sensor_debounce_pending and not self._grace_active`) requires `not self._sensor_debounce_pending`, and the debounce timer had just started; with `_idle_open` false and `_grace_active` false, the outer guard returns before ever reaching the reactivation-gate check. `nat_vent_fsm.py`'s v1 transition function has no notion of sensor debounce state at all — it evaluates `decide_nat_vent_gate()` unconditionally whenever `paused_by_door=False`, so it activated on the same favorable indoor/outdoor reading (72°F/67°F) production was correctly still withholding judgment on.
 
 This is exactly the `_idle_open` widening scope boundary the module's own docstring already declared out of v1 — not a new defect. It didn't recur on the next cycle (the debounce window settled). Left as a live, concrete data point rather than "fixed": sensor debounce timing is fundamentally a door/window-lifecycle concern (the timer, and the flag it gates, both belong to that lifecycle, not nat-vent's), which is exactly why door/window pause is next in the plan's sequencing — its own FSM, once built, will expose debounce state to nat-vent through the cross-lifecycle event channel (`lifecycle_dispatcher.py`) rather than nat-vent needing to model a concern that isn't its own.
+
+## Phase R prep: soft-start escalation modeled + opt-in cutover switch (Issue #633, epic #594)
+
+Re-scoped Phase R (the epic's final "owner-controlled cutover" step) after re-analyzing
+its cutover mechanism for DRY-ness: the FSM's `transition()` calls the *same* pure
+`decide_*()` functions production's own entry points already call directly, so the
+decision logic was never duplicated — only the read/write of *state* was. Cutover is
+therefore not "build a second actuator alongside production," it's "make the FSM's
+state the thing production's existing choke points condition on, instead of the ad-hoc
+flags." One set of `_activate_fan`/`_deactivate_fan`/`_set_hvac_mode` calls, always.
+
+**Step 1 — modeled the soft-start escalation gap.** `_transition_from_active()` now
+re-checks `decide_nat_vent_gate()` whenever the current state is `ACTIVE_SOFT_START`,
+mirroring `automation.py`'s own "soft-start → full nat-vent upgrade" block (Issue #540)
+exactly — same pure function, same condition, no new decision logic. The `_idle_open`
+widening remains unmodeled but is re-classified (see Code Reference above) rather than
+left as an open gap: it gates *whether* the FSM's entry logic runs a given tick, which
+Step 2's cutover makes moot by construction — once production's own call site is what
+invokes `transition()`, the FSM only ever runs when that precondition already held.
+
+**Step 2 — read-authority swap, feature-flagged.** `AutomationEngine._natvent_fsm_authoritative`
+defaults `False`. When set, the soft-start-escalation branch inside
+`check_natural_vent_conditions()`'s active-session block computes its answer via
+`nat_vent_fsm.transition()` instead of a second, hand-written copy of the same
+`decide_nat_vent_gate()` call — a DRY fix, not a behavior change. The exit-chain
+decision immediately below was already calling `decide_nat_vent_exit()` directly, so
+there was nothing to swap there.
+
+**Step 3 — decision-equivalence, not just state-label agreement.** Every prior FSM
+coverage test (this spec's own "Live Shadow Engine" section, `test_shadow_engine_pair.py`)
+proved the FSM's *derived state label* matched production's flags. None proved that
+flipping a "let the FSM decide" switch leaves the *real commanded actions* unchanged.
+`nat_vent_fsm_authoritative_compare.py` + its test file close that gap: `diff_runs()`
+over the full golden+pending corpus with the flag forced on, diffing the entire
+`event_log`/`action_log` against an untouched baseline. This surfaced a real,
+unrelated bug in the shared differential-harness itself — `_canon_action_log()` was
+comparing each action's raw `Context` object (a fresh `uuid4()` per call, by design,
+mirroring real HA) via `repr()`, which can never agree between two independent runs
+regardless of behavior. Fixed by excluding `context` from comparison (real decision
+content — domain/service/data/ts — is unaffected). A positive control confirms the
+comparator can still detect a genuinely broken FSM gate; the corpus itself doesn't yet
+contain a soft-start scenario, a documented gap the positive control substitutes for
+by exercising the branch directly.
+
+**Step 4 — per-lifecycle switch.** `switch.climate_advisor_nat_vent_fsm_authoritative`,
+same on/off mechanics as the pre-existing `automation_enabled` switch, but deliberately
+**not** persisted across restart — this is the first switch in the Block 5 migration
+capable of letting a bug in new code reach real hardware (every prior phase was
+`dry_run=True` shadow-only by construction), so an unattended restart always comes back
+up on the proven legacy path rather than silently carrying the choice forward.
+
+**Not yet done**: no golden/pending scenario exercises nat-vent soft-start, so the
+Step 3 corpus comparator's "clean across the corpus" result is real but narrower than
+it looks — the swapped branch is only genuinely exercised by the direct-engine positive
+control, not by any scenario file. Door/window pause and override/grace each have their
+own known state/flag inconsistency against production (see `grace-periods-spec.md`)
+that needs resolving as part of their own future Step 1, before either can repeat this
+sequence.

--- a/tests/test_nat_vent_fsm.py
+++ b/tests/test_nat_vent_fsm.py
@@ -193,6 +193,52 @@ class TestFromActiveExitWiring:
         assert t.exit_reason == NatVentExitReason.COMFORT_FLOOR
 
 
+class TestSoftStartEscalation:
+    """Issue #594 Phase R prep: soft-start -> full-gate escalation, mirroring
+    automation.py's own mid-session upgrade check (Issue #540)."""
+
+    def test_escalates_to_full_gate_when_full_gate_conditions_now_met(self) -> None:
+        # outdoor well below indoor by more than hysteresis -> full gate fires.
+        t = transition(
+            NatVentLifecycleState.ACTIVE_SOFT_START,
+            _tick(indoor=75.0, outdoor=65.0, comfort_heat_raw=68.0, hysteresis=0.0),
+        )
+        assert t.changed
+        assert t.to_state == NatVentLifecycleState.ACTIVE_FULL_GATE
+        assert t.exit_reason is None
+
+    def test_stays_soft_start_when_full_gate_still_not_met(self) -> None:
+        # outdoor == indoor (parity only) -> full gate condition still fails.
+        t = transition(
+            NatVentLifecycleState.ACTIVE_SOFT_START,
+            _tick(indoor=74.0, outdoor=74.0, comfort_heat_raw=68.0, comfort_cool=90.0, hysteresis=0.0),
+        )
+        assert not t.changed
+        assert t.to_state == NatVentLifecycleState.ACTIVE_SOFT_START
+
+    def test_escalation_does_not_apply_when_already_full_gate(self) -> None:
+        # Full gate re-checked only from ACTIVE_SOFT_START; from ACTIVE_FULL_GATE
+        # there's nothing to escalate to, and the exit chain runs unaffected.
+        t = transition(
+            NatVentLifecycleState.ACTIVE_FULL_GATE,
+            _tick(indoor=75.0, outdoor=65.0, comfort_heat_raw=68.0, hysteresis=0.0),
+        )
+        assert not t.changed
+        assert t.to_state == NatVentLifecycleState.ACTIVE_FULL_GATE
+
+    def test_exit_takes_priority_over_escalation_on_same_tick(self) -> None:
+        # Full-gate conditions are met AND the comfort floor has also been
+        # reached this same tick -> production's own code order (upgrade check
+        # first, then exit chain unconditionally after) means an exit still
+        # fires; escalating first must not suppress it.
+        t = transition(
+            NatVentLifecycleState.ACTIVE_SOFT_START,
+            _tick(indoor=68.0, outdoor=60.0, comfort_heat_raw=68.0, hysteresis=0.0, in_sleep_window=False),
+        )
+        assert t.exit_reason == NatVentExitReason.COMFORT_FLOOR
+        assert t.to_state == NatVentLifecycleState.INACTIVE
+
+
 class TestEventKindCapturedForAuditTrail:
     @pytest.mark.parametrize("kind", list(NatVentFsmEventKind))
     def test_event_kind_recorded_on_transition(self, kind: NatVentFsmEventKind) -> None:

--- a/tests/test_nat_vent_fsm_authoritative_compare.py
+++ b/tests/test_nat_vent_fsm_authoritative_compare.py
@@ -1,0 +1,149 @@
+"""Tests for Issue #594 Phase R, Step 3: decision-equivalence for the nat-vent
+FSM-authoritative swap (Step 2).
+
+Prior coverage (``test_shadow_engine_pair.py``, ``test_nat_vent_fsm_shadow_wiring.py``)
+only proved *state-label* agreement — would the FSM's independently-derived
+state match production's flags. This file proves the stronger claim Phase R
+actually needs before any live switch is considered: flipping
+``AutomationEngine._natvent_fsm_authoritative`` from its default ``False`` to
+``True`` produces a byte-for-byte identical ``event_log``/``action_log`` — the
+real commanded fan/HVAC actions, not just a derived label — across the full
+golden + pending scenario corpus.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.sim_harness.differential import diff_runs
+from tools.sim_harness.nat_vent_fsm_authoritative_compare import fsm_authoritative_mutation
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_GOLDEN_DIR = _REPO_ROOT / "tools" / "simulations" / "golden"
+_PENDING_DIR = _REPO_ROOT / "tools" / "simulations" / "pending"
+
+# Known to exercise soft-start entry + the upgrade-to-full-gate escalation
+# (test_nat_vent_soft_start.py's TestSoftStartUpgrade covers the same math in
+# isolation) — used as the positive-control probe below.
+_PROBE_GOLDEN = "2026-03-28-overnight"
+
+
+def _load_scenario(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _all_golden_and_pending_scenarios() -> list[Path]:
+    paths = [p for p in _GOLDEN_DIR.glob("*.json") if p.name != "MANIFEST.json"]
+    paths += [p for p in _PENDING_DIR.glob("*.json") if p.name != "MANIFEST.json"]
+    return sorted(paths)
+
+
+class TestFsmAuthoritativeEquivalence:
+    @pytest.mark.parametrize("scenario_path", _all_golden_and_pending_scenarios(), ids=lambda p: p.stem)
+    def test_flag_on_produces_identical_outcome(self, scenario_path: Path) -> None:
+        scenario = _load_scenario(scenario_path)
+        diff = diff_runs(scenario, mutate_b=fsm_authoritative_mutation, scenario_name=scenario_path.stem)
+        assert not diff.a_error and not diff.b_error, (
+            f"{scenario_path.stem}: a_error={diff.a_error!r} b_error={diff.b_error!r}"
+        )
+        assert diff.is_clean, (
+            f"{scenario_path.stem}: FSM-authoritative diverged from baseline — "
+            f"{len(diff.event_divergences)} event, {len(diff.action_divergences)} action divergences — "
+            f"Step 2's read-authority swap must be a behavioral no-op"
+        )
+
+
+class TestFsmAuthoritativePositiveControl:
+    """Test the test: a deliberately broken FSM gate MUST produce a real,
+    detectable divergence — proves this comparator can actually catch a bug in
+    the swapped path, not just always report clean.
+
+    Note on scope: the corpus-wide test above is honest but narrower than it
+    first looks. Step 2's swap only executes when ``_nat_vent_soft_start`` is
+    True at the top of the active-session block — none of the 88 current
+    golden/pending scenarios exercise soft-start (it's a newer, less common
+    entry path; see Issue #540). For every scenario in the corpus test, the
+    flag flip is therefore an inert no-op by construction (branch never
+    taken), not evidence the FSM path itself computes correctly under load.
+    This positive control exercises the actual swapped branch directly
+    (bypassing the corpus, same direct-engine-construction style as
+    ``test_nat_vent_soft_start.py``) so a broken FSM gate is provably
+    detectable, and flags the corpus gap rather than silently relying on
+    scenarios that never touch the new code."""
+
+    def _make_soft_start_engine(self, *, fsm_authoritative: bool):
+        import sys
+        from datetime import datetime
+        from unittest.mock import AsyncMock, MagicMock
+
+        from custom_components.climate_advisor.automation import AutomationEngine
+        from custom_components.climate_advisor.const import CONF_FAN_MODE, FAN_MODE_WHOLE_HOUSE
+
+        sys.modules["homeassistant.util.dt"].now = lambda: datetime(2026, 7, 29, 18, 0, 0)
+
+        hass = MagicMock()
+        hass.services = MagicMock()
+        hass.services.async_call = AsyncMock()
+        hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+        climate_state = MagicMock()
+        climate_state.state = "cool"
+        climate_state.attributes = {"current_temperature": 76.0}
+        hass.states = MagicMock()
+        hass.states.get = MagicMock(return_value=climate_state)
+
+        engine = AutomationEngine(
+            hass=hass,
+            climate_entity="climate.thermostat",
+            weather_entity="weather.forecast_home",
+            door_window_sensors=["binary_sensor.front_door"],
+            notify_service="notify.notify",
+            config={
+                "comfort_heat": 70.0,
+                "comfort_cool": 76.0,
+                "setback_heat": 60,
+                "setback_cool": 80,
+                "natural_vent_delta": 3.0,
+                "notify_service": "notify.notify",
+                CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+            },
+        )
+        engine._natvent_fsm_authoritative = fsm_authoritative
+        engine._natural_vent_active = True
+        engine._nat_vent_soft_start = True
+        engine._paused_by_door = False
+        # outdoor well below indoor - hysteresis -> full gate clears for real.
+        engine._last_outdoor_temp = 70.0
+        engine._outdoor_temp_today_peak = 90.0
+        engine._outdoor_temp_today_sample_count = 5
+        return engine
+
+    def test_positive_control_detects_a_broken_fsm_gate(self) -> None:
+        import asyncio
+        from unittest.mock import patch
+
+        engine = self._make_soft_start_engine(fsm_authoritative=True)
+        with patch("custom_components.climate_advisor.nat_vent_fsm.decide_nat_vent_gate", lambda inputs: False):
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        # Real full-gate conditions hold (outdoor 70 vs indoor 76), so without
+        # the injected break the session would upgrade (_nat_vent_soft_start ->
+        # False, per TestSoftStartUpgradeFsmAuthoritative above). Forcing the
+        # FSM's gate to always return False must suppress that upgrade —
+        # proves this comparison style can catch a real regression in the
+        # swapped path, not just report clean by construction.
+        assert engine._nat_vent_soft_start is True, (
+            "positive control FAILED: forcing nat_vent_fsm.decide_nat_vent_gate() to always "
+            "return False did not suppress the soft-start upgrade — a broken FSM gate in the "
+            "FSM-authoritative path would go undetected"
+        )
+
+    def test_unbroken_fsm_gate_upgrades_normally(self) -> None:
+        import asyncio
+
+        engine = self._make_soft_start_engine(fsm_authoritative=True)
+        asyncio.run(engine.check_natural_vent_conditions())
+        assert engine._nat_vent_soft_start is False

--- a/tests/test_nat_vent_soft_start.py
+++ b/tests/test_nat_vent_soft_start.py
@@ -226,6 +226,43 @@ class TestSoftStartUpgrade:
         assert engine._nat_vent_soft_start is True
 
 
+class TestSoftStartUpgradeFsmAuthoritative:
+    """Issue #594 Phase R, Step 2: with ``_natvent_fsm_authoritative=True``, the
+    same two scenarios from ``TestSoftStartUpgrade`` above must produce identical
+    outcomes — read authority moved to ``nat_vent_fsm.transition()``, but the
+    underlying pure-function inputs and expected result are unchanged."""
+
+    def test_upgrades_when_full_gate_clears(self):
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, indoor_f=76.0)
+        engine._natvent_fsm_authoritative = True
+        engine._natural_vent_active = True
+        engine._nat_vent_soft_start = True
+        engine._paused_by_door = False
+        engine._last_outdoor_temp = 70.0
+        engine._outdoor_temp_today_peak = 90.0
+        engine._outdoor_temp_today_sample_count = 5
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True
+        assert engine._nat_vent_soft_start is False
+
+    def test_stays_soft_start_while_full_gate_not_yet_cleared(self):
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, indoor_f=76.0)
+        engine._natvent_fsm_authoritative = True
+        engine._natural_vent_active = True
+        engine._nat_vent_soft_start = True
+        engine._paused_by_door = False
+        engine._last_outdoor_temp = 75.5
+        engine._outdoor_temp_today_peak = 90.0
+        engine._outdoor_temp_today_sample_count = 5
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True
+        assert engine._nat_vent_soft_start is True
+
+
 class TestSoftStartExitHierarchy:
     """A soft-start session reuses the existing exit hierarchy unchanged — outdoor-rise
     exit must clear the soft-start qualifier along with _natural_vent_active."""

--- a/tests/test_natvent_fsm_authoritative_switch.py
+++ b/tests/test_natvent_fsm_authoritative_switch.py
@@ -1,0 +1,62 @@
+"""Tests for Issue #594 Phase R, Step 4: the nat-vent FSM-authoritative
+cutover switch's coordinator-level plumbing.
+
+Binds the REAL ``ClimateAdvisorCoordinator.natvent_fsm_authoritative``/
+``set_natvent_fsm_authoritative()`` (object.__new__() + types.MethodType(),
+the established partial-instantiation pattern — see test_contact_status.py)
+rather than re-implementing the toggle logic in the test body, per this
+project's doctrine against mirror tests.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+if "homeassistant" not in sys.modules:
+    from conftest import _install_ha_stubs
+
+    _install_ha_stubs()
+
+from custom_components.climate_advisor.coordinator import ClimateAdvisorCoordinator
+
+
+def _make_coordinator() -> ClimateAdvisorCoordinator:
+    # object.__new__() preserves the real class, so the real `natvent_fsm_authoritative`
+    # property (a class-level descriptor) already resolves without manual binding —
+    # only the plain method needs explicit types.MethodType() binding.
+    coord = object.__new__(ClimateAdvisorCoordinator)
+    coord.automation_engine = MagicMock()
+    coord.automation_engine._natvent_fsm_authoritative = False
+    coord.set_natvent_fsm_authoritative = types.MethodType(
+        ClimateAdvisorCoordinator.set_natvent_fsm_authoritative, coord
+    )
+    return coord
+
+
+class TestNatVentFsmAuthoritativeToggle:
+    def test_defaults_reflect_engine_flag(self):
+        coord = _make_coordinator()
+        assert coord.natvent_fsm_authoritative is False
+
+    def test_enabling_sets_engine_flag(self):
+        coord = _make_coordinator()
+        coord.set_natvent_fsm_authoritative(True)
+        assert coord.automation_engine._natvent_fsm_authoritative is True
+        assert coord.natvent_fsm_authoritative is True
+
+    def test_disabling_clears_engine_flag(self):
+        coord = _make_coordinator()
+        coord.set_natvent_fsm_authoritative(True)
+        coord.set_natvent_fsm_authoritative(False)
+        assert coord.automation_engine._natvent_fsm_authoritative is False
+        assert coord.natvent_fsm_authoritative is False
+
+    def test_not_persisted_no_save_state_call(self):
+        """Deliberately does not call _async_save_state — see the method's own
+        docstring: a restart must always come back up on the legacy path."""
+        coord = _make_coordinator()
+        coord.hass = MagicMock()
+        coord.set_natvent_fsm_authoritative(True)
+        coord.hass.async_create_task.assert_not_called()

--- a/tools/sim_harness/differential.py
+++ b/tools/sim_harness/differential.py
@@ -70,8 +70,20 @@ def _canon_event_log(log: list[tuple[str, dict, datetime | None]]) -> list[Any]:
 
 
 def _canon_action_log(log: list[dict]) -> list[Any]:
-    """Canonicalise an action_log: list of {domain, service, data, ts}."""
-    return [_canonical(entry) for entry in log]
+    """Canonicalise an action_log: list of {domain, service, data, ts, context}.
+
+    ``context`` is dropped before canonicalising (Issue #594 Phase R, Step 3
+    finding): each call attaches a fresh ``ha_stubs._MockContext`` carrying a
+    randomly-generated ``uuid4`` id (mirroring real HA's opaque per-call
+    correlation Context) — it is never derived from scenario content, so two
+    independently-run scenarios always disagree on it even when behaviorally
+    identical. Including it in comparison produced false-positive divergences
+    on every action entry (found via the first full-corpus decision-equivalence
+    comparator to exercise fan-toggle actions across two full independent runs
+    — ``test_nat_vent_fsm_authoritative_compare.py``). Every other field
+    (domain, service, data, ts) is real decision content and stays compared.
+    """
+    return [_canonical({k: v for k, v in entry.items() if k != "context"}) for entry in log]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/sim_harness/nat_vent_fsm_authoritative_compare.py
+++ b/tools/sim_harness/nat_vent_fsm_authoritative_compare.py
@@ -1,0 +1,53 @@
+"""nat_vent_fsm_authoritative_compare — Step 2/Step 3 equivalence proof (Issue #594
+Phase R).
+
+Unlike ``nat_vent_gate_compare.py`` (old hand-written code vs. a newly-extracted
+pure function), this comparator proves something narrower and specific to the
+cutover work: that flipping ``AutomationEngine._natvent_fsm_authoritative`` from
+its default ``False`` to ``True`` produces a byte-for-byte identical
+``event_log``/``action_log`` across the full golden + pending scenario corpus.
+
+This is the decision-equivalence test the Phase R plan called for — prior
+coverage (``test_shadow_engine_coverage.py``, ``test_shadow_engine_pair.py``)
+only asserted *state-label* agreement (would the FSM's derived state match
+production's flags), never that flipping the switch leaves REAL commanded
+actions unchanged. Since ``nat_vent_fsm.transition()``'s active-state path
+calls the identical ``decide_nat_vent_gate()``/``decide_nat_vent_exit()`` pure
+functions ``check_natural_vent_conditions()`` already calls directly (see
+``automation.py``'s ``_natvent_fsm_authoritative`` branch), this comparator
+is a refactor-safety net proving that swap didn't change behavior — not a
+discovery mechanism for new logic differences (there is no new logic; Step 1's
+escalation modeling was itself validated by ``tests/test_nat_vent_fsm.py``
+before this comparator exists).
+
+Use via ``tools.sim_harness.differential.diff_runs(scenario,
+mutate_b=fsm_authoritative_mutation)`` — run A is untouched production (flag
+default False), run B forces the flag True on every engine instance
+constructed during that run. ``diff.is_clean`` must be True for every
+scenario in the golden/pending corpus.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+
+@contextmanager
+def fsm_authoritative_mutation() -> Iterator[None]:
+    """Force ``_natvent_fsm_authoritative = True`` on every engine constructed
+    while this context is active — the "run B" side of a diff_runs comparison.
+    """
+    from unittest.mock import patch
+
+    from custom_components.climate_advisor.automation import AutomationEngine
+
+    original_init = AutomationEngine.__init__
+
+    def _wrapped_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        self._natvent_fsm_authoritative = True
+
+    with patch.object(AutomationEngine, "__init__", _wrapped_init):
+        yield


### PR DESCRIPTION
## Summary

Continuation of #633 (Block 5 epic #594, Phase P completion) — begins the actual
cutover work ("Phase R") for the nat-vent lifecycle FSM, re-scoped after re-analyzing
the mechanism for DRY-ness: the FSM's `transition()` already calls the *same* pure
`decide_*()` functions production's own entry points call directly, so cutover is a
read-authority swap onto the existing choke points, not a second actuator.

- **Modeled the last documented gap** in `nat_vent_fsm.py`'s transition table:
  `ACTIVE_SOFT_START` → `ACTIVE_FULL_GATE` mid-session escalation, mirroring
  `automation.py`'s own upgrade block (Issue #540) exactly — same pure function, no
  new decision logic.
- **`AutomationEngine._natvent_fsm_authoritative`** (off by default): when set,
  `check_natural_vent_conditions()`'s soft-start-escalation read routes through
  `nat_vent_fsm.transition()` instead of a hand-duplicated inline copy of the same
  math.
- **Full-corpus decision-equivalence comparator** (`nat_vent_fsm_authoritative_compare.py`)
  proves the swap is a behavioral no-op — diffs the entire `event_log`/`action_log`
  across every golden+pending scenario, not just a derived state label. This also
  caught and fixed a latent false-positive bug in the shared differential harness
  (`_canon_action_log()` was comparing a randomly-generated per-call `Context` id as
  if it were decision content).
- **New switch** `switch.climate_advisor_nat_vent_fsm_authoritative` — the first
  switch in this migration capable of letting the FSM drive real HVAC/fan hardware
  (every prior phase was `dry_run=True` shadow-only). Off by default, deliberately
  **not** persisted across restart. Surfaced on the existing Shadow Engine Status
  diagnostic sensor's attributes, not a new card.

Zero occupant-visible behavior change while the switch stays off (the shipped default).

## Test plan

- [x] `python -m ruff check`/`format` clean
- [x] Full suite: 4,594 passed, 6 skipped, 0 warnings-as-errors failures
- [x] New: 4 soft-start-escalation unit tests, 90 full-corpus decision-equivalence
      tests (incl. a positive control proving the comparator can detect a broken
      FSM gate), 4 coordinator-plumbing tests for the new switch
- [x] `tests/test_version_sync.py` — versions match across const.py/manifest.json
- [x] Docs: `docs/nat-vent-lifecycle-spec.md` updated (Anchors row + new Phase R section)