### PR TITLE
Fix #661: override/grace shadow FSM fan-override confirm-delay mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.28] — 2026-08-16
+
+- Fix #661: the override/grace shadow FSM's diagnostic accuracy for fan overrides (whole-house-fan remote timers, physical fan-on detection) is now correct — it previously modeled a confirmation delay that fan overrides never actually go through in production, causing a spurious disagreement reading on the most common override path. No occupant-visible change: override/grace has no authoritative switch and never drove real decisions — this only fixes what the diagnostic sensor reports.
+
 ## [0.6.27] — 2026-08-16
 
 - Fix #660: the door/window pause/grace lifecycle FSM now has full, off-by-default authority for all 8 real trigger sites — completing the migration begun in #637. Also fixes a real gap found during that work: when a grace period was already running and a door/window pause independently became active too, the FSM's own tracked state could disagree with what production actually did, and a resume-after-close could restore the wrong prior HVAC mode in a specific reachable sequence. Both are fixed at the source for every caller, not patched per call site. The switch that lets this FSM actually drive decisions (instead of just tracking them for comparison) stays off by default — no occupant-visible behavior change from this release alone.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,19 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.27"
+VERSION = "0.6.28"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.28": [
+        "Fix #661: the override/grace shadow FSM's diagnostic accuracy for fan"
+        " overrides (whole-house-fan remote timers, physical fan-on detection)"
+        " is now correct — it previously modeled a confirmation delay that"
+        " fan overrides never actually go through in production, causing a"
+        " spurious disagreement reading on the most common override path. No"
+        " occupant-visible change: override/grace has no authoritative switch"
+        " and never drove real decisions — this only fixes what the diagnostic"
+        " sensor reports.",
+    ],
     "0.6.27": [
         "Fix #660: the door/window pause/grace lifecycle FSM now has full,"
         " off-by-default authority for all 8 real trigger sites — completing"
@@ -1937,6 +1947,31 @@ KNOWN_FIXES: dict[int, dict] = {
             " automatically gained FSM-authoritative capability through that one shared"
             " wrapper rather than needing individual treatment — noted here since it's a"
             " correction to the investigation's own site count, not a new gap."
+        ),
+    },
+    661: {
+        "version_fixed": "0.6.28",
+        "title": "Override/grace shadow FSM: fan-override path incorrectly modeled a confirm delay",
+        "scope_covered": (
+            "override_grace_fsm.py/coordinator.py: handle_fan_manual_override() was mapped"
+            " to the same OVERRIDE_DETECTED event kind as the two genuinely"
+            " confirm-delay-eligible thermostat-override call sites"
+            " (handle_manual_override(), handle_manual_override_during_pause()), causing"
+            " _land_after_detection() to model a PENDING confirmation for fan overrides"
+            " that production never creates (handle_fan_manual_override() sets"
+            " _fan_override_active and starts a protecting grace directly and"
+            " unconditionally, never touching start_override_confirmation()/"
+            " decide_override_confirm() at all). Added a dedicated FAN_OVERRIDE_DETECTED"
+            " event kind, short-circuited at the top of transition() to"
+            " (IDLE, ACTIVE_PROTECTING_OVERRIDE) before any state-based dispatch — keeps"
+            " _land_after_detection()'s thermostat-only confirm-delay logic completely"
+            " untouched. Exposed override/grace's shadow-diagnostic fields on the Shadow"
+            " Engine Status sensor (previously computed but never surfaced, same gap #660"
+            " fixed for door/window). No authoritative switch exists for override/grace —"
+            " zero occupant-visible behavior change; this is a diagnostic-accuracy fix"
+            " only, closing the live disagreement observed 2026-08-16"
+            " (production=idle/active_protecting_override, fsm=pending/none) on a QuietCool"
+            " RF remote timer press."
         ),
     },
     651: {

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -410,7 +410,7 @@ _DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS: frozenset[str] = frozenset(
 _DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES: frozenset[str] = frozenset({"grace_expired", "override_adopted"})
 
 # Issue #639/#643: which mirrored automation.py methods correspond to which
-# override/grace FSM event kind. Of the 7 OverrideGraceFsmEventKind members,
+# override/grace FSM event kind. Of the 8 OverrideGraceFsmEventKind members,
 # 3 have an actual _mirror_to_shadow() call site in coordinator.py/api.py today
 # (handle_fan_manual_override added in #643 — the FSM's OVERRIDE_DETECTED
 # transition was already fully built and generically input-driven; the only
@@ -431,7 +431,14 @@ _DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES: frozenset[str] = frozenset({"grace_expire
 _OVERRIDE_GRACE_FSM_EVENT_KINDS: dict[str, str] = {
     "handle_manual_override_during_pause": "manual_override_during_pause",
     "resume_from_pause": "dashboard_resume",
-    "handle_fan_manual_override": "override_detected",
+    # Issue #661: was "override_detected" — handle_fan_manual_override() never
+    # routes through start_override_confirmation()'s confirm-delay machinery
+    # like the two OVERRIDE_DETECTED call sites below do, so it was landing the
+    # FSM on a spurious PENDING confirm state that production never creates.
+    # FAN_OVERRIDE_DETECTED is a dedicated kind the dispatcher short-circuits to
+    # (IDLE, ACTIVE_PROTECTING_OVERRIDE) immediately, matching production's
+    # actual unconditional behavior.
+    "handle_fan_manual_override": "fan_override_detected",
     # Issue #651: same entry-wiring gap #643 fixed for handle_fan_manual_override,
     # never done for the thermostat-level override path. Maps to the same
     # OVERRIDE_DETECTED kind — OverrideGraceFsmInputs.setpoint_override already

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.27"
+  "version": "0.6.28"
 }

--- a/custom_components/climate_advisor/override_grace_fsm.py
+++ b/custom_components/climate_advisor/override_grace_fsm.py
@@ -101,6 +101,18 @@ class OverrideGraceFsmEventKind(Enum):
     GRACE_TIMER_EXPIRED = "grace_timer_expired"
     MANUAL_OVERRIDE_DURING_PAUSE = "manual_override_during_pause"
     DASHBOARD_RESUME = "dashboard_resume"
+    # Issue #661: distinct from OVERRIDE_DETECTED. That kind models the
+    # thermostat-mode/setpoint override path, which genuinely routes through
+    # start_override_confirmation()'s disabled-vs-pending branch. Fan overrides
+    # (handle_fan_manual_override()) never touch that machinery at all — they set
+    # _fan_override_active and start a protecting grace directly and
+    # unconditionally, every time, regardless of origin state. Landing this on
+    # the same OVERRIDE_DETECTED kind made _land_after_detection()'s confirm-delay
+    # model misfire for the fan path (it would model a PENDING confirmation that
+    # production never creates). A dedicated kind lets the fan path land
+    # immediately at the dispatcher level without touching the thermostat path's
+    # shared confirm-delay logic at all.
+    FAN_OVERRIDE_DETECTED = "fan_override_detected"
 
 
 @dataclass(frozen=True)
@@ -359,7 +371,23 @@ def transition(current_state: OverrideGraceLifecycleState, event: OverrideGraceF
     Dispatches on the grace axis first (the dominant axis — grace outlives or
     is independent of confirm state in most transitions), then the confirm axis
     only where it matters, mirroring ``door_window_fsm.py``'s own precedent of
-    collapsing sub-states that share almost all their transition logic."""
+    collapsing sub-states that share almost all their transition logic.
+
+    ``FAN_OVERRIDE_DETECTED`` (Issue #661) is handled here, before the
+    state-based dispatch, rather than inside any of the three
+    ``_transition_from_*`` functions: ``handle_fan_manual_override()`` is fully
+    idempotent and unconditional in production (always lands on
+    ``ACTIVE_PROTECTING_OVERRIDE`` regardless of origin state — see
+    ``_GRACE_TRIGGERS_PROTECTING_OVERRIDE`` in automation.py), so there is no
+    state-dependent branching to do, and short-circuiting here keeps
+    ``_land_after_detection()``'s thermostat-only confirm-delay model completely
+    untouched by the fan path's different contract.
+    """
+    if event.kind == OverrideGraceFsmEventKind.FAN_OVERRIDE_DETECTED:
+        next_state = (OverrideConfirmState.IDLE, GraceState.ACTIVE_PROTECTING_OVERRIDE)
+        return OverrideGraceTransition(
+            current_state, next_state, event.kind, "fan_override_immediate", event.inputs.now
+        )
     _confirm, grace = current_state
     if grace == GraceState.NONE:
         return _transition_from_no_grace(current_state, event)

--- a/custom_components/climate_advisor/sensor.py
+++ b/custom_components/climate_advisor/sensor.py
@@ -521,4 +521,14 @@ class ClimateAdvisorShadowEngineStatusSensor(ClimateAdvisorBaseSensor):
             # AutomationEngine._doorwindow_fsm_authoritative's docstring), not a
             # partial subset as previously documented here.
             "doorwindow_fsm_authoritative": self.coordinator.doorwindow_fsm_authoritative,
+            # Issue #661: override/grace's own production/shadow/FSM state fields were
+            # already computed in coordinator.shadow_engine_diagnostic but never exposed
+            # here — the same observability gap door/window had before #660, now closed
+            # for override/grace too. No authoritative switch exists for override/grace
+            # (see AutomationEngine's override/grace handlers) — this is diagnostic only.
+            "override_grace_production_state": diag.get("override_grace_production_state"),
+            "override_grace_shadow_state": diag.get("override_grace_shadow_state"),
+            "override_grace_fsm_state": diag.get("override_grace_fsm_state"),
+            "override_grace_mirror_agrees": diag.get("override_grace_mirror_agrees"),
+            "override_grace_fsm_agrees": diag.get("override_grace_fsm_agrees"),
         }

--- a/tests/test_override_grace_fsm.py
+++ b/tests/test_override_grace_fsm.py
@@ -288,3 +288,48 @@ class TestDispatchOnGraceAxisNotConfirmAxis:
         t_idle = transition(_IDLE_NONE, _ev(OverrideGraceFsmEventKind.DASHBOARD_RESUME))
         t_pending = transition(_PENDING_NONE, _ev(OverrideGraceFsmEventKind.DASHBOARD_RESUME))
         assert t_idle.outcome == t_pending.outcome == "resumed"
+
+
+class TestFanOverrideDetected:
+    """Issue #661: handle_fan_manual_override() never routes through
+    start_override_confirmation()'s confirm-delay machinery — it always lands
+    immediately on (IDLE, ACTIVE_PROTECTING_OVERRIDE), regardless of origin
+    state and regardless of confirm_seconds. FAN_OVERRIDE_DETECTED is
+    short-circuited at the top of transition(), before the state-based
+    dispatch, so this holds from all three origin states."""
+
+    def test_from_no_grace_lands_protecting_immediately(self):
+        t = transition(_IDLE_NONE, _ev(OverrideGraceFsmEventKind.FAN_OVERRIDE_DETECTED, confirm_seconds=600.0))
+        assert t.to_state == _IDLE_PROTECTING
+        assert t.outcome == "fan_override_immediate"
+        assert t.changed
+
+    def test_from_pending_none_lands_protecting_immediately(self):
+        t = transition(_PENDING_NONE, _ev(OverrideGraceFsmEventKind.FAN_OVERRIDE_DETECTED, confirm_seconds=600.0))
+        assert t.to_state == _IDLE_PROTECTING
+        assert t.outcome == "fan_override_immediate"
+
+    def test_from_grace_protecting_stays_protecting_idempotent(self):
+        t = transition(_IDLE_PROTECTING, _ev(OverrideGraceFsmEventKind.FAN_OVERRIDE_DETECTED, confirm_seconds=600.0))
+        assert t.to_state == _IDLE_PROTECTING
+        assert t.outcome == "fan_override_immediate"
+        assert not t.changed
+
+    def test_from_grace_unprotected_lands_protecting_immediately(self):
+        t = transition(_IDLE_UNPROTECTED, _ev(OverrideGraceFsmEventKind.FAN_OVERRIDE_DETECTED, confirm_seconds=600.0))
+        assert t.to_state == _IDLE_PROTECTING
+        assert t.outcome == "fan_override_immediate"
+        assert t.changed
+
+    def test_confirm_seconds_irrelevant_never_lands_pending(self):
+        """Regression guard: unlike OVERRIDE_DETECTED, a nonzero confirm_seconds
+        must never produce a PENDING landing state for the fan path."""
+        t = transition(_IDLE_NONE, _ev(OverrideGraceFsmEventKind.FAN_OVERRIDE_DETECTED, confirm_seconds=9999.0))
+        assert t.to_state[0] == OverrideConfirmState.IDLE
+
+    def test_thermostat_override_detected_unaffected_still_confirm_delayed(self):
+        """Regression guard: the fix must not change OVERRIDE_DETECTED's own
+        real confirm-delay behavior on the thermostat path."""
+        t = transition(_IDLE_NONE, _ev(OverrideGraceFsmEventKind.OVERRIDE_DETECTED, confirm_seconds=600.0))
+        assert t.to_state == _PENDING_NONE
+        assert t.outcome == "detected"

--- a/tests/test_override_grace_fsm_shadow_wiring.py
+++ b/tests/test_override_grace_fsm_shadow_wiring.py
@@ -74,6 +74,17 @@ class TestFsmEvaluationScoping:
         _run(coordinator._mirror_to_shadow("resume_from_pause"))
         assert called == [OverrideGraceFsmEventKind.DASHBOARD_RESUME]
 
+    def test_triggered_by_handle_fan_manual_override(self) -> None:
+        """Issue #661: handle_fan_manual_override() must resolve to the dedicated
+        FAN_OVERRIDE_DETECTED kind, not the thermostat path's OVERRIDE_DETECTED."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        called: list[OverrideGraceFsmEventKind] = []
+        coordinator._evaluate_override_grace_fsm = lambda event_kind: called.append(event_kind)  # type: ignore[method-assign]
+
+        _noop_shadow_methods(coordinator, "handle_fan_manual_override")
+        _run(coordinator._mirror_to_shadow("handle_fan_manual_override", fan_before="auto", fan_after="on"))
+        assert called == [OverrideGraceFsmEventKind.FAN_OVERRIDE_DETECTED]
+
 
 class TestFsmStateTracking:
     def test_starts_idle_none(self) -> None:
@@ -98,6 +109,21 @@ class TestFsmStateTracking:
         _run(coordinator._mirror_to_shadow("handle_manual_override_during_pause"))
 
         assert coordinator._override_grace_fsm_state == (OverrideConfirmState.PENDING, GraceState.NONE)
+
+    def test_fan_manual_override_lands_protecting_regardless_of_confirm_period(self) -> None:
+        """Issue #661: this is the exact live disagreement — a nonzero confirm
+        period previously landed the FSM on (PENDING, NONE) for a fan override,
+        when handle_fan_manual_override() never uses confirm-delay at all."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.config[CONF_OVERRIDE_CONFIRM_PERIOD] = 600
+
+        _noop_shadow_methods(coordinator, "handle_fan_manual_override")
+        _run(coordinator._mirror_to_shadow("handle_fan_manual_override", fan_before="auto", fan_after="on"))
+
+        assert coordinator._override_grace_fsm_state == (
+            OverrideConfirmState.IDLE,
+            GraceState.ACTIVE_PROTECTING_OVERRIDE,
+        )
 
     def test_manual_override_during_pause_confirm_disabled_lands_protecting(self) -> None:
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
@@ -170,6 +196,28 @@ class TestDiagnosticIntegration:
         assert diag is not None
         assert diag["override_grace_mirror_agrees"] is False
         assert diag["agrees"] is False
+
+    def test_fan_manual_override_no_longer_disagrees(self) -> None:
+        """Issue #661: closes the exact live disagreement observed 2026-08-16
+        (production=idle/active_protecting_override, fsm=pending/none) triggered
+        by a QuietCool RF remote timer press. Runs the real production
+        handle_fan_manual_override() call (as coordinator.py's real
+        _async_fan_entity_changed/_flush_fan_remote_burst call sites do,
+        production call immediately followed by the mirror), then asserts the
+        FSM's own tracked state now matches production and the diagnostic
+        reports agreement."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.config[CONF_OVERRIDE_CONFIRM_PERIOD] = 600
+
+        coordinator.automation_engine.handle_fan_manual_override(fan_before="auto", fan_after="on")
+        _noop_shadow_methods(coordinator, "handle_fan_manual_override")
+        _run(coordinator._mirror_to_shadow("handle_fan_manual_override", fan_before="auto", fan_after="on"))
+
+        diag = coordinator.shadow_engine_diagnostic
+        assert diag is not None
+        assert diag["override_grace_production_state"] == "idle/active_protecting_override"
+        assert diag["override_grace_fsm_state"] == "idle/active_protecting_override"
+        assert diag["override_grace_fsm_agrees"] is True
 
     def test_disagreement_logs_distinct_warning(self, caplog) -> None:
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()

--- a/tests/test_shadow_engine_coverage.py
+++ b/tests/test_shadow_engine_coverage.py
@@ -258,6 +258,12 @@ class TestShadowEngineCoverageRegistry:
 # production trigger today (documented, not silently missing).
 _OVERRIDE_GRACE_EVENT_KIND_REGISTRY: dict[str, str] = {
     "OVERRIDE_DETECTED": "reachable",
+    # Issue #661: split from OVERRIDE_DETECTED — handle_fan_manual_override() never
+    # routes through start_override_confirmation()'s confirm-delay machinery the way
+    # the thermostat-override call sites (handle_manual_override(),
+    # handle_manual_override_during_pause()) genuinely do, so it needed its own kind
+    # rather than sharing OVERRIDE_DETECTED's confirm-delay landing logic.
+    "FAN_OVERRIDE_DETECTED": "reachable",
     "MANUAL_OVERRIDE_DURING_PAUSE": "reachable",
     "DASHBOARD_RESUME": "reachable",
     "OVERRIDE_CONFIRM_EXPIRED": "reachable",

--- a/tests/test_shadow_engine_sensor.py
+++ b/tests/test_shadow_engine_sensor.py
@@ -117,6 +117,39 @@ class TestExtraStateAttributes:
         assert attrs["door_window_production_state"] is None
         assert attrs["door_window_fsm_agrees"] is None
 
+    def test_reports_override_grace_fields_when_present(self) -> None:
+        """Issue #661: override/grace's own production/shadow/FSM state fields were
+        already computed in coordinator.shadow_engine_diagnostic but never exposed
+        on this sensor -- the same observability gap #660 fixed for door/window,
+        closed here for override/grace."""
+        sensor = _make_sensor(
+            {
+                "production_state": "active",
+                "shadow_state": "active",
+                "agrees": True,
+                "checked_at": "t",
+                "override_grace_production_state": "idle/active_protecting_override",
+                "override_grace_shadow_state": "idle/active_protecting_override",
+                "override_grace_fsm_state": "idle/active_protecting_override",
+                "override_grace_mirror_agrees": True,
+                "override_grace_fsm_agrees": True,
+            }
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["override_grace_production_state"] == "idle/active_protecting_override"
+        assert attrs["override_grace_shadow_state"] == "idle/active_protecting_override"
+        assert attrs["override_grace_fsm_state"] == "idle/active_protecting_override"
+        assert attrs["override_grace_mirror_agrees"] is True
+        assert attrs["override_grace_fsm_agrees"] is True
+
+    def test_override_grace_fields_absent_before_first_evaluation(self) -> None:
+        sensor = _make_sensor(
+            {"production_state": "active", "shadow_state": "idle", "agrees": False, "checked_at": "t"}
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["override_grace_production_state"] is None
+        assert attrs["override_grace_fsm_agrees"] is None
+
 
 class TestEntityCategory:
     def test_is_diagnostic(self) -> None:


### PR DESCRIPTION
## Summary

- Fixes the live disagreement observed 2026-08-16 (`production=idle/active_protecting_override`, `fsm=pending/none`) triggered by a QuietCool RF remote timer press.
- `handle_fan_manual_override()` was mapped to the same `OVERRIDE_DETECTED` event kind as the two genuinely confirm-delay-eligible thermostat-override call sites (`handle_manual_override()`, `handle_manual_override_during_pause()`). Production's fan path never calls `start_override_confirmation()`/`decide_override_confirm()` at all — it sets `_fan_override_active` and starts a protecting grace directly and unconditionally, every time. Sharing the event kind made the FSM model a `PENDING` confirmation that production never creates.
- Adds a dedicated `FAN_OVERRIDE_DETECTED` event kind, short-circuited at the top of `transition()` before any state-based dispatch, landing immediately on `(IDLE, ACTIVE_PROTECTING_OVERRIDE)` — keeps `_land_after_detection()`'s thermostat-only confirm-delay logic completely untouched by the fan path's different contract.
- Exposes override/grace's shadow-diagnostic fields (`override_grace_production_state`/`shadow_state`/`fsm_state`/`*_agrees`) on the Shadow Engine Status sensor — previously computed but never surfaced, the same observability gap #660 fixed for door/window.

**No production-behavior risk**: override/grace has no authoritative switch (confirmed via exhaustive grep of `switch.py`/`coordinator.py`/`automation.py`) — this diagnostic FSM never drives real decisions, unlike nat-vent/door-window's authoritative switches. This is a pure diagnostic-accuracy fix.

## Test plan

- [x] TDD red/green via `git stash` isolation, confirmed the new tests fail without the fix and pass with it (including the shadow-wiring integration test, which reproduces the exact live log line: `Override/grace FSM disagreement (Issue #639): production=idle/active_protecting_override fsm=pending/none`)
- [x] Unit tests in `tests/test_override_grace_fsm.py` (`TestFanOverrideDetected`): all 3 origin states land on `(IDLE, ACTIVE_PROTECTING_OVERRIDE)`, confirm_seconds is irrelevant, regression guard that the thermostat `OVERRIDE_DETECTED` path is unaffected
- [x] Shadow-feed integration tests in `tests/test_override_grace_fsm_shadow_wiring.py`: dispatch routing, FSM state tracking, and a diagnostic-agreement test that runs the real production `handle_fan_manual_override()` call and confirms `override_grace_fsm_agrees is True`
- [x] Sensor tests in `tests/test_shadow_engine_sensor.py` for the newly exposed fields
- [x] `tests/test_shadow_engine_coverage.py`'s registry caught the new unregistered event kind as designed; classified `FAN_OVERRIDE_DETECTED` as `"reachable"`
- [x] `ruff check`/`ruff format` clean
- [x] `test_version_sync.py` passes (0.6.28)
- [x] Full suite: 4761 passed, 6 skipped, 0 failed
- [x] Golden scenarios: 81/81 passed (confirms no golden scenario references override/grace FSM state)
- [x] Pending scenarios: 7/7 passed