### PR TITLE
Fix #660: door/window FSM full authority for all 8 real trigger sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.27] — 2026-08-16
+
+- Fix #660: the door/window pause/grace lifecycle FSM now has full, off-by-default authority for all 8 real trigger sites — completing the migration begun in #637. Also fixes a real gap found during that work: when a grace period was already running and a door/window pause independently became active too, the FSM's own tracked state could disagree with what production actually did, and a resume-after-close could restore the wrong prior HVAC mode in a specific reachable sequence. Both are fixed at the source for every caller, not patched per call site. The switch that lets this FSM actually drive decisions (instead of just tracking them for comparison) stays off by default — no occupant-visible behavior change from this release alone.
+
 ## [0.6.26] — 2026-08-16
 
 - Fix #655: a door/window briefly reopened during an active grace period could still pause the AC/heat, even though the grace period exists specifically to avoid reacting to exactly that. The grace check now uses the same accurate indoor+outdoor reactivation check the automation already computes a moment later, instead of a coarser outdoor-only shortcut that could disagree with it — grace now reliably holds for its full duration.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -782,16 +782,18 @@ class AutomationEngine:
         # Default False — zero behavior change until a future per-lifecycle
         # switch (Phase R, Step 4) flips it. Not yet exposed to config/switch.py.
         self._natvent_fsm_authoritative: bool = False
-        # Issue #594 Phase R, Step 2 (door/window): PARTIAL authority only —
-        # governs handle_all_doors_windows_closed()/handle_manual_override_during_pause()/
-        # resume_from_pause() alone. The other 4 door/window methods
-        # (handle_door_window_open, _re_pause_for_open_sensor, _on_grace_expired,
-        # _exit_nat_vent's sensor-still-open branch) stay on the legacy path
-        # regardless of this flag's value — each has its own documented blocker
-        # (#655, an origin-state plumbing gap, a missing shadow-FSM feed, and a
-        # write-shape divergence, respectively) that must resolve before it can
-        # join. Default False — zero behavior change until the switch (Step 4)
-        # flips it, and even then only for the 3 methods above.
+        # Issue #594 Phase R, Step 8 (door/window): FULL authority — as of Issue #660,
+        # this flag governs all 8 real door/window trigger sites via the shared
+        # AutomationEngine._resolve_door_window_pause_flags() dispatcher:
+        # handle_manual_override_during_pause(), resume_from_pause(),
+        # handle_all_doors_windows_closed(), _exit_nat_vent()'s sensor-still-open
+        # branch, check_natural_vent_conditions()'s two reactivation branches (the
+        # 8th site — previously had no door/window FSM event feed at all),
+        # handle_door_window_open(), and _on_grace_expired()/_re_pause_for_open_sensor()
+        # (coupled — the highest-risk pair, since _re_pause_for_open_sensor() trusts
+        # the flags _on_grace_expired() already applied rather than re-deciding them).
+        # Default False — zero behavior change until a future switch (config/switch.py)
+        # flips it; deployed OFF, live switch-flip is a separate verification step.
         self._doorwindow_fsm_authoritative: bool = False
 
         # Override confirmation period (Issue #76) — pending window before override is formally accepted
@@ -5947,16 +5949,16 @@ class AutomationEngine:
         """Current door/window pause/grace session state, derived from existing
         flags (Issue #637).
 
-        Read-only observability by default — the value this property computes
-        is also fed as the ``current_state`` argument to ``door_window_fsm.transition()``
-        by the 2 methods that are FSM-authoritative as of Phase R Step 2
-        (``handle_manual_override_during_pause``, ``resume_from_pause``); see each
-        method's own FSM-authoritative branch. (``handle_all_doors_windows_closed``
-        was scoped into this increment originally but deferred — its
-        ``ALL_SENSORS_CLOSED`` transition in ``door_window_fsm.py`` infers
-        ``pre_pause_mode`` from state rather than taking the real value as input,
-        which isn't safe to trust for real flag-derivation until fixed.) Purely a
-        computed view of ``_paused_by_door``/``_paused_with_hvac_already_off``/
+        Read-only observability by default — the value this property computes is
+        also fed as the ``current_state`` argument to ``door_window_fsm.transition()``
+        by ``AutomationEngine._resolve_door_window_pause_flags()``, the shared
+        dispatcher every one of the 8 real door/window trigger methods now calls
+        under ``_doorwindow_fsm_authoritative`` (full authority as of Issue #660
+        Phase R Step 8 — see that flag's own docstring for the full method list).
+        ``_on_grace_expired()`` is the one call site that passes an explicitly
+        captured ``origin_state`` instead of relying on this property's live read,
+        since grace is already cleared by the time it would otherwise read it. Purely
+        a computed view of ``_paused_by_door``/``_paused_with_hvac_already_off``/
         ``_grace_active``, so it cannot desync from the flags it reads. See
         ``door_window_lifecycle.py`` for the pure derivation.
         """

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -2953,6 +2953,8 @@ class AutomationEngine:
 
         Called by the coordinator after the debounce period.
         """
+        from .door_window_fsm import DoorWindowFsmEventKind
+
         async with self._decision_pass("handle_door_window_open"):
             if self._paused_by_door:
                 return  # Already paused
@@ -3133,7 +3135,14 @@ class AutomationEngine:
 
             debounce_minutes = self.config.get(CONF_SENSOR_DEBOUNCE, DEFAULT_SENSOR_DEBOUNCE_SECONDS) // 60
             friendly_name = entity_id.split(".")[-1].replace("_", " ").title()
-            await self._pause_for_door_window(
+            # Issue #660 Step 7: calls the action half directly (instead of going
+            # through the _pause_for_door_window() wrapper) and derives its own flags
+            # under its own event kind (SENSOR_OPENED — same kind the wrapper already
+            # used for this outcome, no change in FSM behavior, just explicit routing
+            # matching this method's Group B role). No change to any decision logic
+            # above this point — both Phase 2 guards, the grace real-gate, and the
+            # planned-window check stay byte-for-byte unchanged.
+            hvac_already_off = await self._pause_for_door_window_action(
                 entity_label=entity_id,
                 reason=f"door/window open — {entity_id}",
                 notify_message=(
@@ -3143,6 +3152,17 @@ class AutomationEngine:
                 ),
                 notify_type="door_window_pause",
             )
+            if hvac_already_off is not None:
+
+                def _legacy_set_pause() -> None:
+                    self._set_door_window_pause_fields(entity_label=entity_id, hvac_already_off=hvac_already_off)
+
+                self._resolve_door_window_pause_flags(
+                    kind=DoorWindowFsmEventKind.SENSOR_OPENED,
+                    legacy=_legacy_set_pause,
+                )
+                self._paused_entity = entity_id
+                self._paused_since = dt_util.now()
 
     async def handle_all_doors_windows_closed(self) -> None:
         """Resume HVAC after all monitored doors/windows are closed."""

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -2857,6 +2857,49 @@ class AutomationEngine:
         self._paused_entity = entity_label
         self._paused_since = dt_util.now()
 
+    async def _pause_for_door_window_action(
+        self, *, entity_label: str, reason: str, notify_message: str, notify_type: str
+    ) -> bool | None:
+        """The HVAC-affecting half of a door/window pause (Issue #660 Step 6):
+        thermostat mode capture, turning HVAC off (or noting it's already off),
+        notifying, and emitting the "sensor_opened" event. Split out of the former
+        monolithic ``_pause_for_door_window()`` so Group B callers
+        (``handle_door_window_open()``, ``_re_pause_for_open_sensor()``) can run this
+        action half unconditionally while deriving their resulting pause *flags*
+        through the shared FSM dispatcher under their own event kind.
+
+        Returns ``hvac_already_off``: ``False`` if HVAC was actively turned off (a
+        real mode transition happened), ``True`` if HVAC was already off (pause flag
+        only). Returns ``None`` if the thermostat state was unavailable/unknown — no
+        pause happens at all in that case (disambiguated from ``hvac_already_off``,
+        which only makes sense once a pause is actually occurring; the original
+        monolithic method's ``return False`` for this case conflated the two).
+        """
+        state = self.hass.states.get(self.climate_entity)
+        mode = state.state if state else None
+        if mode and mode not in ("off", "unavailable", "unknown"):
+            self._pre_pause_mode = mode
+            await self._set_hvac_mode("off", reason=f"{reason}, was {mode} mode")
+            await self._notify(notify_message, "Climate Advisor", notification_type=notify_type)
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "sensor_opened",
+                    {"entity": entity_label, "result": "paused", "hvac_mode_change": f"{mode}→off"},
+                )
+            return False
+        if mode == "off":
+            _LOGGER.info(
+                "Door/window pause (%s): HVAC already off — pause flag set, no mode change needed",
+                entity_label,
+            )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "sensor_opened",
+                    {"entity": entity_label, "result": "paused"},
+                )
+            return True
+        return None
+
     async def _pause_for_door_window(
         self, *, entity_label: str, reason: str, notify_message: str, notify_type: str
     ) -> bool:
@@ -2868,34 +2911,42 @@ class AutomationEngine:
         silently leaving the next apply_classification() cycle unguarded. Single source of
         truth for both call sites now.
 
+        Issue #660 Step 6: thin wrapper over the split action half
+        (``_pause_for_door_window_action()``) and flags half (the shared
+        ``_resolve_door_window_pause_flags()`` dispatcher, kind=SENSOR_OPENED — the
+        same event kind ``handle_door_window_open()`` uses under Step 7, since this
+        is semantically the same "a door/window is open, pause" outcome). Kept
+        callable for its own generic callers (``_apply_comfort_band()``'s guard,
+        ``_sync_paused_by_door_with_live_sensors()``'s SYNC_RECONCILE-adjacent
+        direct-pause path) — both automatically become FSM-authoritative-capable
+        through this one shared wrapper rather than needing individual treatment.
+
         Returns True if HVAC was actively turned off (a real mode transition happened),
-        False if HVAC was already off and only the pause flag was set.
+        False if HVAC was already off and only the pause flag was set (or if the
+        thermostat state was unavailable/unknown and no pause happened at all).
         """
-        state = self.hass.states.get(self.climate_entity)
-        mode = state.state if state else None
-        if mode and mode not in ("off", "unavailable", "unknown"):
-            self._pre_pause_mode = mode
-            self._set_door_window_pause_fields(entity_label=entity_label, hvac_already_off=False)
-            await self._set_hvac_mode("off", reason=f"{reason}, was {mode} mode")
-            await self._notify(notify_message, "Climate Advisor", notification_type=notify_type)
-            if self._emit_event_callback:
-                self._emit_event_callback(
-                    "sensor_opened",
-                    {"entity": entity_label, "result": "paused", "hvac_mode_change": f"{mode}→off"},
-                )
-            return True
-        if mode == "off":
-            self._set_door_window_pause_fields(entity_label=entity_label, hvac_already_off=True)
-            _LOGGER.info(
-                "Door/window pause (%s): HVAC already off — pause flag set, no mode change needed",
-                entity_label,
-            )
-            if self._emit_event_callback:
-                self._emit_event_callback(
-                    "sensor_opened",
-                    {"entity": entity_label, "result": "paused"},
-                )
-        return False
+        hvac_already_off = await self._pause_for_door_window_action(
+            entity_label=entity_label, reason=reason, notify_message=notify_message, notify_type=notify_type
+        )
+        if hvac_already_off is None:
+            return False
+
+        from .door_window_fsm import DoorWindowFsmEventKind
+
+        def _legacy_set_pause() -> None:
+            self._set_door_window_pause_fields(entity_label=entity_label, hvac_already_off=hvac_already_off)
+
+        self._resolve_door_window_pause_flags(
+            kind=DoorWindowFsmEventKind.SENSOR_OPENED,
+            legacy=_legacy_set_pause,
+        )
+        # _paused_entity/_paused_since aren't part of _apply_door_window_fsm_state()'s
+        # 3-field derivation (see its own docstring) — direct writes here regardless
+        # of which branch the dispatcher took, matching what
+        # _set_door_window_pause_fields() would have written on the legacy path.
+        self._paused_entity = entity_label
+        self._paused_since = dt_util.now()
+        return not hvac_already_off
 
     async def handle_door_window_open(self, entity_id: str) -> None:
         """Handle a door/window being opened for longer than the debounce period.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -5744,6 +5744,7 @@ class AutomationEngine:
             grace_source=self._last_resume_source or "automation",
             natural_vent_active=bool(self._natural_vent_active),
             whf_owns_hvac=bool(self._whf_owns_hvac()),
+            grace_active=bool(self._grace_active),
             now=now,
         )
 

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -5745,6 +5745,7 @@ class AutomationEngine:
             natural_vent_active=bool(self._natural_vent_active),
             whf_owns_hvac=bool(self._whf_owns_hvac()),
             grace_active=bool(self._grace_active),
+            pre_pause_mode_active=bool(self._pre_pause_mode),
             now=now,
         )
 

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -3657,8 +3657,19 @@ class AutomationEngine:
                         )
                     )
                     self._natural_vent_active = True
-                    self._paused_by_door = False
-                    self._paused_with_hvac_already_off = False
+
+                    from .door_window_fsm import DoorWindowFsmEventKind
+
+                    # Issue #660 Step 5: routed through the shared dispatcher — the
+                    # 8th trigger site (Step 3 gave this method an event kind at all).
+                    def _legacy_clear_pause() -> None:
+                        self._paused_by_door = False
+                        self._paused_with_hvac_already_off = False
+
+                    self._resolve_door_window_pause_flags(
+                        kind=DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED,
+                        legacy=_legacy_clear_pause,
+                    )
                     self._paused_entity = None
                     self._paused_since = None
                     _LOGGER.info(
@@ -3689,8 +3700,17 @@ class AutomationEngine:
                     )
                     self._natural_vent_active = True
                     self._nat_vent_soft_start = True
-                    self._paused_by_door = False
-                    self._paused_with_hvac_already_off = False
+
+                    from .door_window_fsm import DoorWindowFsmEventKind
+
+                    def _legacy_clear_pause() -> None:
+                        self._paused_by_door = False
+                        self._paused_with_hvac_already_off = False
+
+                    self._resolve_door_window_pause_flags(
+                        kind=DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED,
+                        legacy=_legacy_clear_pause,
+                    )
                     self._paused_entity = None
                     self._paused_since = None
                     _LOGGER.info(

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -4685,6 +4685,24 @@ class AutomationEngine:
                 TIMER_BOUNDARY_SETTLE_SECONDS,
             )
 
+        # Issue #660 Step 8: captured once, before any branch's _cancel_grace_timers()
+        # runs (that call clears _grace_active, which door_window_lifecycle_state
+        # reads) — nothing between here and each branch's own _cancel_grace_timers()
+        # call touches door/window pause/grace state, so one capture at the top
+        # covers all 3 branches. The shared dispatcher always reads
+        # self.door_window_lifecycle_state *live* by default, which would be wrong
+        # here specifically since grace will already be cleared by the time it runs
+        # — this is the one call site that needs the origin_state override.
+        from .door_window_fsm import DoorWindowFsmEventKind
+
+        _origin_state = self.door_window_lifecycle_state
+
+        def _legacy_noop() -> None:
+            # None of the 3 branches below write _paused_by_door/_paused_with_hvac_already_off
+            # directly from _on_grace_expired() itself in legacy mode — the "any sensor
+            # open" branch defers that to the scheduled _re_pause_for_open_sensor() task.
+            pass
+
         # If within planned window period, sensors open is expected — just clear grace
         if self._is_within_planned_window_period():
             _LOGGER.info(
@@ -4692,6 +4710,11 @@ class AutomationEngine:
                 source,
             )
             self._cancel_grace_timers()
+            self._resolve_door_window_pause_flags(
+                kind=DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED,
+                legacy=_legacy_noop,
+                origin_state=_origin_state,
+            )
             self.clear_manual_override(reason="grace_expired")
             if self._request_refresh_callback:
                 self._request_refresh_callback()
@@ -4716,6 +4739,18 @@ class AutomationEngine:
                 source,
             )
             self._cancel_grace_timers()
+            # Issue #660 Step 8: when authoritative, this applies the FSM's RE_PAUSE
+            # outcome (including its own nested nat-vent reactivation gate check) to
+            # _paused_by_door/_paused_with_hvac_already_off/_grace_active BEFORE
+            # _re_pause_for_open_sensor() is scheduled below, so that task can select
+            # its action by reading the already-applied flag instead of independently
+            # recomputing the gate and re-writing them. Legacy mode: no-op, matching
+            # today's behavior of deferring the write entirely to that scheduled task.
+            self._resolve_door_window_pause_flags(
+                kind=DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED,
+                legacy=_legacy_noop,
+                origin_state=_origin_state,
+            )
             self.clear_manual_override(reason="grace_expired")
             if self._request_refresh_callback:
                 self._request_refresh_callback()
@@ -4753,6 +4788,11 @@ class AutomationEngine:
             )
 
         self._cancel_grace_timers()
+        self._resolve_door_window_pause_flags(
+            kind=DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED,
+            legacy=_legacy_noop,
+            origin_state=_origin_state,
+        )
         self.clear_manual_override(reason="adopted_matching_decision" if _adopted else "grace_expired")
         if self._request_refresh_callback:
             self._request_refresh_callback()
@@ -4834,51 +4874,62 @@ class AutomationEngine:
                     "Skipping re-pause — within planned window period (windows recommended)",
                 )
                 return
-            # Check nat-vent conditions before blindly re-pausing
             outdoor = self._last_outdoor_temp
             comfort_cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
             nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
             indoor = self._get_indoor_temp_f()
             comfort_heat = self._nat_vent_reactivation_floor()
-            # Issue #411 (Pass 4): shared reactivation gate, previously hand-copied here as
-            # "Issue #392 Fix 1: mirror the ODE ceiling guard's dormancy condition." No
-            # hysteresis applied at this call site (default 0.0).
             nat_vent_threshold = comfort_cool + nat_vent_delta
-            if self._nat_vent_may_reactivate(
-                outdoor=outdoor,
-                indoor=indoor,
-                comfort_heat=comfort_heat,
-                comfort_cool=comfort_cool,
-                nat_vent_delta=nat_vent_delta,
-            ):
+
+            if self._doorwindow_fsm_authoritative:
+                # Issue #660 Step 8: when authoritative, _on_grace_expired() already
+                # applied the FSM's RE_PAUSE outcome (including its own nested
+                # nat-vent reactivation gate check, identical to
+                # _nat_vent_may_reactivate() below) to _paused_by_door BEFORE
+                # scheduling this task — select the matching action by reading that
+                # already-applied flag instead of independently recomputing the gate.
+                _reactivates = not self._paused_by_door
+            else:
+                # Issue #411 (Pass 4): shared reactivation gate, previously hand-copied
+                # here as "Issue #392 Fix 1: mirror the ODE ceiling guard's dormancy
+                # condition." No hysteresis applied at this call site (default 0.0).
+                _reactivates = self._nat_vent_may_reactivate(
+                    outdoor=outdoor,
+                    indoor=indoor,
+                    comfort_heat=comfort_heat,
+                    comfort_cool=comfort_cool,
+                    nat_vent_delta=nat_vent_delta,
+                )
+
+            if _reactivates:
                 nat_vent_reason = (
                     f"grace expired — nat-vent: outdoor {outdoor:.1f}°F < indoor {indoor:.1f}°F,"
                     f" outdoor {outdoor:.1f}°F ≤ {nat_vent_threshold:.1f}°F"
                 )
                 await self._activate_fan(reason=nat_vent_reason)
                 self._natural_vent_active = True
-                # Issue #637 (Phase R Step 1, violation #3): clear the stale pause flag,
-                # matching the structurally identical branch in
-                # check_natural_vent_conditions() (see _exit_nat_vent()'s callers around
-                # automation.py:3486/3518). Without this, _paused_by_door stays True even
-                # though nat-vent has taken over control, which incorrectly suppresses the
-                # away/vacation setback band (handle_occupancy_away/vacation both early-return
-                # on _paused_by_door=True) and misreports "paused by door" on the
-                # dashboard/API while nat-vent is actually running.
-                # Issue #657: the above fix only cleared _paused_by_door, leaving
-                # _paused_with_hvac_already_off/_paused_entity/_paused_since stale —
-                # the sibling reactivation branches in check_natural_vent_conditions()
-                # (automation.py ~:3614-3617/3646-3649) clear all 4 fields together.
-                # Stale _paused_entity/_paused_since only feed diagnostic text
-                # (Activity Report "Settings" cell via ai_skills_context.py's
-                # _render_paused_entity_settings()), but a stale
-                # _paused_with_hvac_already_off feeds real control flow — it's what
-                # derive_door_window_lifecycle_state() uses to tell PAUSED_ACTIVE from
-                # PAUSED_IDLE.
-                self._paused_by_door = False
-                self._paused_with_hvac_already_off = False
-                self._paused_entity = None
-                self._paused_since = None
+                if not self._doorwindow_fsm_authoritative:
+                    # Issue #637 (Phase R Step 1, violation #3): clear the stale pause
+                    # flag, matching the structurally identical branch in
+                    # check_natural_vent_conditions() (see _exit_nat_vent()'s callers
+                    # around automation.py:3486/3518). Without this, _paused_by_door
+                    # stays True even though nat-vent has taken over control, which
+                    # incorrectly suppresses the away/vacation setback band
+                    # (handle_occupancy_away/vacation both early-return on
+                    # _paused_by_door=True) and misreports "paused by door" on the
+                    # dashboard/API while nat-vent is actually running.
+                    # Issue #657: the above fix only cleared _paused_by_door, leaving
+                    # _paused_with_hvac_already_off/_paused_entity/_paused_since stale
+                    # — the sibling reactivation branches in
+                    # check_natural_vent_conditions() clear all 4 fields together.
+                    # When authoritative, _on_grace_expired()'s dispatcher call already
+                    # applied this (RE_PAUSE -> NORMAL from plain GRACE) before this
+                    # task ran — re-clearing here would be redundant, not wrong, but
+                    # skipped for clarity that the flags are already correct.
+                    self._paused_by_door = False
+                    self._paused_with_hvac_already_off = False
+                    self._paused_entity = None
+                    self._paused_since = None
                 await self._apply_nat_vent_hvac_state()
                 _LOGGER.info(
                     "Re-check after grace: nat-vent conditions met — outdoor %.1f°F < indoor %.1f°F,"
@@ -4899,12 +4950,33 @@ class AutomationEngine:
                         },
                     )
                 return
-            await self._pause_for_door_window(
-                entity_label="re-check",
-                reason="grace expired — door/window still open, re-pausing",
-                notify_message=("Grace period expired but a door/window is still open. HVAC has been paused again."),
-                notify_type="grace_repause",
-            )
+
+            if self._doorwindow_fsm_authoritative:
+                # Flags already applied by _on_grace_expired()'s dispatcher call —
+                # only the HVAC-affecting action half runs here.
+                await self._pause_for_door_window_action(
+                    entity_label="re-check",
+                    reason="grace expired — door/window still open, re-pausing",
+                    notify_message=(
+                        "Grace period expired but a door/window is still open. HVAC has been paused again."
+                    ),
+                    notify_type="grace_repause",
+                )
+                # _paused_entity/_paused_since aren't part of
+                # _apply_door_window_fsm_state()'s 3-field derivation — direct writes
+                # here, matching what _set_door_window_pause_fields() would have
+                # written on the legacy path below.
+                self._paused_entity = "re-check"
+                self._paused_since = dt_util.now()
+            else:
+                await self._pause_for_door_window(
+                    entity_label="re-check",
+                    reason="grace expired — door/window still open, re-pausing",
+                    notify_message=(
+                        "Grace period expired but a door/window is still open. HVAC has been paused again."
+                    ),
+                    notify_type="grace_repause",
+                )
 
     async def _apply_current_scheduled_state(self, reason: str = "grace_expired") -> None:
         """After override clears, converge to the scheduled automation state.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.helpers.event import async_call_later
@@ -101,6 +101,10 @@ from .desired_state import (
     decide_scheduled_write_seq_current,
     decide_setpoint_retry_action,
 )
+
+if TYPE_CHECKING:
+    from .door_window_fsm import DoorWindowFsmEventKind
+
 from .door_window_lifecycle import (
     DoorWindowLifecycleInputs,
     DoorWindowLifecycleState,
@@ -4401,29 +4405,23 @@ class AutomationEngine:
         if not self._paused_by_door:
             return
         _LOGGER.info("Manual HVAC override detected during door/window pause")
-        if self._doorwindow_fsm_authoritative:
-            # Issue #594 Phase R, Step 2: door_window_fsm.transition() decides the
-            # resulting pause/grace state instead of the unconditional inline clear
-            # below. MANUAL_OVERRIDE_DURING_PAUSE lands on NORMAL from PAUSED_ACTIVE/
-            # PAUSED_IDLE, or GRACE from PAUSED_DURING_GRACE (grace left running,
-            # matching the legacy path's own silence on _grace_active here) —
-            # unconditional on origin state either way, so this produces the same
-            # flag values the legacy branch below always wrote; only the source of
-            # truth changes.
-            from .door_window_fsm import DoorWindowFsmEvent, DoorWindowFsmEventKind
-            from .door_window_fsm import transition as _door_window_transition
 
-            _dw_result = _door_window_transition(
-                self.door_window_lifecycle_state,
-                DoorWindowFsmEvent(
-                    kind=DoorWindowFsmEventKind.MANUAL_OVERRIDE_DURING_PAUSE,
-                    inputs=self._build_door_window_fsm_inputs(now=dt_util.now()),
-                ),
-            )
-            self._apply_door_window_fsm_state(_dw_result.to_state)
-        else:
+        from .door_window_fsm import DoorWindowFsmEventKind
+
+        # Issue #594 Phase R, Step 0: routed through the shared dispatcher instead of
+        # an inline if/else — MANUAL_OVERRIDE_DURING_PAUSE lands on NORMAL from
+        # PAUSED_ACTIVE/PAUSED_IDLE, or GRACE from PAUSED_DURING_GRACE (grace left
+        # running, matching the legacy closure's own silence on _grace_active here) —
+        # unconditional on origin state either way, so this produces the same flag
+        # values the legacy closure always wrote; only the source of truth changes.
+        def _legacy_clear_pause() -> None:
             self._paused_by_door = False
             self._paused_with_hvac_already_off = False
+
+        self._resolve_door_window_pause_flags(
+            kind=DoorWindowFsmEventKind.MANUAL_OVERRIDE_DURING_PAUSE,
+            legacy=_legacy_clear_pause,
+        )
         self._paused_entity = None
         self._paused_since = None
         self._pre_pause_mode = None
@@ -4448,26 +4446,22 @@ class AutomationEngine:
             return None
 
         _LOGGER.info("User resumed HVAC from door/window pause via dashboard")
-        if self._doorwindow_fsm_authoritative:
-            # Issue #594 Phase R, Step 2: same shape as
-            # handle_manual_override_during_pause()'s FSM-authoritative branch.
-            # DASHBOARD_RESUME lands unconditionally on GRACE from either origin
-            # state, matching the legacy path's own unconditional
-            # _start_grace_period() call below regardless of origin.
-            from .door_window_fsm import DoorWindowFsmEvent, DoorWindowFsmEventKind
-            from .door_window_fsm import transition as _door_window_transition
 
-            _dw_result = _door_window_transition(
-                self.door_window_lifecycle_state,
-                DoorWindowFsmEvent(
-                    kind=DoorWindowFsmEventKind.DASHBOARD_RESUME,
-                    inputs=self._build_door_window_fsm_inputs(now=dt_util.now()),
-                ),
-            )
-            self._apply_door_window_fsm_state(_dw_result.to_state)
-        else:
+        from .door_window_fsm import DoorWindowFsmEventKind
+
+        # Issue #594 Phase R, Step 0: routed through the shared dispatcher — same
+        # shape as handle_manual_override_during_pause()'s call. DASHBOARD_RESUME
+        # lands unconditionally on GRACE from either origin state, matching the
+        # legacy closure's own unconditional _start_grace_period() call below
+        # regardless of origin.
+        def _legacy_clear_pause() -> None:
             self._paused_by_door = False
             self._paused_with_hvac_already_off = False
+
+        self._resolve_door_window_pause_flags(
+            kind=DoorWindowFsmEventKind.DASHBOARD_RESUME,
+            legacy=_legacy_clear_pause,
+        )
         self._paused_entity = None
         self._paused_since = None
         self._pre_pause_mode = None
@@ -5720,14 +5714,15 @@ class AutomationEngine:
 
     def _build_door_window_fsm_inputs(self, *, now: datetime):
         """Build the door/window FSM's input snapshot from current engine state
-        (Issue #594 Phase R, Step 2). Same field set
-        ``coordinator._door_window_fsm_inputs()`` already builds for the
-        shadow-diagnostic comparison — kept as a single definition callers on
-        both sides can share rather than two independently maintained copies of
-        the same construction. The one exception is ``hvac_mode``: the
-        coordinator's version reads it via ``self.hass.states.get(...)``
-        against its own ``automation_engine`` reference; this reads the exact
-        same live state directly against ``self``.
+        (Issue #594 Phase R, Step 2).
+
+        Issue #594 Phase R, Step 0: this is now the SOLE builder for
+        ``DoorWindowFsmInputs`` — ``coordinator._door_window_fsm_inputs()`` was
+        deleted because both of its call sites always ran against
+        ``self.automation_engine`` (production, never the shadow engine), so it
+        was the same computation written twice, not two builders that happened
+        to agree. Both coordinator call sites now call this method directly
+        (``ae._build_door_window_fsm_inputs(now=now)``).
         """
         from .door_window_fsm import DoorWindowFsmInputs
 
@@ -5798,6 +5793,37 @@ class AutomationEngine:
         )
         self._paused_with_hvac_already_off = state == DoorWindowLifecycleState.PAUSED_IDLE
         self._grace_active = state in (DoorWindowLifecycleState.GRACE, DoorWindowLifecycleState.PAUSED_DURING_GRACE)
+
+    def _resolve_door_window_pause_flags(
+        self,
+        *,
+        kind: DoorWindowFsmEventKind,
+        legacy: Callable[[], None],
+        origin_state: DoorWindowLifecycleState | None = None,
+    ) -> None:
+        """Single dispatch point for every door/window flag-derivation call site
+        (Issue #594 Phase R / #660). Each of the 8 real trigger methods supplies its own
+        event kind and its own legacy closure; this function owns the
+        authoritative-vs-legacy branch exactly once, instead of once per call site.
+
+        ``origin_state``: defaults to a live read of ``self.door_window_lifecycle_state``
+        — correct for every site except ``_on_grace_expired()``, which must capture
+        state *before* ``_cancel_grace_timers()`` clears ``_grace_active`` and pass it
+        explicitly here (grace has already been cleared by the time this function
+        would otherwise read it live).
+        """
+        if self._doorwindow_fsm_authoritative:
+            from .door_window_fsm import DoorWindowFsmEvent
+            from .door_window_fsm import transition as _door_window_transition
+
+            state = origin_state if origin_state is not None else self.door_window_lifecycle_state
+            result = _door_window_transition(
+                state,
+                DoorWindowFsmEvent(kind=kind, inputs=self._build_door_window_fsm_inputs(now=dt_util.now())),
+            )
+            self._apply_door_window_fsm_state(result.to_state)
+        else:
+            legacy()
 
     def _nat_vent_may_reactivate(
         self,

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -3142,8 +3142,21 @@ class AutomationEngine:
             if not self._paused_by_door:
                 return
 
-            self._paused_by_door = False
-            self._paused_with_hvac_already_off = False
+            from .door_window_fsm import DoorWindowFsmEventKind
+
+            # Issue #660 Step 4: routed through the shared dispatcher. The restore-or-
+            # clear action below stays unconditional on the flag branch taken (legacy
+            # vs. FSM) — it is driven by self._pre_pause_mode's own truthiness, the
+            # same input the FSM's ALL_SENSORS_CLOSED transition consults
+            # (pre_pause_mode_active, Step 2's fix), so both paths agree on when to act.
+            def _legacy_clear_pause() -> None:
+                self._paused_by_door = False
+                self._paused_with_hvac_already_off = False
+
+            self._resolve_door_window_pause_flags(
+                kind=DoorWindowFsmEventKind.ALL_SENSORS_CLOSED,
+                legacy=_legacy_clear_pause,
+            )
             self._paused_entity = None
             self._paused_since = None
             if self._pre_pause_mode:
@@ -5602,9 +5615,26 @@ class AutomationEngine:
             # restore (pre_pause_mode is None) means the FSM-visible state is
             # equivalent to "already off" (PAUSED_IDLE), matching
             # decide_door_close_response()'s own truthiness test on pre_pause_mode.
-            self._set_door_window_pause_fields(
-                entity_label="nat-vent-exit", hvac_already_off=self._pre_pause_mode is None
+            #
+            # Issue #660 Step 4: routed through the shared dispatcher for the 3 fields
+            # it derives (_paused_by_door/_paused_with_hvac_already_off/_grace_active).
+            # _paused_entity/_paused_since aren't part of that derivation (see
+            # _apply_door_window_fsm_state()'s own docstring), so they stay direct
+            # writes below regardless of which branch the dispatcher took — same
+            # values _set_door_window_pause_fields() would have written.
+            from .door_window_fsm import DoorWindowFsmEventKind
+
+            _hvac_already_off = self._pre_pause_mode is None
+
+            def _legacy_set_pause() -> None:
+                self._set_door_window_pause_fields(entity_label="nat-vent-exit", hvac_already_off=_hvac_already_off)
+
+            self._resolve_door_window_pause_flags(
+                kind=DoorWindowFsmEventKind.NAT_VENT_EXITED_SENSOR_STILL_OPEN,
+                legacy=_legacy_set_pause,
             )
+            self._paused_entity = "nat-vent-exit"
+            self._paused_since = dt_util.now()
             # Issue #649: a repeat of an already-reported deferral logs at DEBUG, not INFO —
             # this is the exact "one retry tick after another while still blocked" pattern
             # that produced unbounded duplicate INFO lines before this fix.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,23 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.26"
+VERSION = "0.6.27"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.27": [
+        "Fix #660: the door/window pause/grace lifecycle FSM now has full,"
+        " off-by-default authority for all 8 real trigger sites — completing"
+        " the migration begun in #637. Also fixes a real gap found during that"
+        " work: when a grace period was already running and a door/window pause"
+        " independently became active too, the FSM's own tracked state could"
+        " disagree with what production actually did, and a resume-after-close"
+        " could restore the wrong prior HVAC mode in a specific reachable"
+        " sequence. Both are fixed at the source for every caller, not"
+        " patched per call site. The switch that lets this FSM actually drive"
+        " decisions (instead of just tracking them for comparison) stays off"
+        " by default — no occupant-visible behavior change from this release"
+        " alone.",
+    ],
     "0.6.26": [
         "Fix #655: a door/window briefly reopened during an active grace period"
         " could still pause the AC/heat, even though the grace period exists"
@@ -1880,6 +1894,51 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    660: {
+        "version_fixed": "0.6.27",
+        "title": "Door/window FSM: full authority for all 8 real trigger sites (completes #637)",
+        "scope_covered": (
+            "door_window_fsm.py/automation.py/coordinator.py: completes the door/window"
+            " pause/grace lifecycle FSM migration begun in #637. Fixed 2 real gaps found"
+            " during the investigation: (1) _sync_reconcile_next_state() never checked live"
+            " grace_active when the FSM was already in a PAUSED_* state (added a"
+            " grace_active-while-paused branch, and made _transition_from_paused() dispatch"
+            " SYNC_RECONCILE to it, matching NORMAL/GRACE's existing dispatch); (2)"
+            " _transition_from_paused()'s ALL_SENSORS_CLOSED branch inferred pre_pause_mode"
+            " truthiness from current_state == PAUSED_ACTIVE (a placeholder) instead of the"
+            " real AutomationEngine._pre_pause_mode value, which could disagree in a"
+            " reachable edge case involving a still-legacy _exit_nat_vent() branch. Also"
+            " found and added the FSM's real 8th trigger site,"
+            " check_natural_vent_conditions()'s two reactivation-while-paused branches,"
+            " previously fed to the nat-vent FSM but never the door/window FSM at all"
+            " (new DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED). Structural"
+            " consolidation (Step 0, provable no-op): deleted a fully-redundant"
+            " coordinator-side FSM-inputs builder in favor of automation.py's single"
+            " definition; added AutomationEngine._resolve_door_window_pause_flags(), one"
+            " shared authoritative-vs-legacy dispatcher all 8 sites now call instead of a"
+            " hand-copied if/else each; collapsed _mirror_to_shadow()'s and"
+            " _feed_lifecycle_fsms_from_event()'s repeated try/except FSM-dispatch blocks"
+            " into one declarative loop. Split _pause_for_door_window() into an action half"
+            " (_pause_for_door_window_action()) and a flags half, letting"
+            " handle_door_window_open()/_re_pause_for_open_sensor() run the action"
+            " unconditionally while deriving flags under their own event kind (the highest-"
+            " risk step: _re_pause_for_open_sensor() now trusts the flags"
+            " _on_grace_expired() already applied via an explicitly captured pre-grace-"
+            " clear origin state, rather than independently re-deciding and re-writing"
+            " them). Exposed door/window's shadow-diagnostic fields on the Shadow Engine"
+            " Status sensor (previously computed but never surfaced). The"
+            " _doorwindow_fsm_authoritative switch (config/switch.py, not touched by this"
+            " PR) still defaults False — zero occupant-visible behavior change from this"
+            " release alone; a live switch-flip verification is a separate follow-up step."
+            " Two callers of the shared _pause_for_door_window() wrapper"
+            " (_apply_comfort_band()'s door/window guard,"
+            " _sync_paused_by_door_with_live_sensors()'s Issue #620 direct-pause path) were"
+            " not among the 8 sites the originating investigation enumerated, but"
+            " automatically gained FSM-authoritative capability through that one shared"
+            " wrapper rather than needing individual treatment — noted here since it's a"
+            " correction to the investigation's own site count, not a new gap."
+        ),
+    },
     651: {
         "version_fixed": "0.6.21",
         "title": "Override/grace shadow FSM: handle_manual_override entry gap + bedtime/wakeup exit gap",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -365,6 +365,17 @@ _DOOR_WINDOW_FSM_EVENT_KINDS: dict[str, str] = {
     "handle_all_doors_windows_closed": "all_sensors_closed",
     "handle_manual_override_during_pause": "manual_override_during_pause",
     "resume_from_pause": "dashboard_resume",
+    # Issue #660: check_natural_vent_conditions()'s two reactivation branches clear
+    # all 4 door/window pause fields directly when nat-vent may reactivate while
+    # paused -- previously this method had NO door/window FSM event feed at all (it
+    # was only registered in _NAT_VENT_FSM_TRIGGER_METHODS, feeding the *nat-vent*
+    # FSM). It already has a _mirror_to_shadow("check_natural_vent_conditions") call
+    # site (coordinator.py), so adding this entry is enough to reach
+    # _evaluate_door_window_fsm() via _dispatch_fsm_evaluators() -- no new call site
+    # needed. Most invocations of this periodic method aren't a reactivation-while-
+    # paused at all; PAUSED_NAT_VENT_REACTIVATED is a defensive no-op from any
+    # non-paused origin state, same convention SENSOR_OPENED already uses.
+    "check_natural_vent_conditions": "paused_nat_vent_reactivated",
 }
 
 # Issue #594 Phase R Step 1b: door/window's SYNC_RECONCILE event kind has no natural

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -14,7 +14,7 @@ import hashlib
 import inspect
 import logging
 import math
-from collections.abc import Callable
+from collections.abc import Callable, Container
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, time, timedelta
 from pathlib import Path
@@ -933,6 +933,32 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         se._override_confirm_source = ae._override_confirm_source
         se._paused_with_hvac_already_off = ae._paused_with_hvac_already_off
 
+    def _dispatch_fsm_evaluators(
+        self,
+        key: str,
+        dispatches: list[tuple[Container[str], Callable[[], None], str]],
+    ) -> None:
+        """Shared try/except-and-log dispatch loop for FSM re-evaluation (Issue #660,
+        Phase R Step 0).
+
+        Each dispatch tuple is ``(registry, evaluator, label)``. If ``key`` (a
+        mirrored method name or an emitted event type, depending on caller) is a
+        member of ``registry``, ``evaluator()`` runs isolated: any exception is
+        logged under ``label`` and swallowed, never allowed to affect production.
+        Replaces what used to be a hand-copied ``if key in <registry>: try: ...
+        except: _LOGGER.warning(...)`` block per FSM — both in ``_mirror_to_shadow()``'s
+        ``finally`` block and in ``_feed_lifecycle_fsms_from_event()`` — so adding a
+        future FSM (or fixing a missing registration, as Issue #660 did for
+        ``check_natural_vent_conditions()``) is a one-line registry addition instead
+        of a new copy-pasted try/except block.
+        """
+        for registry, evaluator, label in dispatches:
+            if key in registry:
+                try:
+                    evaluator()
+                except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
+                    _LOGGER.warning("%s failed (isolated, no production impact): %s", label, fsm_exc)
+
     async def _mirror_to_shadow(self, method_name: str, *args: Any, **kwargs: Any) -> None:
         """Replay a production nat-vent decision call on the shadow engine (Issue #613).
 
@@ -957,42 +983,32 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 exc,
             )
         finally:
-            if method_name in _NAT_VENT_FSM_TRIGGER_METHODS:
-                try:
-                    self._evaluate_nat_vent_fsm()
-                except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
-                    _LOGGER.warning(
-                        "Nat-vent FSM evaluation failed (isolated, no production impact): %s",
-                        fsm_exc,
-                    )
-            if method_name in _DOOR_WINDOW_FSM_EVENT_KINDS:
-                try:
-                    self._evaluate_door_window_fsm(method_name)
-                except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
-                    _LOGGER.warning(
-                        "Door/window FSM evaluation failed (isolated, no production impact): %s",
-                        fsm_exc,
-                    )
-            if method_name in _DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS:
-                try:
-                    from .door_window_fsm import DoorWindowFsmEventKind as _DWFEventKind
+            from .door_window_fsm import DoorWindowFsmEventKind as _DWFEventKind
+            from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
 
-                    self._evaluate_door_window_fsm(method_name, event_kind=_DWFEventKind.SYNC_RECONCILE)
-                except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
-                    _LOGGER.warning(
-                        "Door/window FSM evaluation (sync-reconcile) failed (isolated, no production impact): %s",
-                        fsm_exc,
-                    )
-            if method_name in _OVERRIDE_GRACE_FSM_EVENT_KINDS:
-                try:
-                    from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
-
-                    self._evaluate_override_grace_fsm(_OGFEventKind(_OVERRIDE_GRACE_FSM_EVENT_KINDS[method_name]))
-                except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
-                    _LOGGER.warning(
-                        "Override/grace FSM evaluation failed (isolated, no production impact): %s",
-                        fsm_exc,
-                    )
+            self._dispatch_fsm_evaluators(
+                method_name,
+                [
+                    (_NAT_VENT_FSM_TRIGGER_METHODS, self._evaluate_nat_vent_fsm, "Nat-vent FSM evaluation"),
+                    (
+                        _DOOR_WINDOW_FSM_EVENT_KINDS,
+                        lambda: self._evaluate_door_window_fsm(method_name),
+                        "Door/window FSM evaluation",
+                    ),
+                    (
+                        _DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS,
+                        lambda: self._evaluate_door_window_fsm(method_name, event_kind=_DWFEventKind.SYNC_RECONCILE),
+                        "Door/window FSM evaluation (sync-reconcile)",
+                    ),
+                    (
+                        _OVERRIDE_GRACE_FSM_EVENT_KINDS,
+                        lambda: self._evaluate_override_grace_fsm(
+                            _OGFEventKind(_OVERRIDE_GRACE_FSM_EVENT_KINDS[method_name])
+                        ),
+                        "Override/grace FSM evaluation",
+                    ),
+                ],
+            )
             try:
                 self._update_shadow_engine_diagnostic()
             except Exception as diag_exc:  # noqa: BLE001 — diagnostic is best-effort observability
@@ -1073,35 +1089,6 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         result = transition(self._nat_vent_fsm_state, event)
         self._nat_vent_fsm_state = result.to_state
 
-    def _door_window_fsm_inputs(self, ae: AutomationEngine, now: datetime, config: dict[str, Any]) -> Any:
-        """Build ``DoorWindowFsmInputs`` from production's current live readings.
-
-        Issue #647: extracted from ``_evaluate_door_window_fsm()`` so
-        ``_feed_lifecycle_fsms_from_event()``'s event-driven trigger (nat-vent exit
-        events) can build the identical inputs without duplicating this construction
-        — one source of truth for "what production state does this FSM read."
-        """
-        from .door_window_fsm import DoorWindowFsmInputs
-
-        return DoorWindowFsmInputs(
-            hvac_mode=self._current_hvac_mode(),
-            outdoor=ae._last_outdoor_temp,
-            indoor=ae._get_indoor_temp_f(),
-            comfort_heat=ae._nat_vent_reactivation_floor(),
-            comfort_cool=float(config.get("comfort_cool", DEFAULT_COMFORT_COOL)),
-            nat_vent_delta=float(config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA)),
-            fan_mode=str(config.get(CONF_FAN_MODE, "whole_house_fan")),
-            aggressive_savings=bool(config.get("aggressive_savings", False)),
-            within_planned_window=ae._is_within_planned_window_period(),
-            any_sensor_open=ae._any_monitored_sensor_open(),
-            sensor_debounce_pending=bool(ae._sensor_debounce_pending),
-            override_matches_current_decision=ae._override_matches_current_decision(ae._current_classification),
-            grace_source=ae._last_resume_source or "automation",
-            natural_vent_active=bool(ae._natural_vent_active),
-            whf_owns_hvac=bool(ae._whf_owns_hvac()),
-            now=now,
-        )
-
     def _evaluate_door_window_fsm(self, method_name: str, event_kind: DoorWindowFsmEventKind | None = None) -> None:
         """Run the unified door/window pause/grace FSM (Issue #637) against
         production's current live readings and track its own independently-
@@ -1140,14 +1127,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
         ae = self.automation_engine
         now = dt_util.now()
-        config = self.config
 
         kind = (
             event_kind if event_kind is not None else DoorWindowFsmEventKind(_DOOR_WINDOW_FSM_EVENT_KINDS[method_name])
         )
         event = DoorWindowFsmEvent(
             kind=kind,
-            inputs=self._door_window_fsm_inputs(ae, now, config),
+            inputs=ae._build_door_window_fsm_inputs(now=now),
         )
         result = transition(self._door_window_fsm_state, event)
         self._door_window_fsm_state = result.to_state
@@ -7706,70 +7692,64 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         ``_mirror_to_shadow()``'s own finally block: an exception here is logged and
         swallowed, never allowed to affect production.
         """
-        if event_type in _NAT_VENT_FSM_EVENT_TYPES:
-            try:
-                self._evaluate_nat_vent_fsm()
-            except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
-                _LOGGER.warning(
-                    "Nat-vent FSM evaluation (event-driven) failed (isolated, no production impact): %s",
-                    fsm_exc,
-                )
-        if event_type in _DOOR_WINDOW_NAT_VENT_EXIT_EVENT_TYPES:
-            try:
-                from .door_window_fsm import DoorWindowFsmEvent, DoorWindowFsmEventKind
-                from .door_window_fsm import transition as _door_window_transition
+        from .door_window_fsm import DoorWindowFsmEventKind as _DWFEventKind
+        from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
 
-                ae = self.automation_engine
-                # NAT_VENT_EXITED_SENSOR_STILL_OPEN's transition() unconditionally
-                # pauses (door_window_fsm.py:255-261) — it does not itself re-check
-                # any_sensor_open, so this event kind must only be sent when the
-                # sensor really is open, or every nat-vent exit (including a clean
-                # one) would incorrectly force a pause the FSM never should have
-                # entered. Read live sensor state directly rather than
-                # `ae._paused_by_door` — `_exit_nat_vent()` (which sets that flag)
-                # runs *after* the exit event these event types are emitted for
-                # (automation.py's own "caller emits its own specific event before
-                # calling this method" convention), so `_paused_by_door` is still
-                # last-cycle's stale value at this point; the live sensor read isn't.
-                if ae._any_monitored_sensor_open():
-                    now = dt_util.now()
-                    config = self.config
-                    event = DoorWindowFsmEvent(
-                        kind=DoorWindowFsmEventKind.NAT_VENT_EXITED_SENSOR_STILL_OPEN,
-                        inputs=self._door_window_fsm_inputs(ae, now, config),
-                    )
-                    result = _door_window_transition(self._door_window_fsm_state, event)
-                    self._door_window_fsm_state = result.to_state
-            except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
-                _LOGGER.warning(
-                    "Door/window FSM evaluation (event-driven) failed (isolated, no production impact): %s",
-                    fsm_exc,
-                )
-        if event_type in _DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES:
-            try:
-                from .door_window_fsm import DoorWindowFsmEventKind as _DWFEventKind
+        self._dispatch_fsm_evaluators(
+            event_type,
+            [
+                (_NAT_VENT_FSM_EVENT_TYPES, self._evaluate_nat_vent_fsm, "Nat-vent FSM evaluation (event-driven)"),
+                (
+                    _DOOR_WINDOW_NAT_VENT_EXIT_EVENT_TYPES,
+                    self._evaluate_door_window_fsm_nat_vent_exit,
+                    "Door/window FSM evaluation (event-driven)",
+                ),
+                (
+                    _DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES,
+                    lambda: self._evaluate_door_window_fsm(
+                        "_on_grace_expired", event_kind=_DWFEventKind.GRACE_TIMER_EXPIRED
+                    ),
+                    "Door/window FSM evaluation (grace-expiry)",
+                ),
+                (
+                    _OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP,
+                    lambda: self._evaluate_override_grace_fsm(
+                        _OGFEventKind(_OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP[event_type])
+                    ),
+                    "Override/grace FSM evaluation (event-driven)",
+                ),
+            ],
+        )
 
-                # "grace_expired"/"override_adopted" are both emitted by
-                # _on_grace_expired() *after* it has already mutated grace/pause state
-                # (self._cancel_grace_timers(), self.clear_manual_override()) — no
-                # staleness risk reading self.automation_engine here, unlike the
-                # NAT_VENT_EXITED_SENSOR_STILL_OPEN block above.
-                self._evaluate_door_window_fsm("_on_grace_expired", event_kind=_DWFEventKind.GRACE_TIMER_EXPIRED)
-            except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
-                _LOGGER.warning(
-                    "Door/window FSM evaluation (grace-expiry) failed (isolated, no production impact): %s",
-                    fsm_exc,
-                )
-        if event_type in _OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP:
-            try:
-                from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+    def _evaluate_door_window_fsm_nat_vent_exit(self) -> None:
+        """Evaluate the door/window FSM's ``NAT_VENT_EXITED_SENSOR_STILL_OPEN`` event
+        (Issue #647; extracted as its own method under Issue #660 Phase R Step 0 so
+        ``_feed_lifecycle_fsms_from_event()`` can dispatch it through the same shared
+        ``_dispatch_fsm_evaluators()`` loop as every other FSM re-evaluation).
 
-                self._evaluate_override_grace_fsm(_OGFEventKind(_OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP[event_type]))
-            except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
-                _LOGGER.warning(
-                    "Override/grace FSM evaluation (event-driven) failed (isolated, no production impact): %s",
-                    fsm_exc,
-                )
+        ``NAT_VENT_EXITED_SENSOR_STILL_OPEN``'s ``transition()`` unconditionally pauses
+        (door_window_fsm.py's ``_transition_from_normal``/``_transition_from_grace``
+        branches) — it does not itself re-check ``any_sensor_open``, so this event kind
+        must only be sent when the sensor really is open, or every nat-vent exit
+        (including a clean one) would incorrectly force a pause the FSM never should
+        have entered. Reads live sensor state directly rather than ``ae._paused_by_door``
+        — ``_exit_nat_vent()`` (which sets that flag) runs *after* the exit event this
+        method is triggered for (automation.py's own "caller emits its own specific
+        event before calling this method" convention), so ``_paused_by_door`` is still
+        last-cycle's stale value at this point; the live sensor read isn't.
+        """
+        from .door_window_fsm import DoorWindowFsmEvent, DoorWindowFsmEventKind
+        from .door_window_fsm import transition as _door_window_transition
+
+        ae = self.automation_engine
+        if ae._any_monitored_sensor_open():
+            now = dt_util.now()
+            event = DoorWindowFsmEvent(
+                kind=DoorWindowFsmEventKind.NAT_VENT_EXITED_SENSOR_STILL_OPEN,
+                inputs=ae._build_door_window_fsm_inputs(now=now),
+            )
+            result = _door_window_transition(self._door_window_fsm_state, event)
+            self._door_window_fsm_state = result.to_state
 
     def _resolve_active_comfort_band(self) -> tuple[float | None, float | None]:
         """Resolve the currently-active (comfort_heat, comfort_cool) band.

--- a/custom_components/climate_advisor/door_window_fsm.py
+++ b/custom_components/climate_advisor/door_window_fsm.py
@@ -189,6 +189,13 @@ class DoorWindowFsmEventKind(Enum):
     DASHBOARD_RESUME = "dashboard_resume"
     NAT_VENT_EXITED_SENSOR_STILL_OPEN = "nat_vent_exited_sensor_still_open"
     SYNC_RECONCILE = "sync_reconcile"  # Issue #620's 4 reconcile call sites
+    # Issue #660: check_natural_vent_conditions()'s two reactivation branches
+    # (automation.py) clear all 4 door/window pause fields directly when nat-vent
+    # reactivates while paused -- this method previously had zero door/window FSM
+    # event feed at all (it was only in _NAT_VENT_FSM_TRIGGER_METHODS, feeding the
+    # *nat-vent* FSM, not door/window's), making it the real 8th production trigger
+    # site the module docstring's "7 event kinds are exhaustive" claim missed.
+    PAUSED_NAT_VENT_REACTIVATED = "paused_nat_vent_reactivated"
 
 
 @dataclass(frozen=True)
@@ -438,6 +445,15 @@ def _transition_from_paused(current_state: DoorWindowLifecycleState, event: Door
         next_state = _sync_reconcile_next_state(current_state, inputs)
         return DoorWindowTransition(current_state, next_state, kind, "sync_reconcile", inputs.now)
 
+    if kind == DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED:
+        # Issue #660 Step 3: check_natural_vent_conditions()'s reactivation branches
+        # clear all 4 pause fields unconditionally when nat-vent may reactivate while
+        # paused. From a plain paused state there is no grace running by definition,
+        # so this always lands on NORMAL.
+        return DoorWindowTransition(
+            current_state, DoorWindowLifecycleState.NORMAL, kind, "nat_vent_reactivated", inputs.now
+        )
+
     # SENSOR_OPENED: guards on paused_by_door already being True and no-ops.
     # GRACE_TIMER_EXPIRED / NAT_VENT_EXITED_SENSOR_STILL_OPEN: not reachable from a
     # plain paused state (no grace timer running; nat-vent cannot be active while
@@ -561,6 +577,15 @@ def _transition_from_paused_during_grace(
     if kind == DoorWindowFsmEventKind.DASHBOARD_RESUME:
         # Clears pause, unconditionally re-arms grace — lands on GRACE.
         return DoorWindowTransition(current_state, DoorWindowLifecycleState.GRACE, kind, "resumed", inputs.now)
+
+    if kind == DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED:
+        # Issue #660 Step 3: clears the pause but leaves the already-running grace
+        # timer untouched — production's reactivation branches never touch
+        # _grace_active — so this lands on plain GRACE, not NORMAL (unlike the
+        # plain-paused-origin case above, where there is no grace to preserve).
+        return DoorWindowTransition(
+            current_state, DoorWindowLifecycleState.GRACE, kind, "nat_vent_reactivated", inputs.now
+        )
 
     # SENSOR_OPENED / SYNC_RECONCILE: both guard on paused_by_door already
     # being True and no-op. NAT_VENT_EXITED_SENSOR_STILL_OPEN: not reachable

--- a/custom_components/climate_advisor/door_window_fsm.py
+++ b/custom_components/climate_advisor/door_window_fsm.py
@@ -221,6 +221,13 @@ class DoorWindowFsmInputs:
                                              list: required for faithful SYNC_RECONCILE
                                              modeling (_sync_paused_by_door_with_live_sensors()'s
                                              own guard reads it)
+      pre_pause_mode_active                -> bool(self._pre_pause_mode) — added under
+                                             Issue #660 Step 2: replaces the
+                                             ``current_state == PAUSED_ACTIVE`` proxy
+                                             ``_transition_from_paused()``'s
+                                             ALL_SENSORS_CLOSED branch used to infer
+                                             ``pre_pause_mode`` truthiness from, which
+                                             could disagree with the real field.
       grace_active                        -> self._grace_active — added under Issue #660:
                                              _sync_reconcile_next_state() previously never
                                              checked live grace_active when already in a
@@ -248,6 +255,7 @@ class DoorWindowFsmInputs:
     natural_vent_active: bool
     whf_owns_hvac: bool
     grace_active: bool
+    pre_pause_mode_active: bool
     now: datetime
 
 
@@ -397,10 +405,15 @@ def _transition_from_paused(current_state: DoorWindowLifecycleState, event: Door
     kind = event.kind
 
     if kind == DoorWindowFsmEventKind.ALL_SENSORS_CLOSED:
+        # Issue #660 Step 2: reads the real pre_pause_mode truthiness from the event's
+        # inputs rather than inferring it from current_state == PAUSED_ACTIVE — that
+        # proxy could disagree with the real AutomationEngine._pre_pause_mode value in
+        # a reachable edge case (see this file's module docstring, formerly "Known
+        # non-mechanical transition").
         outcome = decide_door_close_response(
             DoorCloseResponseInputs(
                 paused_by_door=True,
-                pre_pause_mode="restored" if current_state == DoorWindowLifecycleState.PAUSED_ACTIVE else None,
+                pre_pause_mode="restored" if inputs.pre_pause_mode_active else None,
             )
         )
         next_state = (

--- a/custom_components/climate_advisor/door_window_fsm.py
+++ b/custom_components/climate_advisor/door_window_fsm.py
@@ -221,6 +221,14 @@ class DoorWindowFsmInputs:
                                              list: required for faithful SYNC_RECONCILE
                                              modeling (_sync_paused_by_door_with_live_sensors()'s
                                              own guard reads it)
+      grace_active                        -> self._grace_active — added under Issue #660:
+                                             _sync_reconcile_next_state() previously never
+                                             checked live grace_active when already in a
+                                             PAUSED_* state, so the FSM's carried state
+                                             could silently disagree with production once
+                                             grace started running concurrently with an
+                                             existing pause (see that function's own
+                                             docstring for the fix).
       now                                  -> caller-resolved wall-clock time
     """
 
@@ -239,6 +247,7 @@ class DoorWindowFsmInputs:
     grace_source: str
     natural_vent_active: bool
     whf_owns_hvac: bool
+    grace_active: bool
     now: datetime
 
 
@@ -353,8 +362,21 @@ def _sync_reconcile_next_state(
     current_state: DoorWindowLifecycleState, inputs: DoorWindowFsmInputs
 ) -> DoorWindowLifecycleState:
     """Pure reimplementation of ``_sync_paused_by_door_with_live_sensors()`` (Issue #620),
-    for the two origin states where its own guard doesn't immediately no-op
-    (NORMAL, GRACE — both have ``paused_by_door=False``)."""
+    for the origin states where its own guard doesn't immediately no-op — NORMAL/GRACE
+    (both have ``paused_by_door=False``), plus PAUSED_ACTIVE/PAUSED_IDLE's own narrower
+    ``grace_active``-while-paused check (Issue #660, added below)."""
+    # Issue #660: when already paused and a grace period is independently running
+    # (live grace_active True, e.g. started by a different code path than the pause
+    # itself), the FSM's carried state must upgrade to PAUSED_DURING_GRACE — the
+    # composite state — rather than silently staying a plain paused state that no
+    # longer reflects live grace. This check must run before the early-return guards
+    # below, which are specific to the NORMAL/GRACE reconcile-into-pause direction and
+    # would otherwise leave a plain-paused + grace-active disagreement unresolved.
+    if current_state in (DoorWindowLifecycleState.PAUSED_ACTIVE, DoorWindowLifecycleState.PAUSED_IDLE):
+        if inputs.grace_active:
+            return DoorWindowLifecycleState.PAUSED_DURING_GRACE
+        return current_state
+
     if inputs.natural_vent_active or inputs.whf_owns_hvac:
         return current_state
     if inputs.within_planned_window:
@@ -396,10 +418,17 @@ def _transition_from_paused(current_state: DoorWindowLifecycleState, event: Door
     if kind == DoorWindowFsmEventKind.DASHBOARD_RESUME:
         return DoorWindowTransition(current_state, DoorWindowLifecycleState.GRACE, kind, "resumed", inputs.now)
 
-    # SENSOR_OPENED / SYNC_RECONCILE: both guard on paused_by_door already
-    # being True and no-op. GRACE_TIMER_EXPIRED / NAT_VENT_EXITED_SENSOR_STILL_OPEN:
-    # not reachable from a plain paused state (no grace timer running; nat-vent
-    # cannot be active while already paused per the two evidenced entry paths).
+    if kind == DoorWindowFsmEventKind.SYNC_RECONCILE:
+        # Issue #660: dispatches to the same single reconciliation function every
+        # other origin state uses, instead of silently no-op'ing here — see
+        # _sync_reconcile_next_state()'s own grace_active-while-paused branch.
+        next_state = _sync_reconcile_next_state(current_state, inputs)
+        return DoorWindowTransition(current_state, next_state, kind, "sync_reconcile", inputs.now)
+
+    # SENSOR_OPENED: guards on paused_by_door already being True and no-ops.
+    # GRACE_TIMER_EXPIRED / NAT_VENT_EXITED_SENSOR_STILL_OPEN: not reachable from a
+    # plain paused state (no grace timer running; nat-vent cannot be active while
+    # already paused per the two evidenced entry paths).
     return DoorWindowTransition(current_state, current_state, kind, "noop_already_paused", inputs.now)
 
 

--- a/custom_components/climate_advisor/door_window_fsm.py
+++ b/custom_components/climate_advisor/door_window_fsm.py
@@ -97,57 +97,56 @@ scoping pass are now fixed in production (not just documented as blockers):
   ``PAUSED_IDLE``) can no longer go stale from this branch.
 
 **Shadow-feed coverage (Issue #594 Phase R Step 1b, v0.6.24; residual closed in
-Step 3).** All 7 ``DoorWindowFsmEventKind`` members have a real feed path — see
-``coordinator.py``'s ``_DOOR_WINDOW_FSM_EVENT_KINDS``/
-``_DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS``/``_DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES``.
-Step 1b's one documented residual — ``_on_grace_expired()``'s "within planned window"
-branch (automation.py, the first branch — windows recommended, sensor open is
-expected) previously emitted no event at all — is now closed: that branch emits
-``"grace_expired"`` (the same event type its sibling branches already use, with a
-``within_planned_window=True`` payload key to distinguish it from a real sensor
-re-check), so ``GRACE_TIMER_EXPIRED`` is now fed from all 3 of
-``_on_grace_expired()``'s outcome branches.
-
-**Remaining before this FSM can be authoritative for all 7 methods (Step 3b)**:
-``_re_pause_for_open_sensor()`` still needs to know whether it was reached from
-``GRACE`` or ``PAUSED_DURING_GRACE`` (a signature/plumbing change, not a body swap) —
-none of the Step 3 fixes above changed that. See the plan tracked on #637/#594 for the
-Step 3b scope.
+Step 3; 8th event kind added Issue #660 Step 3).** All 8 ``DoorWindowFsmEventKind``
+members have a real feed path — see ``coordinator.py``'s
+``_DOOR_WINDOW_FSM_EVENT_KINDS``/``_DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS``/
+``_DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES``. Step 1b's one documented residual —
+``_on_grace_expired()``'s "within planned window" branch (automation.py, the first
+branch — windows recommended, sensor open is expected) previously emitted no event
+at all — was closed by reusing the same ``"grace_expired"`` event type its sibling
+branches already use (with a ``within_planned_window=True`` payload key to
+distinguish it from a real sensor re-check), so ``GRACE_TIMER_EXPIRED`` is fed from
+all 3 of ``_on_grace_expired()``'s outcome branches. ``PAUSED_NAT_VENT_REACTIVATED``
+(Issue #660 Step 3) is the 8th kind: ``check_natural_vent_conditions()``'s two
+reactivation-while-paused branches previously had zero door/window FSM event feed
+at all (only registered for the *nat-vent* FSM) — now fed via
+``_DOOR_WINDOW_FSM_EVENT_KINDS["check_natural_vent_conditions"]``.
 
 **Cross-lifecycle inputs.** ``natural_vent_active`` and ``whf_owns_hvac`` are
 state *reads* from other lifecycles (Issue #631's "communicating automata"
 design) — legacy flag-derived today, same convention as ``nat_vent_fsm.py``'s
 own ``paused_by_door`` read.
 
-**Authoritative for production, as of Step 2 (v0.6.25) — PARTIAL scope.** This
-module's ``transition()`` is no longer purely a shadow diagnostic: when
-``AutomationEngine._doorwindow_fsm_authoritative`` is True,
-``handle_manual_override_during_pause()``/``resume_from_pause()`` call it for
-real and derive their resulting flags from ``result.to_state`` (via
-``AutomationEngine._apply_door_window_fsm_state()``). Both transitions
-(``MANUAL_OVERRIDE_DURING_PAUSE``, ``DASHBOARD_RESUME``) land unconditionally on
-their target state regardless of origin state — no placeholder-inference risk,
-unlike ``_transition_from_paused()``'s ``ALL_SENSORS_CLOSED`` branch below. The
-other 5 event kinds/methods stay shadow-only, each blocked on its own documented
-gap (see automation.py's ``_doorwindow_fsm_authoritative`` docstring) — this
-module's transition table is faithful to production for all 7, but "faithful"
-and "safe to read authoritatively" are different bars, and only 2 have cleared
-the second one so far.
+**Authoritative for production, as of Step 8 (Issue #660) — FULL scope, all 8
+real trigger sites.** This module's ``transition()`` is no longer purely a shadow
+diagnostic: when ``AutomationEngine._doorwindow_fsm_authoritative`` is True, every
+one of the 8 real trigger methods
+(``handle_manual_override_during_pause()``, ``resume_from_pause()``,
+``handle_all_doors_windows_closed()``, ``_exit_nat_vent()``'s sensor-still-open
+branch, ``check_natural_vent_conditions()``'s two reactivation branches,
+``handle_door_window_open()``, and the coupled
+``_on_grace_expired()``/``_re_pause_for_open_sensor()`` pair) derives its resulting
+flags from ``result.to_state`` via the shared
+``AutomationEngine._resolve_door_window_pause_flags()`` dispatcher (which calls
+``AutomationEngine._apply_door_window_fsm_state()``), instead of a direct/inline
+flag write. Two structural fixes made this possible for the branches that weren't
+already mechanical:
 
-**Known non-mechanical transition — do not swap without fixing first.**
-``_transition_from_paused()``'s ``ALL_SENSORS_CLOSED`` branch infers
-``pre_pause_mode`` from ``current_state == PAUSED_ACTIVE`` rather than taking the
-real ``AutomationEngine._pre_pause_mode`` value as an input — a placeholder, not
-the actual field ``door_window_close_response.DoorCloseResponseInputs`` was
-designed to take. Found while attempting to swap
-``handle_all_doors_windows_closed()`` in this same increment: since
-``PAUSED_ACTIVE`` vs. ``PAUSED_IDLE`` depends on ``_paused_with_hvac_already_off``,
-which the still-shadow-only ``_exit_nat_vent()`` branch can leave stale (it never
-writes that field), trusting this transition's resulting state for real
-flag-derivation risks a genuine divergence in that reachable edge case. Needs
-either a real ``pre_pause_mode``-truthiness input added to this branch, or
-another safe path, before ``handle_all_doors_windows_closed()`` can join a future
-increment.
+- The ``ALL_SENSORS_CLOSED`` branch below now takes ``pre_pause_mode_active`` as a
+  real input (Issue #660 Step 2) instead of inferring it from
+  ``current_state == PAUSED_ACTIVE`` — the former placeholder risked a genuine
+  divergence whenever ``_paused_with_hvac_already_off`` went stale via a
+  differently-timed write.
+- ``_on_grace_expired()``/``_re_pause_for_open_sensor()`` needed to know whether
+  ``_re_pause_for_open_sensor()`` was reached from ``GRACE`` or
+  ``PAUSED_DURING_GRACE`` — resolved not by a signature change on this pair
+  directly, but by having ``_on_grace_expired()`` apply the FSM's outcome
+  synchronously (using an explicitly captured pre-``_cancel_grace_timers()``
+  origin state) *before* scheduling ``_re_pause_for_open_sensor()`` as a task; that
+  method then just reads the already-applied flag rather than re-deriving it.
+
+Deploying with the switch flipped True is a separate, explicit live-verification
+step (Issue #660 ships with it still defaulting False).
 """
 
 from __future__ import annotations

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.26"
+  "version": "0.6.27"
 }

--- a/custom_components/climate_advisor/sensor.py
+++ b/custom_components/climate_advisor/sensor.py
@@ -501,13 +501,24 @@ class ClimateAdvisorShadowEngineStatusSensor(ClimateAdvisorBaseSensor):
             "shadow_state": diag["shadow_state"],
             "nat_vent_fsm_state": diag.get("nat_vent_fsm_state"),
             "checked_at": diag["checked_at"],
+            # Issue #660: door/window's own production/shadow/FSM state fields were
+            # already computed in coordinator.shadow_engine_diagnostic (Step 1b) but
+            # never exposed here — an observability gap alongside the door/window FSM
+            # authority extension itself, fixed in the same PR since both touch this
+            # diagnostic surface.
+            "door_window_production_state": diag.get("door_window_production_state"),
+            "door_window_shadow_state": diag.get("door_window_shadow_state"),
+            "door_window_fsm_state": diag.get("door_window_fsm_state"),
+            "door_window_mirror_agrees": diag.get("door_window_mirror_agrees"),
+            "door_window_fsm_agrees": diag.get("door_window_fsm_agrees"),
             # Issue #594 Phase R, Step 4: whether the nat-vent FSM is currently
             # authoritative for production decisions (vs. the legacy inline
             # computation). Surfaced here rather than a new card/sensor, same
             # "extend an existing diagnostic" rule this sensor itself follows.
             "natvent_fsm_authoritative": self.coordinator.natvent_fsm_authoritative,
-            # Issue #594 Phase R, Step 4: same rationale as natvent_fsm_authoritative
-            # above — partial scope, see AutomationEngine._doorwindow_fsm_authoritative's
-            # docstring for exactly which methods this does and doesn't cover.
+            # Issue #660: as of Phase R Step 8, this flag governs all 8 real
+            # door/window trigger sites (full parity — see
+            # AutomationEngine._doorwindow_fsm_authoritative's docstring), not a
+            # partial subset as previously documented here.
             "doorwindow_fsm_authoritative": self.coordinator.doorwindow_fsm_authoritative,
         }

--- a/tests/test_door_window.py
+++ b/tests/test_door_window.py
@@ -398,6 +398,72 @@ class TestHandleDoorWindowOpenWithGrace:
         assert ("sensor_opened", {"entity": "binary_sensor.front_door", "result": "paused"}) in events
 
 
+class TestHandleDoorWindowOpenFsmAuthoritative:
+    """Issue #660 Step 7: handle_door_window_open()'s terminal pause path calls the
+    action half directly and derives its own flags via the shared dispatcher,
+    instead of routing through the _pause_for_door_window() wrapper. No change to
+    the decision logic above the terminal pause (grace real-gate, planned-window
+    check, both Phase 2 guards) -- only the flag-write mechanism."""
+
+    def test_pauses_when_authoritative_and_no_grace(self):
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine.hass.states.get.return_value = _make_state("heat")
+
+        with patch("custom_components.climate_advisor.automation.async_call_later"):
+            asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+
+        assert engine._paused_by_door is True
+        assert engine._paused_with_hvac_already_off is False
+        assert engine._paused_entity == "binary_sensor.front_door"
+
+    def test_sets_pause_flag_when_hvac_already_off_and_authoritative(self):
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine.hass.states.get.return_value = _make_state("off")
+
+        asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+
+        assert engine._paused_by_door is True
+        assert engine._paused_with_hvac_already_off is True
+
+    def test_routes_through_shared_dispatcher_with_sensor_opened_kind(self):
+        """Direct proof of the wiring change itself (Issue #660 Step 7)."""
+        from custom_components.climate_advisor.door_window_fsm import DoorWindowFsmEventKind
+
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine.hass.states.get.return_value = _make_state("heat")
+
+        with (
+            patch.object(engine, "_resolve_door_window_pause_flags") as mock_dispatch,
+            patch("custom_components.climate_advisor.automation.async_call_later"),
+        ):
+            asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+
+        mock_dispatch.assert_called_once()
+        assert mock_dispatch.call_args.kwargs["kind"] == DoorWindowFsmEventKind.SENSOR_OPENED
+
+    def test_calls_action_directly_bypassing_the_wrapper(self):
+        """Distinguishes Step 7's specific change from Step 6's wrapper wiring
+        (which alone already makes the dispatch-verification test above pass,
+        since the wrapper used the same SENSOR_OPENED kind): the method must call
+        _pause_for_door_window_action() directly, never the _pause_for_door_window()
+        wrapper -- per the plan's Group B design (own event kind, own dispatcher
+        call, action half only)."""
+        engine = _make_automation_engine()
+        engine.hass.states.get.return_value = _make_state("heat")
+
+        with (
+            patch.object(engine, "_pause_for_door_window") as mock_wrapper,
+            patch("custom_components.climate_advisor.automation.async_call_later"),
+        ):
+            asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+
+        mock_wrapper.assert_not_called()
+        assert engine._paused_by_door is True
+
+
 class TestHandleAllDoorsWindowsClosed:
     """Tests for handle_all_doors_windows_closed starting grace periods."""
 

--- a/tests/test_door_window.py
+++ b/tests/test_door_window.py
@@ -775,6 +775,125 @@ class TestGracePeriodDuration:
 
 
 # ---------------------------------------------------------------------------
+# Issue #660 Step 6 — _pause_for_door_window() action/flags split
+# ---------------------------------------------------------------------------
+
+
+class TestPauseForDoorWindowActionSplit:
+    """_pause_for_door_window_action() (the extracted HVAC-affecting half) and the
+    thin _pause_for_door_window() wrapper that combines it with the shared flags
+    dispatcher — behavioral equivalence with the pre-split monolithic method."""
+
+    def test_action_returns_false_and_turns_off_when_active(self):
+        engine = _make_automation_engine()
+        engine.hass.states.get = MagicMock(return_value=MagicMock(state="cool"))
+
+        result = asyncio.run(
+            engine._pause_for_door_window_action(
+                entity_label="test", reason="test reason", notify_message="msg", notify_type="door_window_pause"
+            )
+        )
+
+        assert result is False  # hvac_already_off=False -- was actively turned off
+        assert engine._pre_pause_mode == "cool"
+        engine.hass.services.async_call.assert_any_call(
+            "climate", "set_hvac_mode", {"entity_id": "climate.thermostat", "hvac_mode": "off"}
+        )
+
+    def test_action_returns_true_when_already_off(self):
+        engine = _make_automation_engine()
+        engine.hass.states.get = MagicMock(return_value=MagicMock(state="off"))
+
+        result = asyncio.run(
+            engine._pause_for_door_window_action(
+                entity_label="test", reason="test reason", notify_message="msg", notify_type="door_window_pause"
+            )
+        )
+
+        assert result is True  # hvac_already_off=True
+
+    def test_action_returns_none_when_unavailable(self):
+        engine = _make_automation_engine()
+        engine.hass.states.get = MagicMock(return_value=None)
+
+        result = asyncio.run(
+            engine._pause_for_door_window_action(
+                entity_label="test", reason="test reason", notify_message="msg", notify_type="door_window_pause"
+            )
+        )
+
+        assert result is None  # no pause at all -- disambiguated from hvac_already_off=False
+
+    def test_wrapper_returns_true_when_actively_turned_off(self):
+        engine = _make_automation_engine()
+        engine.hass.states.get = MagicMock(return_value=MagicMock(state="cool"))
+
+        result = asyncio.run(
+            engine._pause_for_door_window(
+                entity_label="test", reason="test reason", notify_message="msg", notify_type="door_window_pause"
+            )
+        )
+
+        assert result is True
+        assert engine._paused_by_door is True
+        assert engine._paused_with_hvac_already_off is False
+
+    def test_wrapper_returns_false_when_unavailable_no_pause(self):
+        engine = _make_automation_engine()
+        engine.hass.states.get = MagicMock(return_value=None)
+
+        result = asyncio.run(
+            engine._pause_for_door_window(
+                entity_label="test", reason="test reason", notify_message="msg", notify_type="door_window_pause"
+            )
+        )
+
+        assert result is False
+        assert engine._paused_by_door is False
+
+    def test_wrapper_routes_through_shared_dispatcher_when_authoritative(self):
+        """Direct proof of the wiring change: the thin wrapper must call the shared
+        dispatcher with SENSOR_OPENED — this covers _apply_comfort_band()'s guard and
+        _sync_paused_by_door_with_live_sensors()'s direct-pause path automatically,
+        since both call this same wrapper rather than needing individual treatment."""
+        from custom_components.climate_advisor.door_window_fsm import DoorWindowFsmEventKind
+
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine.hass.states.get = MagicMock(return_value=MagicMock(state="cool"))
+
+        with patch.object(engine, "_resolve_door_window_pause_flags") as mock_dispatch:
+            asyncio.run(
+                engine._pause_for_door_window(
+                    entity_label="test", reason="test reason", notify_message="msg", notify_type="door_window_pause"
+                )
+            )
+
+        mock_dispatch.assert_called_once()
+        assert mock_dispatch.call_args.kwargs["kind"] == DoorWindowFsmEventKind.SENSOR_OPENED
+
+    def test_wrapper_sets_paused_entity_and_since_when_authoritative(self):
+        """Regression guard: _apply_door_window_fsm_state() does NOT write
+        _paused_entity/_paused_since (they aren't part of its 3-field derivation),
+        so the wrapper must still set them directly regardless of which branch the
+        dispatcher took -- found during Step 6 verification when the corpus-wide
+        FSM-authoritative comparator caught a real divergence (paused_minutes going
+        None) from this exact omission."""
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine.hass.states.get = MagicMock(return_value=MagicMock(state="cool"))
+
+        asyncio.run(
+            engine._pause_for_door_window(
+                entity_label="test-entity", reason="test reason", notify_message="msg", notify_type="door_window_pause"
+            )
+        )
+
+        assert engine._paused_entity == "test-entity"
+        assert engine._paused_since is not None
+
+
+# ---------------------------------------------------------------------------
 # Issue #216 — sensor_opened event payload fields (nat_vent result)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_door_window.py
+++ b/tests/test_door_window.py
@@ -523,6 +523,87 @@ class TestManualOverrideDuringPauseFsmAuthoritative:
         assert engine._override_confirm_pending is False
 
 
+class TestResolveDoorWindowPauseFlagsDispatcher:
+    """Issue #660 Phase R Step 0: unit tests for the shared
+    ``_resolve_door_window_pause_flags()`` dispatcher in isolation, covering just
+    the authoritative-vs-legacy branch (not any specific call site's semantics —
+    those are covered by each call site's own tests)."""
+
+    def test_switch_off_calls_legacy_not_transition(self):
+        from custom_components.climate_advisor.door_window_fsm import DoorWindowFsmEventKind
+
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = False
+        legacy = MagicMock()
+
+        with patch("custom_components.climate_advisor.door_window_fsm.transition") as mock_transition:
+            engine._resolve_door_window_pause_flags(
+                kind=DoorWindowFsmEventKind.MANUAL_OVERRIDE_DURING_PAUSE,
+                legacy=legacy,
+            )
+
+        legacy.assert_called_once()
+        mock_transition.assert_not_called()
+
+    def test_switch_on_applies_transition_result_not_legacy(self):
+        from custom_components.climate_advisor.door_window_fsm import (
+            DoorWindowFsmEventKind,
+            DoorWindowLifecycleState,
+        )
+
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._paused_with_hvac_already_off = False
+        engine._grace_active = False
+        legacy = MagicMock()
+
+        engine._resolve_door_window_pause_flags(
+            kind=DoorWindowFsmEventKind.MANUAL_OVERRIDE_DURING_PAUSE,
+            legacy=legacy,
+        )
+
+        legacy.assert_not_called()
+        # MANUAL_OVERRIDE_DURING_PAUSE from PAUSED_ACTIVE lands on NORMAL —
+        # _apply_door_window_fsm_state() clears the pause flags.
+        assert engine._paused_by_door is False
+        assert engine.door_window_lifecycle_state == DoorWindowLifecycleState.NORMAL
+
+    def test_origin_state_override_used_instead_of_live_read(self):
+        """The one documented exception (_on_grace_expired()'s need to capture state
+        before _cancel_grace_timers() clears it): passing origin_state must be used
+        in place of a live self.door_window_lifecycle_state read.
+
+        DASHBOARD_RESUME from PAUSED_ACTIVE lands on GRACE
+        (``_transition_from_paused``); from NORMAL it's a defensive no-op that stays
+        NORMAL (``_transition_from_normal``'s catch-all). The two origins produce
+        different outcomes, so this is a real behavioral distinguisher: if the live
+        read (NORMAL) were used instead of the passed-in origin_state (PAUSED_ACTIVE),
+        grace would stay inactive.
+        """
+        from custom_components.climate_advisor.door_window_fsm import (
+            DoorWindowFsmEventKind,
+            DoorWindowLifecycleState,
+        )
+
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        # Live state reads as NORMAL (no pause/grace flags set)...
+        engine._paused_by_door = False
+        engine._paused_with_hvac_already_off = False
+        engine._grace_active = False
+
+        # ...but origin_state claims PAUSED_ACTIVE.
+        engine._resolve_door_window_pause_flags(
+            kind=DoorWindowFsmEventKind.DASHBOARD_RESUME,
+            legacy=MagicMock(),
+            origin_state=DoorWindowLifecycleState.PAUSED_ACTIVE,
+        )
+
+        assert engine._grace_active is True
+        assert engine.door_window_lifecycle_state == DoorWindowLifecycleState.GRACE
+
+
 class TestGracePeriodDuration:
     """Tests for configurable grace period durations."""
 

--- a/tests/test_door_window.py
+++ b/tests/test_door_window.py
@@ -442,6 +442,129 @@ class TestHandleAllDoorsWindowsClosed:
         )
 
 
+class TestHandleAllDoorsWindowsClosedFsmAuthoritative:
+    """Issue #660 Step 4: with _doorwindow_fsm_authoritative=True,
+    handle_all_doors_windows_closed() derives its resulting flags from
+    door_window_fsm.transition() instead of the unconditional inline clear —
+    same outcome, different source of truth. Mirrors TestHandleAllDoorsWindowsClosed
+    above with the flag on."""
+
+    def test_resume_starts_automation_grace_from_paused_active(self):
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._paused_with_hvac_already_off = False  # PAUSED_ACTIVE
+        engine._pre_pause_mode = "heat"
+
+        with patch("custom_components.climate_advisor.automation.async_call_later") as mock_call_later:
+            mock_call_later.return_value = MagicMock()
+            asyncio.run(engine.handle_all_doors_windows_closed())
+
+        assert engine._paused_by_door is False
+        assert engine._grace_active is True
+        mock_call_later.assert_called_once()
+
+    def test_routes_through_shared_dispatcher_with_all_sensors_closed_kind(self):
+        """Direct proof of the wiring change itself (Issue #660 Step 4): the method
+        must call the shared dispatcher with ALL_SENSORS_CLOSED — this is the actual
+        fix under test, since the two methods' external flag outcomes are, by design,
+        identical whether the legacy or FSM branch runs (Group A: "action already
+        unconditional")."""
+        from custom_components.climate_advisor.door_window_fsm import DoorWindowFsmEventKind
+
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._paused_with_hvac_already_off = False
+        engine._pre_pause_mode = None
+
+        with (
+            patch.object(engine, "_resolve_door_window_pause_flags") as mock_dispatch,
+            patch("custom_components.climate_advisor.automation.async_call_later", return_value=MagicMock()),
+        ):
+            asyncio.run(engine.handle_all_doors_windows_closed())
+
+        mock_dispatch.assert_called_once()
+        assert mock_dispatch.call_args.kwargs["kind"] == DoorWindowFsmEventKind.ALL_SENSORS_CLOSED
+
+    def test_resume_clears_no_grace_from_paused_idle(self):
+        """PAUSED_IDLE (hvac_already_off=True, pre_pause_mode unset) -> CLEAR_NO_GRACE
+        -> NORMAL, no restore action, no grace started."""
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._paused_with_hvac_already_off = True  # PAUSED_IDLE
+        engine._pre_pause_mode = None
+
+        asyncio.run(engine.handle_all_doors_windows_closed())
+
+        assert engine._paused_by_door is False
+        assert engine._grace_active is False
+        engine.hass.services.async_call.assert_not_called()
+
+    def test_no_resume_when_not_paused(self):
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = False
+
+        asyncio.run(engine.handle_all_doors_windows_closed())
+
+        engine.hass.services.async_call.assert_not_called()
+
+
+class TestExitNatVentSensorStillOpenFsmAuthoritative:
+    """Issue #660 Step 4: _exit_nat_vent()'s sensor-still-open branch, with
+    _doorwindow_fsm_authoritative=True, derives its resulting pause flags from
+    door_window_fsm.transition() instead of the unconditional
+    _set_door_window_pause_fields() call — same outcome, different source of truth.
+    The _deactivate_fan()/_pre_pause_mode-capture action stays unconditional and is
+    mocked out here to isolate the flag-derivation behavior under test."""
+
+    def _make_engine_exiting_nat_vent(self, *, hvac_mode: str | None) -> AutomationEngine:
+        from custom_components.climate_advisor.automation import FanCommandResult
+
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine._natural_vent_active = True
+        engine._sensor_check_callback = lambda: True  # monitored sensor still open
+        engine._deactivate_fan = AsyncMock(return_value=FanCommandResult.EXECUTED)
+        engine.hass.states.get = MagicMock(return_value=MagicMock(state=hvac_mode) if hvac_mode is not None else None)
+        return engine
+
+    def test_active_pause_from_normal(self):
+        """No prior pause -> NORMAL origin. NAT_VENT_EXITED_SENSOR_STILL_OPEN
+        unconditionally pauses; hvac_mode not off -> PAUSED_ACTIVE."""
+        engine = self._make_engine_exiting_nat_vent(hvac_mode="cool")
+
+        asyncio.run(engine._exit_nat_vent(reason="test exit"))
+
+        assert engine._paused_by_door is True
+        assert engine._paused_with_hvac_already_off is False
+        assert engine._paused_entity == "nat-vent-exit"
+        assert engine._pre_pause_mode == "cool"
+
+    def test_idle_pause_when_hvac_off(self):
+        engine = self._make_engine_exiting_nat_vent(hvac_mode="off")
+
+        asyncio.run(engine._exit_nat_vent(reason="test exit"))
+
+        assert engine._paused_by_door is True
+        assert engine._paused_with_hvac_already_off is True
+        assert engine._pre_pause_mode is None
+
+    def test_routes_through_shared_dispatcher_with_nat_vent_exit_kind(self):
+        """Direct proof of the wiring change itself (Issue #660 Step 4)."""
+        from custom_components.climate_advisor.door_window_fsm import DoorWindowFsmEventKind
+
+        engine = self._make_engine_exiting_nat_vent(hvac_mode="cool")
+
+        with patch.object(engine, "_resolve_door_window_pause_flags") as mock_dispatch:
+            asyncio.run(engine._exit_nat_vent(reason="test exit"))
+
+        mock_dispatch.assert_called_once()
+        assert mock_dispatch.call_args.kwargs["kind"] == DoorWindowFsmEventKind.NAT_VENT_EXITED_SENSOR_STILL_OPEN
+
+
 class TestManualOverrideDuringPause:
     """Tests for handle_manual_override_during_pause."""
 

--- a/tests/test_door_window.py
+++ b/tests/test_door_window.py
@@ -1381,6 +1381,164 @@ class TestGracePeriodExpiry:
 
 
 # ---------------------------------------------------------------------------
+# Issue #660 Step 8 (highest-risk) — _on_grace_expired() + _re_pause_for_open_sensor()
+# ---------------------------------------------------------------------------
+
+
+class TestOnGraceExpiredFsmAuthoritative:
+    """_on_grace_expired()'s 3 branches, with _doorwindow_fsm_authoritative=True,
+    apply the FSM's GRACE_TIMER_EXPIRED outcome via the shared dispatcher using an
+    origin_state captured BEFORE _cancel_grace_timers() clears _grace_active --
+    the one call site the dispatcher's origin_state override exists for."""
+
+    def _make_engine_grace_origin(self, *, paused_during_grace: bool, outdoor: float) -> AutomationEngine:
+        engine = _make_automation_engine(
+            {"comfort_heat": 70, "comfort_cool": 76, "natural_vent_delta": 3, "sensor_debounce_seconds": 0}
+        )
+        engine._doorwindow_fsm_authoritative = True
+        engine._grace_active = True
+        engine._last_resume_source = "automation"
+        engine._paused_by_door = paused_during_grace  # False -> plain GRACE, True -> PAUSED_DURING_GRACE
+        engine._paused_with_hvac_already_off = False
+        engine._sensor_check_callback = lambda: True  # any_monitored_sensor_open() -> True
+        engine._last_outdoor_temp = outdoor
+        engine._get_indoor_temp_f = MagicMock(return_value=76.0)
+        engine.hass.states.get.return_value = _make_state("cool")
+        return engine
+
+    def test_grace_origin_sensor_open_gate_fails_lands_paused(self):
+        """Origin GRACE (not already paused), sensor still open, nat-vent gate fails
+        (outdoor too warm) -> RE_PAUSE -> nested gate says no -> plain paused
+        sub-state. Applied synchronously, before _re_pause_for_open_sensor() is
+        even scheduled."""
+        engine = self._make_engine_grace_origin(paused_during_grace=False, outdoor=90.0)
+
+        engine._on_grace_expired(source="automation", duration=300, should_notify=False)
+
+        assert engine._paused_by_door is True
+
+    def test_grace_origin_sensor_open_gate_succeeds_lands_normal(self):
+        """Same origin, but nat-vent gate succeeds (outdoor cool enough) -> RE_PAUSE's
+        nested nat-vent recheck decides NORMAL (hand-off to nat-vent) instead."""
+        engine = self._make_engine_grace_origin(paused_during_grace=False, outdoor=68.0)
+
+        engine._on_grace_expired(source="automation", duration=300, should_notify=False)
+
+        assert engine._paused_by_door is False
+
+    def test_paused_during_grace_origin_stays_paused_regardless_of_gate(self):
+        """From PAUSED_DURING_GRACE specifically, the RE_PAUSE outcome always lands on
+        a plain paused state regardless of the nested nat-vent recheck -- pause was
+        already separately active, and grace clearing doesn't touch it (module
+        docstring's documented origin-state distinction)."""
+        engine = self._make_engine_grace_origin(paused_during_grace=True, outdoor=68.0)
+
+        engine._on_grace_expired(source="automation", duration=300, should_notify=False)
+
+        assert engine._paused_by_door is True
+
+    def test_dispatcher_called_with_captured_origin_state_not_live_read(self):
+        """Direct proof that origin_state is passed and used: grace gets cleared by
+        _cancel_grace_timers() (live door_window_lifecycle_state would read GRACE-less
+        NORMAL/paused-only by the time the dispatcher would otherwise read it), but the
+        dispatcher must still receive the pre-clear origin state."""
+        from custom_components.climate_advisor.door_window_fsm import (
+            DoorWindowFsmEventKind,
+            DoorWindowLifecycleState,
+        )
+
+        engine = self._make_engine_grace_origin(paused_during_grace=False, outdoor=90.0)
+
+        with patch.object(engine, "_resolve_door_window_pause_flags") as mock_dispatch:
+            engine._on_grace_expired(source="automation", duration=300, should_notify=False)
+
+        mock_dispatch.assert_called_once()
+        assert mock_dispatch.call_args.kwargs["kind"] == DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED
+        assert mock_dispatch.call_args.kwargs["origin_state"] == DoorWindowLifecycleState.GRACE
+
+    def test_within_planned_window_branch_dispatches_as_safe_noop(self):
+        engine = self._make_engine_grace_origin(paused_during_grace=False, outdoor=90.0)
+        engine._is_within_planned_window_period = MagicMock(return_value=True)
+
+        from custom_components.climate_advisor.door_window_fsm import DoorWindowFsmEventKind
+
+        with patch.object(engine, "_resolve_door_window_pause_flags") as mock_dispatch:
+            engine._on_grace_expired(source="automation", duration=300, should_notify=False)
+
+        mock_dispatch.assert_called_once()
+        assert mock_dispatch.call_args.kwargs["kind"] == DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED
+        # No sensor pause -- outcome stays NORMAL, no change to _paused_by_door.
+        assert engine._paused_by_door is False
+
+    def test_normal_expiry_branch_dispatches_as_safe_noop(self):
+        engine = self._make_engine_grace_origin(paused_during_grace=False, outdoor=90.0)
+        engine._sensor_check_callback = lambda: False  # no sensor open -> normal expiry path
+
+        from custom_components.climate_advisor.door_window_fsm import DoorWindowFsmEventKind
+
+        with patch.object(engine, "_resolve_door_window_pause_flags") as mock_dispatch:
+            engine._on_grace_expired(source="automation", duration=300, should_notify=False)
+
+        mock_dispatch.assert_called_once()
+        assert mock_dispatch.call_args.kwargs["kind"] == DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED
+        assert engine._paused_by_door is False
+
+
+class TestRePauseForOpenSensorFsmAuthoritative:
+    """_re_pause_for_open_sensor(), with _doorwindow_fsm_authoritative=True, selects
+    its action by reading the already-applied _paused_by_door flag (set by
+    _on_grace_expired()'s authoritative dispatcher call before this was scheduled)
+    instead of independently recomputing _nat_vent_may_reactivate()."""
+
+    def _make_engine(self, *, paused_by_door: bool) -> AutomationEngine:
+        engine = _make_automation_engine(
+            {"comfort_heat": 70, "comfort_cool": 76, "natural_vent_delta": 3, "sensor_debounce_seconds": 0}
+        )
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = paused_by_door
+        engine._last_outdoor_temp = 68.0
+        engine._get_indoor_temp_f = MagicMock(return_value=76.0)
+        engine.hass.states.get.return_value = _make_state("cool")
+        return engine
+
+    def test_reads_already_applied_flag_instead_of_recomputing_gate(self):
+        """_paused_by_door already False (FSM decided reactivate) -> nat-vent action
+        runs without calling _nat_vent_may_reactivate() again."""
+        engine = self._make_engine(paused_by_door=False)
+        engine._nat_vent_may_reactivate = MagicMock(side_effect=AssertionError("must not recompute when authoritative"))
+
+        asyncio.run(engine._re_pause_for_open_sensor())
+
+        assert engine._natural_vent_active is True
+
+    def test_reads_already_applied_flag_selects_pause_action(self):
+        """_paused_by_door already True (FSM decided re-pause) -> pause action runs
+        via _pause_for_door_window_action() directly, and _paused_entity/_paused_since
+        are set as direct writes (not part of _apply_door_window_fsm_state())."""
+        engine = self._make_engine(paused_by_door=True)
+        engine._nat_vent_may_reactivate = MagicMock(side_effect=AssertionError("must not recompute when authoritative"))
+
+        asyncio.run(engine._re_pause_for_open_sensor())
+
+        assert engine._paused_entity == "re-check"
+        assert engine._paused_since is not None
+        engine.hass.services.async_call.assert_any_call(
+            "climate", "set_hvac_mode", {"entity_id": "climate.thermostat", "hvac_mode": "off"}
+        )
+
+    def test_does_not_call_full_wrapper_when_authoritative(self):
+        """Distinguishes the authoritative branch from the legacy one: must call
+        _pause_for_door_window_action() (action only), never the full
+        _pause_for_door_window() wrapper (which would re-derive flags a second time)."""
+        engine = self._make_engine(paused_by_door=True)
+
+        with patch.object(engine, "_pause_for_door_window") as mock_wrapper:
+            asyncio.run(engine._re_pause_for_open_sensor())
+
+        mock_wrapper.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Issue #339 — occupancy setback suppressed while paused by door/window
 # ---------------------------------------------------------------------------
 

--- a/tests/test_door_window_fsm.py
+++ b/tests/test_door_window_fsm.py
@@ -208,6 +208,22 @@ class TestFromPaused:
         )
         assert t.to_state == DoorWindowLifecycleState.PAUSED_IDLE
 
+    def test_nat_vent_reactivated_lands_on_normal(self):
+        """Issue #660 Step 3: the 8th event kind. From a plain paused state, nat-vent
+        reactivating always lands on NORMAL (origin has no grace by definition)."""
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_ACTIVE,
+            _ev(DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED),
+        )
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+
+    def test_nat_vent_reactivated_lands_on_normal_from_idle(self):
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_IDLE,
+            _ev(DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED),
+        )
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+
 
 class TestFromGrace:
     def test_sensor_opened_outdoor_too_warm_suppressed(self):
@@ -339,3 +355,12 @@ class TestFromPausedDuringGrace:
     def test_sensor_opened_noop(self):
         t = transition(DoorWindowLifecycleState.PAUSED_DURING_GRACE, _ev(DoorWindowFsmEventKind.SENSOR_OPENED))
         assert t.to_state == DoorWindowLifecycleState.PAUSED_DURING_GRACE
+
+    def test_nat_vent_reactivated_lands_on_grace(self):
+        """Issue #660 Step 3: from PAUSED_DURING_GRACE, nat-vent reactivating clears
+        the pause but leaves grace running (untouched) -- lands on plain GRACE."""
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_DURING_GRACE,
+            _ev(DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED),
+        )
+        assert t.to_state == DoorWindowLifecycleState.GRACE

--- a/tests/test_door_window_fsm.py
+++ b/tests/test_door_window_fsm.py
@@ -41,6 +41,7 @@ def _inputs(**overrides) -> DoorWindowFsmInputs:
         natural_vent_active=False,
         whf_owns_hvac=False,
         grace_active=False,
+        pre_pause_mode_active=False,
         now=_NOW,
     )
     base.update(overrides)
@@ -127,12 +128,33 @@ class TestFromNormal:
 
 class TestFromPaused:
     def test_all_sensors_closed_active_restores_and_graces(self):
-        t = transition(DoorWindowLifecycleState.PAUSED_ACTIVE, _ev(DoorWindowFsmEventKind.ALL_SENSORS_CLOSED))
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_ACTIVE,
+            _ev(DoorWindowFsmEventKind.ALL_SENSORS_CLOSED, pre_pause_mode_active=True),
+        )
         assert t.to_state == DoorWindowLifecycleState.GRACE
 
     def test_all_sensors_closed_idle_clears_no_grace(self):
-        t = transition(DoorWindowLifecycleState.PAUSED_IDLE, _ev(DoorWindowFsmEventKind.ALL_SENSORS_CLOSED))
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_IDLE,
+            _ev(DoorWindowFsmEventKind.ALL_SENSORS_CLOSED, pre_pause_mode_active=False),
+        )
         assert t.to_state == DoorWindowLifecycleState.NORMAL
+
+    def test_all_sensors_closed_idle_origin_but_pre_pause_mode_active_restores(self):
+        """Issue #660 Step 2: the ALL_SENSORS_CLOSED branch used to infer
+        pre_pause_mode from `current_state == PAUSED_ACTIVE`, a placeholder rather
+        than the real AutomationEngine._pre_pause_mode value. PAUSED_ACTIVE vs.
+        PAUSED_IDLE depends on _paused_with_hvac_already_off, which a still-legacy
+        call site (_exit_nat_vent()'s sensor-still-open branch) could leave stale —
+        so a reachable case exists where current_state == PAUSED_IDLE but the real
+        pre_pause_mode is still set (truthy). This must now correctly restore/grace,
+        not silently clear with no restore because the origin-state proxy said IDLE."""
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_IDLE,
+            _ev(DoorWindowFsmEventKind.ALL_SENSORS_CLOSED, pre_pause_mode_active=True),
+        )
+        assert t.to_state == DoorWindowLifecycleState.GRACE
 
     def test_manual_override_during_pause_clears_to_normal(self):
         t = transition(DoorWindowLifecycleState.PAUSED_ACTIVE, _ev(DoorWindowFsmEventKind.MANUAL_OVERRIDE_DURING_PAUSE))

--- a/tests/test_door_window_fsm.py
+++ b/tests/test_door_window_fsm.py
@@ -40,6 +40,7 @@ def _inputs(**overrides) -> DoorWindowFsmInputs:
         grace_source="manual",
         natural_vent_active=False,
         whf_owns_hvac=False,
+        grace_active=False,
         now=_NOW,
     )
     base.update(overrides)
@@ -148,6 +149,42 @@ class TestFromPaused:
     def test_grace_timer_expired_unreachable_noop(self):
         t = transition(DoorWindowLifecycleState.PAUSED_ACTIVE, _ev(DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED))
         assert t.to_state == DoorWindowLifecycleState.PAUSED_ACTIVE
+
+    def test_sync_reconcile_grace_active_upgrades_to_paused_during_grace(self):
+        """Issue #660: _sync_reconcile_next_state() previously never checked live
+        grace_active when already in a PAUSED_* state — the FSM's own carried state
+        would silently disagree with production once grace started running
+        concurrently with an existing pause. SYNC_RECONCILE from PAUSED_ACTIVE/
+        PAUSED_IDLE with grace_active=True must now upgrade to PAUSED_DURING_GRACE."""
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_ACTIVE,
+            _ev(DoorWindowFsmEventKind.SYNC_RECONCILE, grace_active=True),
+        )
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_DURING_GRACE
+
+    def test_sync_reconcile_grace_active_upgrades_from_paused_idle(self):
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_IDLE,
+            _ev(DoorWindowFsmEventKind.SYNC_RECONCILE, grace_active=True),
+        )
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_DURING_GRACE
+
+    def test_sync_reconcile_grace_inactive_stays_paused_active(self):
+        """Regression guard: grace_active=False must not change the outcome —
+        SYNC_RECONCILE from a plain paused state with no grace running is still a
+        no-op (the pre-existing behavior for this origin state)."""
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_ACTIVE,
+            _ev(DoorWindowFsmEventKind.SYNC_RECONCILE, grace_active=False),
+        )
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_ACTIVE
+
+    def test_sync_reconcile_grace_inactive_stays_paused_idle(self):
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_IDLE,
+            _ev(DoorWindowFsmEventKind.SYNC_RECONCILE, grace_active=False),
+        )
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_IDLE
 
 
 class TestFromGrace:

--- a/tests/test_door_window_fsm_shadow_wiring.py
+++ b/tests/test_door_window_fsm_shadow_wiring.py
@@ -66,6 +66,18 @@ class TestFsmEvaluationScoping:
         _run(coordinator._mirror_to_shadow("handle_manual_override_during_pause"))
         assert called == ["handle_manual_override_during_pause"]
 
+    def test_triggered_by_check_natural_vent_conditions(self) -> None:
+        """Issue #660 Step 3: the 8th real trigger site. check_natural_vent_conditions()
+        previously had zero door/window FSM event feed at all -- it was only
+        registered in _NAT_VENT_FSM_TRIGGER_METHODS (feeding the nat-vent FSM)."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        called: list[str] = []
+        coordinator._evaluate_door_window_fsm = lambda method_name: called.append(method_name)  # type: ignore[method-assign]
+
+        _noop_shadow_methods(coordinator, "check_natural_vent_conditions")
+        _run(coordinator._mirror_to_shadow("check_natural_vent_conditions"))
+        assert called == ["check_natural_vent_conditions"]
+
 
 class TestFsmStateTracking:
     def test_starts_normal(self) -> None:

--- a/tests/test_doorwindow_fsm_authoritative_compare.py
+++ b/tests/test_doorwindow_fsm_authoritative_compare.py
@@ -1,14 +1,15 @@
-"""Tests for Issue #594 Phase R, Step 3: decision-equivalence for the door/window
-FSM-authoritative swap (Step 2, partial-authority increment).
+"""Tests for Issue #594 Phase R: decision-equivalence for the door/window
+FSM-authoritative swap. As of Issue #660 Phase R Step 8, full authority — see
+``automation.py``'s ``_doorwindow_fsm_authoritative`` docstring for the complete
+8-method list this flag now governs, all via the shared
+``AutomationEngine._resolve_door_window_pause_flags()`` dispatcher.
 
 Prior coverage (``test_shadow_engine_coverage.py``, ``test_shadow_engine_pair.py``)
 only proved *state-label* agreement. This file proves the stronger claim Phase R
 needs before any live switch is considered: flipping
 ``AutomationEngine._doorwindow_fsm_authoritative`` from its default ``False`` to
-``True`` produces a byte-for-byte identical ``event_log``/``action_log`` — for the
-2 methods this increment actually swaps
-(``handle_manual_override_during_pause``/``resume_from_pause``) — across the full
-golden + pending scenario corpus.
+``True`` produces a byte-for-byte identical ``event_log``/``action_log`` across the
+full golden + pending scenario corpus.
 
 **Corpus coverage confirmed insufficient before writing this, not assumed.**
 ``resume_from_pause()`` has NO scenario-event mapping at all in
@@ -23,6 +24,22 @@ reachable in principle (``thermostat_state_changed`` scenario events, when
 that exact state is not assumed here either. Both get a direct-engine-construction
 positive control below, same style as
 ``test_nat_vent_fsm_authoritative_compare.py``'s soft-start probe.
+
+**Issue #660 Step 8 additions.** The corpus-wide equivalence test above is now
+clean across all 8 sites (confirmed: no scenario in the golden/pending corpus
+diverges with the flag flipped for any of the 6 newly-authoritative methods), but a
+clean corpus diff proves absence of divergence, not presence of real coverage —
+same lesson ``resume_from_pause()`` established. Two areas are the most likely to
+be under-exercised by the corpus specifically (per the Step 8 plan's own caution):
+the ``GRACE_TIMER_EXPIRED`` origin-state variant (does the corpus ever reach
+``_on_grace_expired()`` from ``PAUSED_DURING_GRACE``, not just plain ``GRACE``?)
+and the brand-new ``PAUSED_NAT_VENT_REACTIVATED`` kind (fed only from
+``check_natural_vent_conditions()``, which the corpus does drive every tick, but
+whether any scenario's specific temperature/pause state combination reaches the
+reactivation-while-paused branch at all is not assumed). Both get direct-
+construction positive controls below (``TestGraceTimerExpiredOriginStatePositive
+Control``, ``TestPausedNatVentReactivatedPositiveControl``), proving a broken FSM
+transition for each would actually be caught, not just that the corpus stays quiet.
 """
 
 from __future__ import annotations
@@ -160,3 +177,165 @@ class TestFsmAuthoritativePositiveControl:
         asyncio.run(engine.resume_from_pause())
         assert engine._paused_by_door is False
         assert engine._grace_active is True
+
+
+class TestGraceTimerExpiredOriginStatePositiveControl:
+    """Issue #660 Step 8/10: direct-construction positive controls proving a broken
+    GRACE_TIMER_EXPIRED transition would be caught, for both origin states
+    _on_grace_expired() can be reached from (GRACE and PAUSED_DURING_GRACE) —
+    the plan's own explicit caution that this origin-state variant is the most
+    likely to be under-exercised by the corpus (a clean corpus diff proves absence
+    of divergence, not presence of real coverage)."""
+
+    def _make_engine(self, *, paused_during_grace: bool, outdoor: float) -> AutomationEngine:  # noqa: F821
+        from unittest.mock import AsyncMock, MagicMock
+
+        from custom_components.climate_advisor.automation import AutomationEngine
+
+        hass = MagicMock()
+        hass.services = MagicMock()
+        hass.services.async_call = AsyncMock()
+        hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+        climate_state = MagicMock()
+        climate_state.state = "cool"
+        hass.states = MagicMock()
+        hass.states.get = MagicMock(return_value=climate_state)
+
+        engine = AutomationEngine(
+            hass=hass,
+            climate_entity="climate.thermostat",
+            weather_entity="weather.forecast_home",
+            door_window_sensors=["binary_sensor.front_door"],
+            notify_service="notify.notify",
+            config={"comfort_heat": 70.0, "comfort_cool": 76.0, "natural_vent_delta": 3.0},
+        )
+        engine._doorwindow_fsm_authoritative = True
+        engine._grace_active = True
+        engine._last_resume_source = "automation"
+        engine._paused_by_door = paused_during_grace
+        engine._paused_with_hvac_already_off = False
+        engine._sensor_check_callback = lambda: True
+        engine._last_outdoor_temp = outdoor
+        engine._get_indoor_temp_f = lambda: 76.0
+        return engine
+
+    def test_broken_transition_detected_from_grace_origin(self) -> None:
+        """Origin GRACE (not already paused): a broken transition() forced to return
+        the WRONG state (NORMAL, i.e. "cleared, no re-pause") when the real outcome
+        should re-pause must show up as a detectable divergence."""
+        from unittest.mock import patch
+
+        from custom_components.climate_advisor.door_window_lifecycle import DoorWindowLifecycleState
+
+        engine = self._make_engine(paused_during_grace=False, outdoor=90.0)  # too warm -> real outcome re-pauses
+        with patch(
+            "custom_components.climate_advisor.door_window_fsm.transition",
+            side_effect=lambda *a, **k: type(
+                "T", (), {"to_state": DoorWindowLifecycleState.NORMAL, "outcome": "broken", "at": None}
+            )(),
+        ):
+            engine._on_grace_expired(source="automation", duration=300, should_notify=False)
+
+        assert engine._paused_by_door is False, (
+            "positive control FAILED: forcing door_window_fsm.transition() to return NORMAL was not "
+            "reflected in engine._paused_by_door — the mock wasn't actually exercised (real outcome "
+            "here should have re-paused, so an undetected broken swap would incorrectly show "
+            "_paused_by_door=True instead)"
+        )
+
+    def test_broken_transition_detected_from_paused_during_grace_origin(self) -> None:
+        """Origin PAUSED_DURING_GRACE: a broken transition() forced to return NORMAL
+        (real outcome should stay paused, per this origin's own documented
+        distinction — see door_window_fsm.py's module docstring) must also be
+        detectable."""
+        from unittest.mock import patch
+
+        from custom_components.climate_advisor.door_window_lifecycle import DoorWindowLifecycleState
+
+        engine = self._make_engine(paused_during_grace=True, outdoor=68.0)  # cool enough to reactivate, but origin
+        # PAUSED_DURING_GRACE always stays paused regardless
+        with patch(
+            "custom_components.climate_advisor.door_window_fsm.transition",
+            side_effect=lambda *a, **k: type(
+                "T", (), {"to_state": DoorWindowLifecycleState.NORMAL, "outcome": "broken", "at": None}
+            )(),
+        ):
+            engine._on_grace_expired(source="automation", duration=300, should_notify=False)
+
+        assert engine._paused_by_door is False, (
+            "positive control FAILED: forcing door_window_fsm.transition() to return NORMAL was not "
+            "reflected in engine._paused_by_door — the mock wasn't actually exercised, invalidating "
+            "this control"
+        )
+
+    def test_unbroken_transition_from_paused_during_grace_stays_paused(self) -> None:
+        """Regression guard for the real (unmocked) transition table: confirms the
+        actual fix behaves per its own documented origin-state distinction."""
+        engine = self._make_engine(paused_during_grace=True, outdoor=68.0)
+        engine._on_grace_expired(source="automation", duration=300, should_notify=False)
+        assert engine._paused_by_door is True
+
+
+class TestPausedNatVentReactivatedPositiveControl:
+    """Issue #660 Step 8/10: direct-construction positive control for the brand-new
+    PAUSED_NAT_VENT_REACTIVATED kind (Step 3) — fed only from
+    check_natural_vent_conditions(), which the corpus drives every tick, but whether
+    any specific scenario's temperature/pause combination reaches this exact branch
+    is not assumed."""
+
+    def _make_engine(self) -> AutomationEngine:  # noqa: F821
+        from unittest.mock import AsyncMock, MagicMock
+
+        from custom_components.climate_advisor.automation import AutomationEngine
+
+        hass = MagicMock()
+        hass.services = MagicMock()
+        hass.services.async_call = AsyncMock()
+        hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+        hass.states = MagicMock()
+        hass.states.get = MagicMock(return_value=None)
+
+        engine = AutomationEngine(
+            hass=hass,
+            climate_entity="climate.thermostat",
+            weather_entity="weather.forecast_home",
+            door_window_sensors=["binary_sensor.front_door"],
+            notify_service="notify.notify",
+            config={"comfort_heat": 70.0, "comfort_cool": 76.0, "natural_vent_delta": 3.0},
+        )
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._natural_vent_active = False
+        engine._last_outdoor_temp = 68.0
+        engine._get_indoor_temp_f = lambda: 76.0
+        return engine
+
+    def test_broken_transition_detected(self) -> None:
+        import asyncio
+        from unittest.mock import patch
+
+        from custom_components.climate_advisor.door_window_lifecycle import DoorWindowLifecycleState
+
+        engine = self._make_engine()
+        with patch(
+            "custom_components.climate_advisor.door_window_fsm.transition",
+            side_effect=lambda *a, **k: type(
+                "T", (), {"to_state": DoorWindowLifecycleState.PAUSED_ACTIVE, "outcome": "broken", "at": None}
+            )(),
+        ):
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._paused_by_door is True, (
+            "positive control FAILED: forcing door_window_fsm.transition() to return PAUSED_ACTIVE was "
+            "not reflected in engine._paused_by_door — the mock wasn't actually exercised (real outcome "
+            "for a successful reactivation is NORMAL, so an undetected broken swap would incorrectly "
+            "show _paused_by_door=False instead)"
+        )
+
+    def test_unbroken_transition_clears_pause_on_reactivation(self) -> None:
+        import asyncio
+
+        engine = self._make_engine()
+        asyncio.run(engine.check_natural_vent_conditions())
+        assert engine._paused_by_door is False
+        assert engine._natural_vent_active is True

--- a/tests/test_grace_refresh_and_band_call.py
+++ b/tests/test_grace_refresh_and_band_call.py
@@ -60,7 +60,9 @@ def _minimal_engine() -> AutomationEngine:
             "_active_listeners": [],
             "_current_classification": None,
             "_paused_by_door": False,
+            "_paused_with_hvac_already_off": False,
             "_pre_pause_mode": None,
+            "_doorwindow_fsm_authoritative": False,
             "_manual_grace_cancel": None,
             "_automation_grace_cancel": None,
             "_grace_active": True,  # grace is active when expiry fires

--- a/tests/test_nat_vent_activation.py
+++ b/tests/test_nat_vent_activation.py
@@ -449,6 +449,80 @@ class TestReactivationLockout:
         assert engine._natural_vent_active is True
 
 
+class TestReactivationFsmDispatch:
+    """Issue #660 Step 5: check_natural_vent_conditions()'s two reactivation-while-
+    paused branches (full-gate and soft-start) route their flag-clear through the
+    shared dispatcher instead of a direct 4-field write. Group A: the activation
+    action itself is unchanged; this proves the dispatcher wiring itself, since the
+    external flag outcome is identical whether legacy or FSM ran (both always clear
+    to NORMAL from a plain paused origin, per Step 3)."""
+
+    def test_full_gate_reactivation_routes_through_dispatcher(self):
+        from custom_components.climate_advisor.door_window_fsm import DoorWindowFsmEventKind
+
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._natural_vent_active = False
+        engine._last_outdoor_temp = 68.0
+
+        with patch.object(engine, "_resolve_door_window_pause_flags") as mock_dispatch:
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        mock_dispatch.assert_called_once()
+        assert mock_dispatch.call_args.kwargs["kind"] == DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED
+
+    def test_full_gate_reactivation_clears_pause_when_authoritative(self):
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._natural_vent_active = False
+        engine._last_outdoor_temp = 68.0
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True
+        assert engine._paused_by_door is False
+        assert engine._paused_entity is None
+
+    def test_soft_start_reactivation_routes_through_dispatcher(self):
+        """Same dispatcher, reached via the soft-start branch instead of the full
+        gate — isolated by forcing the full gate to decline and the soft-start gate
+        to accept, rather than reconstructing the exact peak/decline outdoor history
+        _nat_vent_may_soft_start() itself requires (that logic has its own dedicated
+        coverage elsewhere)."""
+        from custom_components.climate_advisor.door_window_fsm import DoorWindowFsmEventKind
+
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._natural_vent_active = False
+        engine._last_outdoor_temp = 68.0
+        engine._nat_vent_may_reactivate = MagicMock(return_value=False)
+        engine._nat_vent_may_soft_start = MagicMock(return_value=True)
+
+        with patch.object(engine, "_resolve_door_window_pause_flags") as mock_dispatch:
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        mock_dispatch.assert_called_once()
+        assert mock_dispatch.call_args.kwargs["kind"] == DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED
+
+    def test_soft_start_reactivation_clears_pause_when_authoritative(self):
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._natural_vent_active = False
+        engine._last_outdoor_temp = 68.0
+        engine._nat_vent_may_reactivate = MagicMock(return_value=False)
+        engine._nat_vent_may_soft_start = MagicMock(return_value=True)
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True
+        assert engine._nat_vent_soft_start is True
+        assert engine._paused_by_door is False
+
+
 class TestReactivationLockoutLoadBearing:
     """Architecture-reset Step 2: proves check_natural_vent_conditions() genuinely calls
     is_reactivation_locked_out() to decide, not some other code path that happens to agree."""

--- a/tests/test_shadow_engine_coverage.py
+++ b/tests/test_shadow_engine_coverage.py
@@ -345,6 +345,7 @@ _DOOR_WINDOW_EVENT_KIND_REGISTRY: dict[str, str] = {
     "DASHBOARD_RESUME": "reachable",
     "NAT_VENT_EXITED_SENSOR_STILL_OPEN": "reachable",
     "SYNC_RECONCILE": "reachable",
+    "PAUSED_NAT_VENT_REACTIVATED": "reachable",
 }
 
 

--- a/tests/test_shadow_engine_sensor.py
+++ b/tests/test_shadow_engine_sensor.py
@@ -84,6 +84,39 @@ class TestExtraStateAttributes:
         )
         assert sensor.extra_state_attributes["nat_vent_fsm_state"] is None
 
+    def test_reports_door_window_fields_when_present(self) -> None:
+        """Issue #660: door/window's own production/shadow/FSM state fields were
+        already computed in coordinator.shadow_engine_diagnostic but never exposed
+        on this sensor -- an observability gap fixed alongside the door/window FSM
+        authority extension."""
+        sensor = _make_sensor(
+            {
+                "production_state": "active",
+                "shadow_state": "active",
+                "agrees": True,
+                "checked_at": "t",
+                "door_window_production_state": "paused_active",
+                "door_window_shadow_state": "paused_active",
+                "door_window_fsm_state": "paused_active",
+                "door_window_mirror_agrees": True,
+                "door_window_fsm_agrees": True,
+            }
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["door_window_production_state"] == "paused_active"
+        assert attrs["door_window_shadow_state"] == "paused_active"
+        assert attrs["door_window_fsm_state"] == "paused_active"
+        assert attrs["door_window_mirror_agrees"] is True
+        assert attrs["door_window_fsm_agrees"] is True
+
+    def test_door_window_fields_absent_before_first_evaluation(self) -> None:
+        sensor = _make_sensor(
+            {"production_state": "active", "shadow_state": "idle", "agrees": False, "checked_at": "t"}
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["door_window_production_state"] is None
+        assert attrs["door_window_fsm_agrees"] is None
+
 
 class TestEntityCategory:
     def test_is_diagnostic(self) -> None:

--- a/tests/test_window_hvac_interaction.py
+++ b/tests/test_window_hvac_interaction.py
@@ -93,6 +93,7 @@ def _make_ae_stub(**overrides) -> AutomationEngine:
     ae._economizer_phase = "inactive"
     ae._paused_by_door = False
     ae._pre_pause_mode = None
+    ae._doorwindow_fsm_authoritative = False
     ae._grace_active = False
     ae._grace_end_time = None
     ae._last_resume_source = None

--- a/tests/test_window_hvac_interaction.py
+++ b/tests/test_window_hvac_interaction.py
@@ -92,6 +92,7 @@ def _make_ae_stub(**overrides) -> AutomationEngine:
     ae._economizer_active = False
     ae._economizer_phase = "inactive"
     ae._paused_by_door = False
+    ae._paused_with_hvac_already_off = False
     ae._pre_pause_mode = None
     ae._doorwindow_fsm_authoritative = False
     ae._grace_active = False


### PR DESCRIPTION
## Summary

Completes the door/window pause/grace lifecycle FSM migration begun in #637 (epic #594, Phase R). All 8 real production trigger sites now derive their door/window pause flags through one shared dispatcher (`AutomationEngine._resolve_door_window_pause_flags()`), gated on the existing `_doorwindow_fsm_authoritative` switch — which stays **off by default** in this PR (no occupant-visible behavior change on its own; a live switch-flip is a separate follow-up).

**Two real bugs fixed** (Steps 1-2), independent of the authority extension:
- `_sync_reconcile_next_state()` never checked live `grace_active` when the FSM was already in a `PAUSED_*` state — the FSM's own tracked state could silently disagree with production once grace started running concurrently with an existing pause.
- `_transition_from_paused()`'s `ALL_SENSORS_CLOSED` branch inferred `pre_pause_mode` truthiness from `current_state == PAUSED_ACTIVE` (a placeholder) instead of the real `AutomationEngine._pre_pause_mode` value — reachable divergence when `_paused_with_hvac_already_off` went stale via a differently-timed write.

**8th trigger site found and added** (Step 3): `check_natural_vent_conditions()`'s two reactivation-while-paused branches previously had *zero* door/window FSM event feed at all (only registered for the nat-vent FSM) — added `DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED`.

**Structural consolidation** (Step 0, provable no-op — full suite + golden corpus clean before/after): deleted a fully-redundant coordinator-side FSM-inputs builder; added the shared dispatcher; collapsed repeated try/except FSM-dispatch blocks into one declarative loop.

**All 8 sites migrated to the dispatcher** (Steps 4-8): `handle_all_doors_windows_closed()`, `_exit_nat_vent()`'s sensor-still-open branch, `check_natural_vent_conditions()`'s two reactivation branches, `handle_door_window_open()`, and the coupled `_on_grace_expired()`/`_re_pause_for_open_sensor()` pair (highest-risk: `_re_pause_for_open_sensor()` now trusts flags `_on_grace_expired()` already applied via an explicitly captured pre-grace-clear origin state, instead of independently re-deciding).

**Diagnostics** (Step 9): Shadow Engine Status sensor now exposes door/window's already-computed diagnostic fields (previously computed but never surfaced). Docstrings updated across `automation.py`/`door_window_fsm.py`.

**Verification** (Step 10): extended `test_doorwindow_fsm_authoritative_compare.py` with direct-construction positive controls for the two areas least likely to be naturally exercised by the golden/pending corpus — the `GRACE_TIMER_EXPIRED` origin-state variant (both `GRACE` and `PAUSED_DURING_GRACE`) and the new `PAUSED_NAT_VENT_REACTIVATED` kind.

## Deviation from the original plan (found during implementation, not a blocker)

The plan's investigation enumerated "8 real trigger sites" and stated the `_pause_for_door_window()` wrapper has "no [other] generic callers today." Two more real callers of that wrapper were found: `_apply_comfort_band()`'s door/window guard and `_sync_paused_by_door_with_live_sensors()`'s (Issue #620) direct-pause path. Both automatically gained FSM-authoritative capability through the one shared wrapper (Step 6) rather than needing individual treatment — a correction to the investigation's site count, not a design gap. Noted in the `KNOWN_FIXES[660]` entry.

## Test plan

- [x] Full test suite (`pytest tests/ -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`) — 4747 passed, 6 skipped, 3 deselected (pre-existing, unrelated `TestGracePeriodDuration`/`TestGracePeriodExpiry` mock-ordering failures, confirmed identical before/after every step via `git stash`)
- [x] `python tools/simulate.py` — 81/81 golden scenarios clean
- [x] `test_doorwindow_fsm_authoritative_compare.py` — corpus-wide equivalence clean across all 8 sites + new direct-construction positive controls for both origin states and the new event kind
- [x] Each production fix TDD'd: test written first, confirmed red via `git stash` against pre-fix code, green after
- [x] Lint (`ruff check` + `ruff format`) clean across all modified files
- [x] Deployed with `_doorwindow_fsm_authoritative` still defaulting `False` — no live switch-flip in this PR

Closes #660. Completes #637's scope (do not close #637 or comment on epic #594 from this PR — left for review).