### PR TITLE
Fix #655, #657: door/window Phase R Step 3 blocker cleanup (#637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.26] — 2026-08-16
+
+- Fix #655: a door/window briefly reopened during an active grace period could still pause the AC/heat, even though the grace period exists specifically to avoid reacting to exactly that. The grace check now uses the same accurate indoor+outdoor reactivation check the automation already computes a moment later, instead of a coarser outdoor-only shortcut that could disagree with it — grace now reliably holds for its full duration.
+- Fix #657: after a grace period ends with a door/window still open but conditions now favor natural ventilation, some pause-related dashboard and Activity Report fields (which door/window, how long it's been paused) could keep showing stale information from an earlier pause. These now clear correctly alongside the rest of the pause state.
+- Fix (found during #637 Phase R Step 3 scoping, no user-facing symptom confirmed): a nat-vent-exit pause path wrote fewer pause-tracking fields than the equivalent door/window pause path, which could leave a dashboard field stale and — in one specific edge case — cause a later door-close to start an unwanted extra grace period. Both pause paths now share one definition of what a door/window pause writes.
+
 ## [0.6.25] — 2026-08-16
 
 - Feat #637 (Phase R Step 2, partial): begins letting the door/window pause/grace lifecycle FSM actually drive production decisions — a new, off-by-default switch lets it take over 2 of the lifecycle's 7 actions (a manual thermostat override detected during a pause, and resuming from a dashboard pause) instead of the older logic. Both were proven behavior-identical to the existing logic before this shipped, across the full scenario library plus dedicated tests. The switch defaults off — no occupant-visible behavior change unless it is explicitly turned on, and even then only for those 2 actions; everything else about door/window pause/grace handling is unchanged.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -2831,6 +2831,28 @@ class AutomationEngine:
             notify_type="door_window_pause",
         )
 
+    def _set_door_window_pause_fields(self, *, entity_label: str, hvac_already_off: bool) -> None:
+        """Write the door/window pause-state fields shared across every pause entry point.
+
+        One definition of "what fields a door/window pause writes" for
+        ``_pause_for_door_window()`` and ``_exit_nat_vent()``'s sensor-still-open
+        branch — the latter used to hand-roll only ``_paused_by_door`` (plus its own
+        ``_pre_pause_mode``), silently omitting ``_paused_with_hvac_already_off``/
+        ``_paused_entity``/``_paused_since``. ``_paused_with_hvac_already_off`` feeds
+        real control flow (``derive_door_window_lifecycle_state()`` uses it to tell
+        ``PAUSED_ACTIVE`` from ``PAUSED_IDLE``); the other two are diagnostic-only
+        (Activity Report "Settings" text via ``ai_skills_context.py``'s
+        ``_render_paused_entity_settings()``).
+
+        ``_pre_pause_mode`` is intentionally NOT written here — each caller derives
+        it with its own state-read logic and writes it separately before calling
+        this helper.
+        """
+        self._paused_by_door = True
+        self._paused_with_hvac_already_off = hvac_already_off
+        self._paused_entity = entity_label
+        self._paused_since = dt_util.now()
+
     async def _pause_for_door_window(
         self, *, entity_label: str, reason: str, notify_message: str, notify_type: str
     ) -> bool:
@@ -2849,10 +2871,7 @@ class AutomationEngine:
         mode = state.state if state else None
         if mode and mode not in ("off", "unavailable", "unknown"):
             self._pre_pause_mode = mode
-            self._paused_by_door = True
-            self._paused_with_hvac_already_off = False
-            self._paused_entity = entity_label
-            self._paused_since = dt_util.now()
+            self._set_door_window_pause_fields(entity_label=entity_label, hvac_already_off=False)
             await self._set_hvac_mode("off", reason=f"{reason}, was {mode} mode")
             await self._notify(notify_message, "Climate Advisor", notification_type=notify_type)
             if self._emit_event_callback:
@@ -2862,10 +2881,7 @@ class AutomationEngine:
                 )
             return True
         if mode == "off":
-            self._paused_by_door = True
-            self._paused_with_hvac_already_off = True
-            self._paused_entity = entity_label
-            self._paused_since = dt_util.now()
+            self._set_door_window_pause_fields(entity_label=entity_label, hvac_already_off=True)
             _LOGGER.info(
                 "Door/window pause (%s): HVAC already off — pause flag set, no mode change needed",
                 entity_label,
@@ -2887,19 +2903,32 @@ class AutomationEngine:
                 return  # Already paused
 
             if self._grace_active:
-                outdoor = self._last_outdoor_temp
-                comfort_cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
-                nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
-                nat_vent_threshold = comfort_cool + nat_vent_delta
-                if outdoor is not None and outdoor < nat_vent_threshold:
-                    pass  # outdoor cool enough — fall through to nat-vent check below
-                else:
+                # Issue #655: this used to short-circuit on a coarse outdoor-only
+                # proxy (outdoor < comfort_cool + nat_vent_delta) instead of the real
+                # 4-variable reactivation gate computed a few lines below — the two
+                # could disagree, letting a "cool enough" outdoor reading fall through
+                # the grace suppression only to still hit a pause moments later when
+                # the real gate (which also needs indoor/comfort_heat) said no. Reuse
+                # the same shared gate here instead of a hand-copied proxy.
+                _outdoor_g = self._last_outdoor_temp
+                _comfort_cool_g = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
+                _nat_vent_delta_g = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
+                _grace_gate_entered = self._nat_vent_may_reactivate(
+                    outdoor=_outdoor_g,
+                    indoor=self._get_indoor_temp_f(),
+                    comfort_heat=self._nat_vent_reactivation_floor(),
+                    comfort_cool=_comfort_cool_g,
+                    nat_vent_delta=_nat_vent_delta_g,
+                )
+                if not _grace_gate_entered:
                     _LOGGER.info(
                         "Door/window open (%s) but %s grace period active — not pausing",
                         entity_id,
                         self._last_resume_source,
                     )
                     return
+                # else: real gate says reactivation is viable — fall through to the
+                # nat-vent-vs-pause decision below, same as before.
 
             if self._is_within_planned_window_period():
                 _LOGGER.info(
@@ -4570,6 +4599,16 @@ class AutomationEngine:
                 self._request_refresh_callback()
             if self._post_grace_fan_check_callback:
                 self._post_grace_fan_check_callback()
+            # Shadow-feed completion (door/window Step 1b's documented residual): this
+            # was the one GRACE_TIMER_EXPIRED outcome with no event emit at all, so it
+            # never fed the shadow door/window FSM. Reuses the same "grace_expired"
+            # event type the sibling branches below already emit — no wiring changes
+            # to _DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES needed — with a payload key
+            # distinguishing this outcome from a real sensor re-check.
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "grace_expired", {"source": source, "within_planned_window": True, "re_paused": False}
+                )
             return
 
         # If any contact sensor is still open, re-pause instead of clearing
@@ -4728,7 +4767,20 @@ class AutomationEngine:
                 # away/vacation setback band (handle_occupancy_away/vacation both early-return
                 # on _paused_by_door=True) and misreports "paused by door" on the
                 # dashboard/API while nat-vent is actually running.
+                # Issue #657: the above fix only cleared _paused_by_door, leaving
+                # _paused_with_hvac_already_off/_paused_entity/_paused_since stale —
+                # the sibling reactivation branches in check_natural_vent_conditions()
+                # (automation.py ~:3614-3617/3646-3649) clear all 4 fields together.
+                # Stale _paused_entity/_paused_since only feed diagnostic text
+                # (Activity Report "Settings" cell via ai_skills_context.py's
+                # _render_paused_entity_settings()), but a stale
+                # _paused_with_hvac_already_off feeds real control flow — it's what
+                # derive_door_window_lifecycle_state() uses to tell PAUSED_ACTIVE from
+                # PAUSED_IDLE.
                 self._paused_by_door = False
+                self._paused_with_hvac_already_off = False
+                self._paused_entity = None
+                self._paused_since = None
                 await self._apply_nat_vent_hvac_state()
                 _LOGGER.info(
                     "Re-check after grace: nat-vent conditions met — outdoor %.1f°F < indoor %.1f°F,"
@@ -5547,9 +5599,18 @@ class AutomationEngine:
             result = await self._deactivate_fan(
                 reason=reason, restore_hvac=False, release_suppression=True, emit_event=False
             )
-            self._paused_by_door = True
             state = self.hass.states.get(self.climate_entity)
             self._pre_pause_mode = state.state if state and state.state != "off" else None
+            # Write-shape divergence fix (found while scoping #637 Step 3): this branch
+            # used to set only _paused_by_door, unlike _pause_for_door_window()'s full
+            # field set — see _set_door_window_pause_fields()'s docstring.
+            # hvac_already_off mirrors _pre_pause_mode's own truthiness: nothing to
+            # restore (pre_pause_mode is None) means the FSM-visible state is
+            # equivalent to "already off" (PAUSED_IDLE), matching
+            # decide_door_close_response()'s own truthiness test on pre_pause_mode.
+            self._set_door_window_pause_fields(
+                entity_label="nat-vent-exit", hvac_already_off=self._pre_pause_mode is None
+            )
             # Issue #649: a repeat of an already-reported deferral logs at DEBUG, not INFO —
             # this is the exact "one retry tick after another while still blocked" pattern
             # that produced unbounded duplicate INFO lines before this fix.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,29 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.25"
+VERSION = "0.6.26"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.26": [
+        "Fix #655: a door/window briefly reopened during an active grace period"
+        " could still pause the AC/heat, even though the grace period exists"
+        " specifically to avoid reacting to exactly that. The grace check now uses"
+        " the same accurate indoor+outdoor reactivation check the automation"
+        " already computes a moment later, instead of a coarser outdoor-only"
+        " shortcut that could disagree with it — grace now reliably holds for its"
+        " full duration.",
+        "Fix #657: after a grace period ends with a door/window still open but"
+        " conditions now favor natural ventilation, some pause-related dashboard"
+        " and Activity Report fields (which door/window, how long it's been"
+        " paused) could keep showing stale information from an earlier pause."
+        " These now clear correctly alongside the rest of the pause state.",
+        "Fix (found during #637 Phase R Step 3 scoping, no user-facing symptom"
+        " confirmed): a nat-vent-exit pause path wrote fewer pause-tracking"
+        " fields than the equivalent door/window pause path, which could leave"
+        " a dashboard field stale and — in one specific edge case — cause a"
+        " later door-close to start an unwanted extra grace period. Both pause"
+        " paths now share one definition of what a door/window pause writes.",
+    ],
     "0.6.25": [
         "Feat #637 (Phase R Step 2, partial): begins letting the door/window"
         " pause/grace lifecycle FSM actually drive production decisions — a new,"
@@ -2099,7 +2119,7 @@ KNOWN_FIXES: dict[int, dict] = {
         ),
     },
     637: {
-        "version_fixed": "0.6.25",
+        "version_fixed": "0.6.26",
         "title": (
             "Block 5 epic #594 Phase 2: builds the unified door/window pause/grace"
             " transition table (5 new pure functions + door_window_fsm.py assembly),"
@@ -2161,6 +2181,38 @@ KNOWN_FIXES: dict[int, dict] = {
             " filed as #657): `_re_pause_for_open_sensor()`'s 0.6.23 fix only cleared"
             " `_paused_by_door`, not the 3 other stale pause fields the mirrored branch"
             " in `check_natural_vent_conditions()` clears together."
+            " Phase R Step 3 (0.6.26): closed all 4 of Step 2's documented blockers except"
+            " one. #655 fixed: `handle_door_window_open()`'s grace-active branch now shares"
+            " the same real `_nat_vent_may_reactivate()` gate result the nat-vent-vs-pause"
+            " decision further down the function already computes, instead of a coarse"
+            " outdoor-only proxy that could disagree with it -- closing the exact gap that"
+            " let a grace period be silently defeated. `door_window_open_response.py`'s"
+            " pure mirror updated to match. #657 fixed: `_re_pause_for_open_sensor()`'s"
+            " nat-vent-reactivation branch now clears `_paused_with_hvac_already_off`/"
+            "`_paused_entity`/`_paused_since` alongside `_paused_by_door`, matching"
+            " `check_natural_vent_conditions()`'s sibling branch. `_exit_nat_vent()`'s"
+            " sensor-still-open branch write-shape divergence fixed too (found while"
+            " scoping Step 3, no separate issue filed): it used to write only"
+            " `_paused_by_door`/`_pre_pause_mode`; both this branch and"
+            " `_pause_for_door_window()` now go through a new shared"
+            " `_set_door_window_pause_fields()` helper. This also closes the previously"
+            "-documented `ALL_SENSORS_CLOSED`/`pre_pause_mode`-placeholder risk in"
+            " `door_window_fsm.py`, since `_paused_with_hvac_already_off` can no longer"
+            " go stale from this branch -- so `handle_all_doors_windows_closed()` needed"
+            " no separate fix of its own, contrary to Step 2's assumption that it would."
+            " Also closed Step 1b's one documented shadow-feed residual:"
+            ' `_on_grace_expired()`\'s "within planned window" branch now emits'
+            ' `"grace_expired"` (reusing the existing event type with a distinguishing'
+            " `within_planned_window` payload key), so all 3 of its outcome branches feed"
+            " `GRACE_TIMER_EXPIRED`, not just 2. Required updating one LOCKED golden"
+            " scenario (`issue_637_paused_during_grace_open_fallthrough.json`) with"
+            " explicit user sign-off per the Golden Simulation Test Policy -- it had"
+            " deliberately encoded #655's bug as its expected final outcome"
+            " (`paused_during_grace`); re-signed to assert the fixed behavior"
+            " (`resumed`, i.e. grace correctly holds). Still blocked, deferred to a future"
+            " increment: `_re_pause_for_open_sensor()` still needs to know whether it was"
+            " reached from `GRACE` or `PAUSED_DURING_GRACE` (a signature/plumbing change,"
+            " not a body swap) before it can join FSM authority."
         ),
         "scope_covered": (
             "New: door_window_lifecycle.py (5-state derivation), door_window_pause_entry.py, "
@@ -2193,6 +2245,72 @@ KNOWN_FIXES: dict[int, dict] = {
             " sites in `_async_morning_wakeup()`/`_async_pre_cool_trigger()`. New"
             " `_DOOR_WINDOW_EVENT_KIND_REGISTRY` + `TestDoorWindowFsmEventCoverage` in"
             " test_shadow_engine_coverage.py enforces all 7 event kinds stay reachable."
+            " 0.6.26: automation.py `handle_door_window_open()`'s grace-active branch now"
+            " calls `_nat_vent_may_reactivate()` directly instead of a coarse outdoor-only"
+            " proxy (#655); `door_window_open_response.py`'s `decide_door_open_response()`"
+            " updated to match. `_re_pause_for_open_sensor()`'s nat-vent-reactivation branch"
+            " clears 4 pause fields, not 1 (#657). New `_set_door_window_pause_fields()`"
+            " helper shared by `_pause_for_door_window()` and `_exit_nat_vent()`. New event"
+            ' emit in `_on_grace_expired()`\'s "within planned window" branch. Updated'
+            " golden `issue_637_paused_during_grace_open_fallthrough.json` (re-signed)."
+            " New/extended tests: test_door_window.py"
+            "::TestGracePeriodExpiry::test_door_open_during_grace_coarse_outdoor_ok_real_gate_fails_still_blocked,"
+            " test_resume_from_pause.py"
+            "::TestGraceExpiryRecheck::test_repause_clears_paused_by_door_on_nat_vent_reactivation"
+            " (extended), test_nat_vent_activation.py"
+            "::TestNatVentOutdoorRiseExit::test_outdoor_rises_above_indoor_exits (extended),"
+            " test_grace_refresh_and_band_call.py"
+            "::TestGraceExpiryTriggersRefreshCallback::test_planned_window_path_calls_refresh_callback"
+            " (extended), test_door_window_pure_modules.py (grace-suppression tests"
+            " updated to real-gate semantics), test_door_window_fsm.py::TestFromGrace"
+            " (updated to match)."
+        ),
+    },
+    655: {
+        "version_fixed": "0.6.26",
+        "title": (
+            "A door/window briefly reopened during an active grace period could still"
+            " pause HVAC, defeating the grace period's purpose. Root cause:"
+            " `handle_door_window_open()`'s grace-active branch used a coarse"
+            " outdoor-only proxy check to decide whether to suppress the pause, while a"
+            " stricter, real 4-variable reactivation gate (`_nat_vent_may_reactivate()`)"
+            " was computed independently a few lines later in the same function — the"
+            " two could disagree, letting a 'looks cool enough' outdoor reading fall"
+            " through the grace suppression only to still land on a pause when the real"
+            " gate failed. Fixed by making the grace-active branch share the same real"
+            " gate result the fallthrough already computes, instead of a separate proxy."
+        ),
+        "scope_covered": (
+            "automation.py `handle_door_window_open()`: coarse proxy removed, grace-"
+            "active branch now calls `_nat_vent_may_reactivate()` directly. "
+            "door_window_open_response.py `decide_door_open_response()`: updated to"
+            " test `nat_vent_gate_entered` instead of a separate outdoor/threshold"
+            " comparison. Golden `issue_637_paused_during_grace_open_fallthrough.json`"
+            " re-signed — its final assertion changed from `paused_during_grace` (the"
+            " bug, confirmed with explicit user sign-off) to `resumed` (the fix)."
+        ),
+    },
+    657: {
+        "version_fixed": "0.6.26",
+        "title": (
+            "After a grace period ended with a door/window still open but conditions"
+            " now favoring natural ventilation, `_re_pause_for_open_sensor()`'s 0.6.23"
+            " fix (issue #637 Step 1) cleared only `_paused_by_door`, leaving"
+            " `_paused_with_hvac_already_off`/`_paused_entity`/`_paused_since` stale from"
+            " the earlier pause — unlike the structurally identical branch in"
+            " `check_natural_vent_conditions()`, which clears all 4 fields together."
+            " `_paused_entity`/`_paused_since` only feed diagnostic text (a stale entity"
+            " name and blank elapsed-minutes in the Activity Report's 'Settings' cell);"
+            " `_paused_with_hvac_already_off` feeds real control flow"
+            " (`derive_door_window_lifecycle_state()`'s `PAUSED_ACTIVE`/`PAUSED_IDLE`"
+            " derivation)."
+        ),
+        "scope_covered": (
+            "automation.py `_re_pause_for_open_sensor()`'s nat-vent-reactivation branch"
+            " now clears all 4 fields, matching `check_natural_vent_conditions()`."
+            " Extended test_resume_from_pause.py::TestGraceExpiryRecheck::"
+            "test_repause_clears_paused_by_door_on_nat_vent_reactivation to seed stale"
+            " values and assert all 4 are cleared."
         ),
     },
     633: {

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -356,9 +356,10 @@ def _pick_daily_line(pool: tuple[str, ...], salt: str) -> str:
 # (also event-driven). SYNC_RECONCILE is fed separately via
 # _DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS (method-name-triggered, same shape as
 # _NAT_VENT_FSM_TRIGGER_METHODS — Phase R Step 1b, epic #594, v0.6.24). As of Step 1b
-# all 7 DoorWindowFsmEventKind members have a real feed path; see door_window_fsm.py's
-# own docstring for the one still-accepted residual (the "within planned window" grace
-# expiry branch emits no event at all, so that one outcome doesn't feed the FSM).
+# all 7 DoorWindowFsmEventKind members have a real feed path; door/window Step 3
+# (#637) closed the one remaining residual (the "within planned window" grace
+# expiry branch previously emitted no event at all) by adding an emit there too —
+# see door_window_fsm.py's docstring for history.
 _DOOR_WINDOW_FSM_EVENT_KINDS: dict[str, str] = {
     "handle_door_window_open": "sensor_opened",
     "handle_all_doors_windows_closed": "all_sensors_closed",
@@ -386,11 +387,12 @@ _DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS: frozenset[str] = frozenset(
 # Issue #594 Phase R Step 1b: event types that indicate a door/window grace period just
 # expired, for feeding DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED. _on_grace_expired()
 # (automation.py) is an internal timer callback with no _mirror_to_shadow() call site,
-# but 3 of its 4 branches already emit a distinct event type after mutating state (no
-# staleness risk): "grace_expired" (the re-pause-on-still-open branch and the normal-
-# expiry branch) and "override_adopted" (the adopted-matching-decision branch). The
-# 4th branch ("within planned window") emits nothing at all — an accepted residual, see
-# door_window_fsm.py's docstring. These event-type strings are also consumed by
+# and, as of door/window Step 3 (#637), all 4 branches emit a distinct event type
+# after mutating state (no staleness risk): "grace_expired" (the re-pause-on-still-
+# open branch, the normal-expiry branch, and the within-planned-window branch — the
+# latter two share the string with a distinguishing payload key) and
+# "override_adopted" (the adopted-matching-decision branch). These event-type
+# strings are also consumed by
 # _OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP for a *different* FSM's GRACE_TIMER_EXPIRED
 # concept — one event type can and does feed multiple FSMs, same as every other branch
 # in _feed_lifecycle_fsms_from_event().

--- a/custom_components/climate_advisor/door_window_fsm.py
+++ b/custom_components/climate_advisor/door_window_fsm.py
@@ -69,29 +69,50 @@ decides paused-vs-normal (now correctly reflected in production, per the fix
 above).
 
 **#637 Step 1 closed.** ``_exit_nat_vent()``'s unconditional sensor-still-open pause was
-investigated and verified **benign, not a bug**: the flag is accurate the moment it's
-set, and ``_on_grace_expired()`` already re-derives its decision from live sensor state
-rather than reading ``_paused_by_door``, so it self-corrects regardless of whether grace
-is left running. ``handle_door_window_open()``'s grace-fallthrough (a coarser
-outdoor-only proxy check gating a stricter gate computed later in the same function) is
-a real, independent gap — tracked on its own issue, **#655**, deliberately kept separate
-from this FSM migration since it's unrelated production behavior, not a migration
-blocker. This module continues to mirror both faithfully as-is; #655's resolution (if
-any) will land in production first, same "fix production, then the FSM inherits the fix
-for free" order Step 1's violation #3 already followed.
+investigated and verified **benign, not a bug** with respect to ``_paused_by_door``
+itself: the flag is accurate the moment it's set, and ``_on_grace_expired()`` already
+re-derives its decision from live sensor state rather than reading ``_paused_by_door``,
+so it self-corrects regardless of whether grace is left running.
 
-**Shadow-feed coverage (Issue #594 Phase R Step 1b, v0.6.24).** All 7
-``DoorWindowFsmEventKind`` members now have a real feed path — see
+**#637 Step 3 closed the remaining production gaps.** Three findings from Step 2's
+scoping pass are now fixed in production (not just documented as blockers):
+
+- ``handle_door_window_open()``'s grace-fallthrough (**#655**) — the coarse
+  outdoor-only proxy check has been removed; the grace-active branch now shares the
+  same real ``_nat_vent_may_reactivate()`` gate result used by the nat-vent-vs-pause
+  decision further down the function. This module's ``decide_door_open_response()``
+  already modeled the gate as a caller-resolved boolean input
+  (``nat_vent_gate_entered``), so no change was needed here — production simply now
+  passes it the real gate result on the grace path too, closing the prior divergence.
+- ``_re_pause_for_open_sensor()``'s incomplete field-clear (**#657**) — the
+  nat-vent-reactivation branch now clears ``_paused_with_hvac_already_off``/
+  ``_paused_entity``/``_paused_since`` alongside ``_paused_by_door``, matching the
+  sibling branches in ``check_natural_vent_conditions()``.
+- ``_exit_nat_vent()``'s sensor-still-open branch write-shape divergence — it used to
+  write only ``_paused_by_door``/``_pre_pause_mode``, omitting the same 3 fields
+  #657 fixed above. Both branches now go through a shared
+  ``_set_door_window_pause_fields()`` helper (one definition, not two hand-copies).
+  This closes the previously-documented risk to the ``ALL_SENSORS_CLOSED`` transition
+  below: ``_paused_with_hvac_already_off`` (which determines ``PAUSED_ACTIVE`` vs.
+  ``PAUSED_IDLE``) can no longer go stale from this branch.
+
+**Shadow-feed coverage (Issue #594 Phase R Step 1b, v0.6.24; residual closed in
+Step 3).** All 7 ``DoorWindowFsmEventKind`` members have a real feed path — see
 ``coordinator.py``'s ``_DOOR_WINDOW_FSM_EVENT_KINDS``/
 ``_DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS``/``_DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES``.
-**One accepted residual**: ``_on_grace_expired()``'s "within planned window" branch
-(automation.py, the first branch — windows recommended, sensor open is expected) emits
-no event at all, so that specific grace-expiry outcome does not feed
-``GRACE_TIMER_EXPIRED`` this increment — the shadow FSM's tracked state simply doesn't
-advance for that one case until the next event that does feed it. Explicit scope
-boundary, not a silent gap: if this needs closing before Step 2, it requires either a
-new emitted event on that branch or a bespoke direct callback (same shape as
-``_feed_override_grace_fsm_cancelled()``'s exception in override_grace_fsm.py).
+Step 1b's one documented residual — ``_on_grace_expired()``'s "within planned window"
+branch (automation.py, the first branch — windows recommended, sensor open is
+expected) previously emitted no event at all — is now closed: that branch emits
+``"grace_expired"`` (the same event type its sibling branches already use, with a
+``within_planned_window=True`` payload key to distinguish it from a real sensor
+re-check), so ``GRACE_TIMER_EXPIRED`` is now fed from all 3 of
+``_on_grace_expired()``'s outcome branches.
+
+**Remaining before this FSM can be authoritative for all 7 methods (Step 3b)**:
+``_re_pause_for_open_sensor()`` still needs to know whether it was reached from
+``GRACE`` or ``PAUSED_DURING_GRACE`` (a signature/plumbing change, not a body swap) —
+none of the Step 3 fixes above changed that. See the plan tracked on #637/#594 for the
+Step 3b scope.
 
 **Cross-lifecycle inputs.** ``natural_vent_active`` and ``whf_owns_hvac`` are
 state *reads* from other lifecycles (Issue #631's "communicating automata"

--- a/custom_components/climate_advisor/door_window_open_response.py
+++ b/custom_components/climate_advisor/door_window_open_response.py
@@ -75,13 +75,10 @@ def decide_door_open_response(inputs: DoorOpenResponseInputs) -> DoorOpenRespons
     if inputs.paused_by_door:
         return DoorOpenResponse.ALREADY_PAUSED_NOOP
 
-    if inputs.grace_active:
-        threshold = inputs.comfort_cool + inputs.nat_vent_delta
-        outdoor_cool_enough = inputs.outdoor is not None and inputs.outdoor < threshold
-        if not outdoor_cool_enough:
-            return DoorOpenResponse.GRACE_SUPPRESSED
-        # else: outdoor cool enough — fall through to the same chain below,
-        # matching production's `pass  # outdoor cool enough — fall through`.
+    if inputs.grace_active and not inputs.nat_vent_gate_entered:
+        return DoorOpenResponse.GRACE_SUPPRESSED
+    # else (grace_active and gate entered): real reactivation gate says viable —
+    # fall through to the same chain below, matching production's fallthrough.
 
     if inputs.within_planned_window:
         return DoorOpenResponse.PLANNED_WINDOW_NOOP

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.25"
+  "version": "0.6.26"
 }

--- a/tests/test_door_window.py
+++ b/tests/test_door_window.py
@@ -938,6 +938,30 @@ class TestGracePeriodExpiry:
         # No HVAC service call should have been made
         engine.hass.services.async_call.assert_not_called()
 
+    def test_door_open_during_grace_coarse_outdoor_ok_real_gate_fails_still_blocked(self):
+        """Issue #655 regression: a door/window open during an active grace period,
+        where outdoor alone looks 'cool enough' (would have passed the old coarse
+        proxy: outdoor 65 < comfort_cool 75 + nat_vent_delta 3 = threshold 78) but the
+        real 4-variable reactivation gate fails because indoor hasn't risen above the
+        comfort floor — must NOT pause. Before the fix, this scenario fell through
+        the grace check on the coarse proxy alone and could still land on a pause a
+        few lines later when the real gate was independently re-evaluated and failed.
+        """
+        engine = _make_automation_engine()
+        engine._grace_active = True
+        engine._last_resume_source = "automation"
+        engine._last_outdoor_temp = 65.0  # cool enough per the old coarse proxy
+
+        state_mock = MagicMock()
+        state_mock.state = "cool"
+        state_mock.attributes = {"current_temperature": 68}  # below comfort_heat=70
+        engine.hass.states.get.return_value = state_mock
+
+        asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+
+        assert engine._paused_by_door is False
+        engine.hass.services.async_call.assert_not_called()
+
     def test_door_open_after_grace_expires_triggers_pause(self):
         """After grace expires, a new door open correctly pauses HVAC."""
         engine = _make_automation_engine(

--- a/tests/test_door_window_fsm.py
+++ b/tests/test_door_window_fsm.py
@@ -156,15 +156,19 @@ class TestFromGrace:
         assert t.to_state == DoorWindowLifecycleState.GRACE
         assert t.outcome == "grace_suppressed"
 
-    def test_sensor_opened_falls_through_to_composite_state(self):
-        # outdoor cool enough (76 < threshold 80) -> falls through past the grace
-        # guard; nat-vent gate then fails (outdoor == indoor, not strictly less)
-        # -> pause, with grace still active -> PAUSED_DURING_GRACE.
+    def test_sensor_opened_real_gate_fails_suppressed_not_composite_state(self):
+        # Issue #655 fix: the grace guard is now gated on the real reactivation gate
+        # (nat_vent_gate_entered), not an outdoor-only proxy. outdoor==indoor (76==76)
+        # means the real gate fails (not strictly less), so this must stay suppressed
+        # — it must NOT fall through to a composite paused state, even though outdoor
+        # alone (76 < threshold 80) would have looked "cool enough" under the old,
+        # since-removed proxy check this scenario used to exercise.
         t = transition(
             DoorWindowLifecycleState.GRACE,
             _ev(DoorWindowFsmEventKind.SENSOR_OPENED, outdoor=76.0, indoor=76.0, hvac_mode="cool"),
         )
-        assert t.to_state == DoorWindowLifecycleState.PAUSED_DURING_GRACE
+        assert t.to_state == DoorWindowLifecycleState.GRACE
+        assert t.outcome == "grace_suppressed"
 
     def test_sensor_opened_falls_through_to_nat_vent_eligible_stays_grace(self):
         t = transition(

--- a/tests/test_door_window_pure_modules.py
+++ b/tests/test_door_window_pure_modules.py
@@ -95,19 +95,25 @@ class TestDecideDoorOpenResponse:
         result = decide_door_open_response(self._inputs(paused_by_door=True))
         assert result == DoorOpenResponse.ALREADY_PAUSED_NOOP
 
-    def test_grace_active_outdoor_too_warm_suppressed(self):
-        result = decide_door_open_response(self._inputs(grace_active=True, outdoor=85.0))
+    def test_grace_active_gate_not_entered_suppressed(self):
+        # Issue #655 fix: grace-active fallthrough is gated on the real reactivation
+        # gate result, not a coarse outdoor-only proxy — outdoor alone can no longer
+        # decide this. A cool outdoor temp with the real gate still False must NOT
+        # fall through (the exact premature-pause bug #655 reported).
+        result = decide_door_open_response(self._inputs(grace_active=True, outdoor=65.0, nat_vent_gate_entered=False))
         assert result == DoorOpenResponse.GRACE_SUPPRESSED
 
     def test_grace_active_outdoor_unavailable_suppressed(self):
         result = decide_door_open_response(self._inputs(grace_active=True, outdoor=None))
         assert result == DoorOpenResponse.GRACE_SUPPRESSED
 
-    def test_grace_active_outdoor_cool_falls_through_to_pause(self):
-        result = decide_door_open_response(self._inputs(grace_active=True, outdoor=65.0))
-        assert result == DoorOpenResponse.PAUSE
-
-    def test_grace_active_outdoor_cool_falls_through_to_nat_vent(self):
+    def test_grace_active_gate_entered_never_falls_through_to_pause(self):
+        # Once the shared gate is entered, the same result is reused at the final
+        # nat-vent-vs-pause branch below — grace-active fallthrough can only land on
+        # NAT_VENT_ELIGIBLE (or PLANNED_WINDOW_NOOP), never PAUSE. This invariant is
+        # the fix: #655's bug was reachable exactly because the old coarse proxy and
+        # the real gate could disagree, letting a "cool enough" outdoor temp fall
+        # through the grace suppression only to still land on PAUSE moments later.
         result = decide_door_open_response(self._inputs(grace_active=True, outdoor=65.0, nat_vent_gate_entered=True))
         assert result == DoorOpenResponse.NAT_VENT_ELIGIBLE
 

--- a/tests/test_grace_refresh_and_band_call.py
+++ b/tests/test_grace_refresh_and_band_call.py
@@ -149,6 +149,8 @@ class TestGraceExpiryTriggersRefreshCallback:
         engine = _minimal_engine()
         refresh_mock = MagicMock()
         engine._request_refresh_callback = refresh_mock
+        events: list[tuple] = []
+        engine._emit_event_callback = lambda name, data: events.append((name, data))
 
         # Make _is_within_planned_window_period return True by patching
         engine._current_classification = MagicMock()
@@ -164,6 +166,11 @@ class TestGraceExpiryTriggersRefreshCallback:
             engine._on_grace_expired(source="manual", duration=1800, should_notify=False)
 
         refresh_mock.assert_called_once()
+        # Shadow-feed completion (door/window Step 3, #637): this was the one
+        # GRACE_TIMER_EXPIRED outcome that never emitted an event at all, leaving the
+        # shadow FSM's tracked state stale for this specific expiry outcome. Reuses
+        # the existing "grace_expired" event type with a distinguishing payload key.
+        assert ("grace_expired", {"source": "manual", "within_planned_window": True, "re_paused": False}) in events
 
     def test_sensor_still_open_path_calls_refresh_callback(self):
         """Re-pause path (sensor still open): callback fires after clearing grace."""

--- a/tests/test_nat_vent_activation.py
+++ b/tests/test_nat_vent_activation.py
@@ -322,6 +322,13 @@ class TestNatVentOutdoorRiseExit:
         assert engine._natural_vent_active is False
         assert engine._paused_by_door is True
         assert engine._nat_vent_outdoor_exit_time is not None
+        # Write-shape divergence fix (found while scoping #637 Step 3): _exit_nat_vent()'s
+        # sensor-still-open branch used to write only _paused_by_door/_pre_pause_mode —
+        # now writes the same field set _pause_for_door_window() does. climate_state
+        # reports "cool" (not off), so pre_pause_mode is truthy → hvac_already_off=False.
+        assert engine._paused_with_hvac_already_off is False
+        assert engine._paused_entity == "nat-vent-exit"
+        assert engine._paused_since is not None
 
         rise_events = [e for e in events if e[0] == "nat_vent_outdoor_rise_exit"]
         assert len(rise_events) == 1

--- a/tests/test_resume_from_pause.py
+++ b/tests/test_resume_from_pause.py
@@ -494,6 +494,13 @@ class TestGraceExpiryRecheck:
             }
         )
         engine._paused_by_door = True
+        # Issue #657: these 3 fields were left stale by the #637 Step 1 fix above —
+        # only _paused_by_door was cleared. Seed them with stale values from a prior
+        # pause cycle to prove the fix clears all 4 fields together, matching the
+        # sibling branch in check_natural_vent_conditions().
+        engine._paused_with_hvac_already_off = True
+        engine._paused_entity = "binary_sensor.stale_from_prior_pause"
+        engine._paused_since = datetime.now()
         engine._last_outdoor_temp = 65.0
         climate_state = MagicMock()
         climate_state.state = "off"
@@ -505,6 +512,9 @@ class TestGraceExpiryRecheck:
 
         assert engine._natural_vent_active is True
         assert engine._paused_by_door is False
+        assert engine._paused_with_hvac_already_off is False
+        assert engine._paused_entity is None
+        assert engine._paused_since is None
 
     def test_grace_expiry_clears_normally_when_closed(self):
         """If all sensors are closed at grace expiry, grace clears normally."""

--- a/tests/test_shadow_engine_coverage.py
+++ b/tests/test_shadow_engine_coverage.py
@@ -89,6 +89,12 @@ _COVERAGE_REGISTRY: dict[str, str] = {
     "_pause_for_door_window": (
         "internal: called only from handle_door_window_open (mirrored) and _re_pause_for_open_sensor (internal)"
     ),
+    "_set_door_window_pause_fields": (
+        "internal: Issue #637 Phase R Step 3 shared setter, called only from "
+        "_pause_for_door_window (internal, itself called from already-mirrored entry "
+        "points) and _exit_nat_vent (internal, shared choke point) — one definition of "
+        "the door/window pause write-shape, not itself a new entry point"
+    ),
     "_apply_door_window_fsm_state": (
         "internal: Issue #594 Phase R Step 2 helper, called only from the FSM-authoritative "
         "branches of handle_manual_override_during_pause (mirrored) and resume_from_pause "

--- a/tools/simulations/golden/MANIFEST.json
+++ b/tools/simulations/golden/MANIFEST.json
@@ -394,8 +394,8 @@
     "issue": 629
   },
   "issue_637_paused_during_grace_open_fallthrough": {
-    "sha256": "c06e3dbb0aa583fc182954702f5a936e4206c280f3f2587be0ffc60c26af9f75",
-    "signed": "2026-08-14",
+    "sha256": "90e1a78d73f2fa27558186f57cf55b9655cb4153393683a6f8ce9318304ad15b",
+    "signed": "2026-08-16",
     "issue": 637
   },
   "issue_637_paused_during_grace_nat_vent_exit": {

--- a/tools/simulations/golden/issue_637_paused_during_grace_open_fallthrough.json
+++ b/tools/simulations/golden/issue_637_paused_during_grace_open_fallthrough.json
@@ -1,14 +1,14 @@
 {
   "name": "issue_637_paused_during_grace_open_fallthrough",
-  "description": "Confirms the door/window pause FSM's new PAUSED_DURING_GRACE composite state is genuinely reachable in production, not just a static-trace hypothesis (Issue #637, Block 5 Phase 2). Sensor opens while hot (pauses HVAC), closes (resumes + starts a 10-min automation grace period), a cool front moves in, then the sensor reopens while grace is STILL active. handle_door_window_open()'s grace guard only suppresses when outdoor is too warm to nat-vent — with outdoor now cool, it falls through past the guard, but the nat-vent gate itself fails (indoor has not risen above comfort_heat), so _pause_for_door_window() fires with _grace_active never cleared. Occupant impact: HVAC pauses correctly (a door is genuinely open), but the system is left in an undocumented flag combination (paused + grace both active) that the pre-FSM code has no name for — this scenario proves the FSM's new composite state matches what production actually does here, not a hypothetical.",
+  "description": "Confirms grace periods genuinely hold through this exact fallthrough path in production, not just as a static-trace hypothesis (Issue #637/#655, Block 5 Phase R Step 3). Sensor opens while hot (pauses HVAC), closes (resumes + starts a 10-min automation grace period), a cool front moves in, then the sensor reopens while grace is STILL active. Before the #655 fix, handle_door_window_open()'s grace guard only suppressed the pause using a coarse outdoor-only proxy -- when outdoor looked cool enough, execution fell through past the guard to the real (indoor-and-outdoor) nat-vent gate, and if THAT gate then failed, the fallthrough paused HVAC anyway, silently defeating the grace period the occupant was just given. The #655 fix makes the grace guard share the same real gate result the fallthrough already computes, so a reopen during grace that the real gate says isn't nat-vent-viable now correctly stays suppressed -- HVAC keeps running, uninterrupted, exactly as a 'grace period' should behave. Occupant impact: before the fix, briefly reopening a door mid-grace-window could pause the AC/heat anyway; after the fix, it can't.",
   "source": "synthetic",
   "issue": 637,
   "notes": [
-    "Exercises violation path #1 from the Phase 2 plan's five-whys analysis: handle_door_window_open()'s `if self._grace_active:` guard (automation.py ~L2823) only suppresses the pause when outdoor is too warm for nat-vent; when outdoor is cool enough to fall through, execution reaches _pause_for_door_window() with grace still active if the nat-vent gate itself then fails (here: indoor has not risen above comfort_heat).",
+    "Exercises the exact fallthrough path #655 was filed against: handle_door_window_open()'s `if self._grace_active:` guard (automation.py ~L2889) now shares the same real _nat_vent_may_reactivate() gate result the nat-vent-vs-pause decision further down the function uses, instead of a coarse outdoor-only proxy. When that shared gate fails, the grace-active branch returns immediately (not pausing) rather than falling through to a second, independently-computed gate that could disagree.",
     "use_coordinator=true so the real _async_door_window_changed listener drives debounce/pause/resume/grace exactly as production does (sensor_debounce_seconds default is 0 in the harness, so debounce is effectively instant).",
-    "comfort_heat=72 (unusually high) is deliberate: at the 13:14 reopen, indoor=71 is BELOW comfort_heat=72, so decide_nat_vent_gate()'s floor check (indoor > comfort_heat) fails even though outdoor(60) is otherwise nat-vent-favorable (cool, below threshold) -- this is what forces the fall-through to land on PAUSE instead of nat-vent activation.",
-    "automation_grace_seconds=600 (10 min) gives enough room between the 13:00 resume and the 13:14 reopen for grace to still be active (expires 13:10).",
-    "Assertion at 13:14 uses the new 'paused_during_grace' custom assertion type (tools/sim_harness/outcomes.py), which reads the production engine's final _paused_by_door AND _grace_active flags directly -- the same evidence-based pattern the existing 'paused_by_door' assertion type already uses, extended to check both flags at once."
+    "comfort_heat=72 (unusually high) is deliberate: at the 13:07 reopen, indoor=71 is BELOW comfort_heat=72, so decide_nat_vent_gate()'s floor check (indoor > comfort_heat) fails even though outdoor(60) is otherwise nat-vent-favorable (cool, below threshold) -- this is exactly the shape of disagreement the old coarse proxy could miss, and the fixed shared-gate check correctly still suppresses on.",
+    "automation_grace_seconds=600 (10 min) gives enough room between the 13:00 resume and the 13:07 reopen for grace to still be active (expires 13:10).",
+    "Before the #655 fix, this scenario's final assertion was 'paused_during_grace' (the bug: HVAC paused anyway, grace silently defeated). It is now 'resumed' (the fix: grace holds, no pause) -- updated 2026-08-16 with explicit user sign-off per the Golden Simulation Test Policy, since #655's fix is what this scenario now exists to prove."
   ],
   "use_coordinator": true,
   "skip_startup_coalesce": true,
@@ -62,7 +62,7 @@
       "time": "2026-08-14T13:07:00",
       "type": "sensor_open",
       "entity": "binary_sensor.back_door",
-      "note": "Door reopens at 13:07, while the 13:00 grace period is still active (expires 13:10). Grace's own outdoor-too-warm guard does NOT suppress (60F < 77F threshold) -- falls through. Nat-vent gate then fails (indoor 71F is not > comfort_heat 72F), so the fall-through lands on a pause with grace still active: PAUSED_DURING_GRACE."
+      "note": "Door reopens at 13:07, while the 13:00 grace period is still active (expires 13:10). The real reactivation gate (outdoor 60F is favorable, but indoor 71F is not above comfort_heat 72F) fails, so the grace guard now correctly suppresses -- grace holds, HVAC stays resumed, no pause."
     },
     {
       "time": "2026-08-14T13:08:00",
@@ -87,8 +87,8 @@
     },
     {
       "at": "2026-08-14T13:08:00",
-      "expect": "paused_during_grace",
-      "reason": "Sensor reopens while grace is still active. Outdoor is cool enough to fall through the grace guard, but the nat-vent gate fails on the indoor-vs-comfort_heat floor check, so the fall-through pauses HVAC without ever clearing the still-active grace period -- production genuinely reaches _paused_by_door=True AND _grace_active=True simultaneously (Issue #637's confirmed-reachable PAUSED_DURING_GRACE state).",
+      "expect": "resumed",
+      "reason": "Sensor reopens while grace is still active. The real reactivation gate fails (indoor 71F is not above comfort_heat 72F, even though outdoor 60F is otherwise favorable) -- the #655 fix means the grace guard shares this same gate result, so it suppresses the pause instead of falling through to it. HVAC stays resumed through the entire grace window, honoring the grace period's purpose.",
       "track": "integration"
     }
   ]


### PR DESCRIPTION
## Summary

Closes 4 of Step 2's 5 documented blockers for the door/window pause/grace FSM migration (Block 5 epic #594, #637), right-sized per a revised, evidence-based scope investigated this session.

- **Fixes #655**: `handle_door_window_open()`'s grace-active branch used a coarse outdoor-only proxy check that could disagree with the real 4-variable reactivation gate (`_nat_vent_may_reactivate()`) computed a few lines later in the same function — letting a briefly reopened door defeat an active grace period. Now shares one gate result instead of two independently-computed checks. `door_window_open_response.py`'s pure mirror updated to match.
- **Fixes #657**: `_re_pause_for_open_sensor()`'s nat-vent-reactivation branch cleared only `_paused_by_door`, leaving `_paused_with_hvac_already_off`/`_paused_entity`/`_paused_since` stale. Now clears all 4 fields, matching the sibling branch in `check_natural_vent_conditions()`.
- **Write-shape divergence** (found while scoping Step 3, no separate issue filed): `_exit_nat_vent()`'s sensor-still-open branch wrote fewer pause fields than `_pause_for_door_window()`. Both now go through a new shared `_set_door_window_pause_fields()` helper. This also closes the previously-documented `ALL_SENSORS_CLOSED`/`pre_pause_mode`-placeholder risk in `door_window_fsm.py`, so `handle_all_doors_windows_closed()` needed no separate fix of its own — contrary to Step 2's original assumption.
- **Shadow-feed completion**: `_on_grace_expired()`'s "within planned window" branch now emits an event (reusing `"grace_expired"` with a distinguishing payload key), closing Step 1b's one documented residual — all 3 of its outcome branches now feed `GRACE_TIMER_EXPIRED`.

Updates one **LOCKED golden scenario** (`issue_637_paused_during_grace_open_fallthrough.json`) with explicit user sign-off per the Golden Simulation Test Policy — it had deliberately encoded #655's bug as its expected final outcome (`paused_during_grace`); re-signed to assert the fixed behavior (`resumed`, i.e. grace correctly holds).

Still blocked, deferred to a future increment: `_re_pause_for_open_sensor()` still needs to know whether it was reached from `GRACE` or `PAUSED_DURING_GRACE` (a signature/plumbing change) before it can join FSM authority.

## Test plan
- [x] Full suite: 4697 passed, 6 skipped (3 pre-existing unrelated flakes deselected, confirmed pre-existing on main)
- [x] Golden corpus: 81/81 passed
- [x] `ruff check` / `ruff format` clean
- [x] TDD: each of the 4 fixes verified red against pre-fix code, green against fixed code
- [x] Golden scenario re-signed with explicit user sign-off, `--check-integrity` clean