### PR TITLE
Fix #666: test harness silently broke event-driven shadow-FSM feed coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.30] — 2026-08-17
+
+- Fix #666: no user-visible change. The coordinator test harness silently dropped the shadow-diagnostic FSM feed for every nat-vent/door-window exit event — a test-infrastructure bug, not a production one (real HVAC pause behavior was always correct). Fixed the harness wiring, closed a matching coverage gap where one specific nat-vent exit reason never emitted its Activity Report event at all, and added a regression test proven load-bearing against a real revert.
+
 ## [0.6.29] — 2026-08-17
 
 - Feat #664: the override/grace lifecycle FSM (whole-house-fan and thermostat manual overrides, and the grace period that protects them from being undone) can now optionally drive real production decisions instead of only observing them — a new, off-by-default, non-persisted switch, matching the same pattern nat-vent and door/window already have. Unlike door/window's staged rollout, this ships full authority for all 8 real trigger sites at once, since investigation proved the FSM and the existing logic always compute identical results, confirmed across the full scenario library with the switch turned on. Also fixes a config edge case found during this work: a manual grace period disabled via configuration (0 seconds) could have been reported as active with no way to ever clear it, had the switch been turned on before this fix. The switch defaults off — no occupant-visible behavior change from this release alone.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -3807,9 +3807,23 @@ class AutomationEngine:
                     # above — the reactivation gate's own ceiling_ok = outdoor < threshold
                     # check is the exact complementary boundary, so outdoor hovering near
                     # threshold can flip-flop this exit against reactivation identically.
+                    # Issue #666: event_type was missing here — every sibling exit branch in
+                    # this function (OUTDOOR_RISE above, PROACTIVE_FLOOR before it) and
+                    # fan_thermostat_check()'s own equivalent outdoor-exit branch all pass
+                    # "nat_vent_outdoor_rise_exit" (added project-wide by Issue #649, add1b8f
+                    # — this call site was the one sibling it missed). Without it, neither
+                    # _NAT_VENT_FSM_EVENT_TYPES nor _DOOR_WINDOW_NAT_VENT_EXIT_EVENT_TYPES
+                    # ever gets fed for a CEILING_THRESHOLD exit, leaving both shadow FSMs
+                    # silently stuck whenever nat-vent exits this specific way.
                     await self._exit_nat_vent(
                         reason=f"natural vent exit: outdoor {outdoor:.1f}°F > threshold {threshold:.1f}°F",
                         set_outdoor_exit_time=True,
+                        event_type="nat_vent_outdoor_rise_exit",
+                        event_payload={
+                            "outdoor": outdoor,
+                            "indoor": indoor,
+                            "fan_device": _fan_device_label(self.config),
+                        },
                     )
                     return
 

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.29"
+VERSION = "0.6.30"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.30": [
+        "Fix #666: no user-visible change. The coordinator test harness silently"
+        " dropped the shadow-diagnostic FSM feed for every nat-vent/door-window exit"
+        " event (a test-infrastructure bug, not a production one — real HVAC pause"
+        " behavior was always correct). Fixed the harness wiring, closed a matching"
+        " coverage gap where a specific nat-vent exit reason never emitted its"
+        " Activity Report event at all, and added a regression test that reproduces"
+        " the exact live disagreement pattern seen in production logs.",
+    ],
     "0.6.29": [
         "Feat #664: the override/grace lifecycle FSM (whole-house-fan and thermostat"
         " manual overrides, and the grace period that protects them from being"
@@ -1915,6 +1924,38 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    666: {
+        "version_fixed": "0.6.30",
+        "title": "Test harness silently broke event-driven shadow-FSM feed coverage (3rd occurrence of #613/#647)",
+        "scope_covered": (
+            "tools/sim_harness/build_coordinator.py: fixed build_headless_coordinator()"
+            " pointing automation_engine._emit_event_callback at a bare local"
+            " event_log-appending function instead of the real coordinator._emit_event()"
+            " — the only place _feed_lifecycle_fsms_from_event() is called in production."
+            " This silently defeated event-driven FSM-feed coverage (nat-vent, door/window,"
+            " override/grace) for every coordinator-level Tier A test, including"
+            " test_shadow_engine_live.py, which is why #647 (merged the day before this"
+            " investigation, explicitly about this bug class) could ship green and still"
+            " leave live production logging chronic 'Nat-vent FSM disagreement (#633)'/"
+            " 'Door/window FSM disagreement (#637)' WARNINGs (traced live to 2026-08-15"
+            " 06:30:43, occupant impact: none — production's own HVAC pause/nat-vent state"
+            " was always correct; this is shadow-diagnostic-only). Fix: wrap the real"
+            " coordinator._emit_event once and point the engine callback at the wrapped"
+            " version, mirroring production's own wiring exactly, so the flat scenario"
+            " event_log and the real FSM-feed side effect both fire from one call."
+            " automation.py: also fixed a real, independently-confirmed sibling gap found"
+            " during the investigation — check_natural_vent_conditions()'s"
+            " NatVentExitReason.CEILING_THRESHOLD exit branch called _exit_nat_vent()"
+            " without an event_type= kwarg (missed by #649's project-wide rollout,"
+            " add1b8f), silently starving both shadow FSMs whenever nat-vent exits that"
+            " specific way. New tests/test_shadow_fsm_harness_event_coverage.py replays the"
+            " real incident sequence (sensor open before any fresh-open event, nat-vent"
+            " hard-floor exit) against the real coordinator and proves both the fix works"
+            " and — via a positive control reproducing the harness bug — that the test is"
+            " actually load-bearing, confirmed via an explicit revert test (git-stashing"
+            " the harness fix reproduces the exact live disagreement; restoring it passes)."
+        ),
+    },
     660: {
         "version_fixed": "0.6.27",
         "title": "Door/window FSM: full authority for all 8 real trigger sites (completes #637)",

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.29"
+  "version": "0.6.30"
 }

--- a/tests/test_shadow_fsm_harness_event_coverage.py
+++ b/tests/test_shadow_fsm_harness_event_coverage.py
@@ -1,0 +1,153 @@
+"""Regression test for Issue #666: coordinator test harness silently dropped
+event-driven shadow-FSM feed for every engine-originated event.
+
+Live incident: ``Nat-vent FSM disagreement (Issue #633)`` and
+``Door/window FSM disagreement (Issue #637)`` warnings fired continuously in
+production starting 2026-08-15 06:30:43, surviving multiple restarts, with zero
+occupant impact (production's real pause/nat-vent state was always correct — this
+is a shadow-diagnostic-only bug). Root cause investigation found the true first
+trigger: ``nat_vent_temperature_check()``'s hard-floor exit path, called while a
+monitored sensor was open.
+
+Investigation proved two separate things, both covered here:
+
+1. ``door_window_fsm.py``'s pure transition logic is correct for this exact
+   transition (``NAT_VENT_EXITED_SENSOR_STILL_OPEN`` from ``NORMAL`` -> ``PAUSED_IDLE``
+   given real-world inputs) — already covered by ``tests/test_door_window_fsm.py``'s
+   unit-level table, not re-proven here.
+2. ``tools/sim_harness/build_coordinator.py`` itself broke the ability to test the
+   *dispatch* path: it pointed ``automation_engine._emit_event_callback`` at a bare
+   local function instead of the real ``coordinator._emit_event`` (the only place
+   ``_feed_lifecycle_fsms_from_event()`` — and therefore every event-type-keyed FSM
+   evaluator — is invoked in production). Every coordinator-level Tier A test,
+   including ``test_shadow_engine_live.py``, was silently unable to exercise this
+   path. This is why Issue #647 (merged the day before this incident, explicitly
+   about closing this exact coverage gap) could ship green and still leave the bug
+   class unresolved.
+
+This test replays the real incident sequence through the REAL, now-fixed harness
+wiring and asserts the shadow FSM actually reaches the same lifecycle state
+production's own live flags derive — the assertion #647's own test suite could
+never have made honestly before the harness fix.
+"""
+
+from __future__ import annotations
+
+from tools.sim_harness._loop import run_coro
+from tools.sim_harness.build_coordinator import build_headless_coordinator
+from tools.sim_harness.ha_stubs import install_ha_stubs
+
+install_ha_stubs()
+
+from custom_components.climate_advisor.door_window_lifecycle import (  # noqa: E402
+    DoorWindowLifecycleInputs,
+    DoorWindowLifecycleState,
+    derive_door_window_lifecycle_state,
+)
+
+
+def _build_incident_coordinator():
+    """Reconstructs the live 2026-08-15 06:30:43 incident's starting conditions:
+    a monitored sensor open, an active nat-vent session, HVAC mode off, indoor
+    temperature at the comfort-heat hard floor."""
+    config = {
+        "door_window_sensors": ["binary_sensor.front_door"],
+        "comfort_heat": 68.0,
+        "comfort_cool": 76.0,
+        "fan_mode": "whole_house_fan",
+    }
+    coordinator, fake_hass, scheduler, event_log = build_headless_coordinator(
+        config=config,
+        climate_state="off",
+        skip_startup_coalesce=True,
+    )
+    ae = coordinator.automation_engine
+
+    # Silent seed (set_simple, not async_set): models a sensor that was ALREADY
+    # open before this coordinator instance started — no fresh "door opened"
+    # state-change event ever fires, so door_window_fsm never receives a
+    # SENSOR_OPENED event. This is the real incident's actual shape (matches
+    # _sync_paused_by_door_with_live_sensors()'s own documented "sensor open
+    # since before any event-driven path ever ran" class of gap, Issue #620) —
+    # using async_set() here would dispatch a real listener and pause the
+    # coordinator via the SENSOR_OPENED path before nat-vent's own exit event
+    # is ever reached, which is a different (already-covered) scenario.
+    fake_hass.states.set_simple("binary_sensor.front_door", "on")
+
+    coordinator._resolved_sensors = ["binary_sensor.front_door"]
+    ae._natural_vent_active = True
+    ae._nat_vent_soft_start = False
+    ae._pre_fan_hvac_mode = "off"
+    ae._fan_active = True
+
+    return coordinator, fake_hass, scheduler, event_log, ae
+
+
+class TestHardFloorExitWithSensorOpen:
+    """Replays nat_vent_temperature_check()'s real hard-floor exit path — the
+    exact trigger identified as the live incident's origin."""
+
+    def test_door_window_fsm_reaches_paused_idle(self) -> None:
+        coordinator, _fake_hass, scheduler, _event_log, ae = _build_incident_coordinator()
+
+        assert coordinator._door_window_fsm_state == DoorWindowLifecycleState.NORMAL
+
+        with scheduler.installed():
+            run_coro(ae.nat_vent_temperature_check(67.0, outdoor=58.5))
+
+        production_state = derive_door_window_lifecycle_state(
+            DoorWindowLifecycleInputs(
+                paused_by_door=bool(ae._paused_by_door),
+                paused_with_hvac_already_off=bool(ae._paused_with_hvac_already_off),
+                grace_active=bool(ae._grace_active),
+            )
+        )
+        assert ae._paused_by_door is True, "production's own pause flag must be set — sanity check"
+        assert production_state == DoorWindowLifecycleState.PAUSED_IDLE
+        assert coordinator._door_window_fsm_state == production_state, (
+            f"shadow door/window FSM ({coordinator._door_window_fsm_state}) disagreed with "
+            f"production's real derived state ({production_state}) after a hard-floor nat-vent "
+            "exit with the sensor open — this is the exact live incident (Issue #666)"
+        )
+
+    def test_nat_vent_fsm_reaches_inactive(self) -> None:
+        coordinator, _fake_hass, scheduler, _event_log, ae = _build_incident_coordinator()
+
+        with scheduler.installed():
+            run_coro(ae.nat_vent_temperature_check(67.0, outdoor=58.5))
+
+        assert ae._natural_vent_active is False
+        assert coordinator._nat_vent_fsm_state.value == "inactive", (
+            f"shadow nat-vent FSM ({coordinator._nat_vent_fsm_state}) disagreed with production's "
+            "real _natural_vent_active=False after a hard-floor exit — matches the live "
+            "'Nat-vent FSM disagreement (Issue #633)' warning"
+        )
+
+
+class TestHarnessEventFeedPositiveControl:
+    """Proves the regression test above is load-bearing: reintroducing the exact
+    harness bug found in Issue #666 must make it fail. Without this, a future
+    accidental reintroduction of the same bug would pass silently — the same trap
+    that let this bug ship unnoticed through Issue #647."""
+
+    def test_bypassing_coordinator_emit_event_reproduces_the_bug(self) -> None:
+        coordinator, _fake_hass, scheduler, _event_log, ae = _build_incident_coordinator()
+
+        # Reintroduce the Issue #666 bug: point the engine callback at a bare
+        # function that never reaches coordinator._emit_event(), exactly as
+        # build_coordinator.py did before the fix.
+        captured: list[tuple[str, dict]] = []
+        ae._emit_event_callback = lambda event_type, data: captured.append((event_type, data))
+
+        with scheduler.installed():
+            run_coro(ae.nat_vent_temperature_check(67.0, outdoor=58.5))
+
+        assert ae._paused_by_door is True, "production's own flag is unaffected by the callback bug"
+        assert coordinator._door_window_fsm_state == DoorWindowLifecycleState.NORMAL, (
+            "positive control FAILED: bypassing coordinator._emit_event() should reproduce the "
+            "live bug (shadow FSM stuck at NORMAL) — if this assertion fails, the harness fix "
+            "test above is not actually exercising the code path it claims to"
+        )
+        assert any(evt[0] == "nat_vent_comfort_floor_exit" for evt in captured), (
+            "sanity check: the event really was emitted, just not routed to the FSM feed"
+        )

--- a/tools/sim_harness/build_coordinator.py
+++ b/tools/sim_harness/build_coordinator.py
@@ -180,29 +180,33 @@ def build_headless_coordinator(
     #    — only hass.config.config_dir, set above.
     coordinator = ClimateAdvisorCoordinator(fake_hass, merged_config)
 
-    # Wire the event log the same way build_headless_engine does — the
-    # coordinator already wires its own callbacks onto automation_engine in
-    # __init__, so overriding _emit_event_callback here replaces the
-    # coordinator's own (which forwards to self._event_log, a ring buffer we
-    # don't need for scenario assertions) with the flat scenario event_log.
-    coordinator.automation_engine._emit_event_callback = _emit_event
-
-    # 7b. Issue #481: coordinator-originated events (e.g. _emit_incident()'s
-    #     incident_detected, occupancy_transition/rapid_override_after_automation from
-    #     _detect_and_emit_incidents()) call self._emit_event() DIRECTLY — a bound
-    #     coordinator method, not routed through automation_engine._emit_event_callback
-    #     (that wiring only covers events the ENGINE emits). In real production both
-    #     paths funnel into the same self._event_log ring buffer (coordinator.py:280 wires
-    #     automation_engine._emit_event_callback = self._emit_event, so it's genuinely one
-    #     buffer there) — but here, step 7 above already redirected the engine's callback
-    #     to the flat scenario event_log directly, bypassing coordinator._emit_event
-    #     entirely for engine events. That left coordinator-originated events writing ONLY
-    #     to the internal self._event_log ring buffer, invisible to any scenario assertion
-    #     reading ProductionRunResult.event_log. Wrap coordinator._emit_event so it ALSO
-    #     feeds the flat list — purely additive (adds visibility for a class of real
-    #     production events the harness previously dropped silently); it does not change
-    #     what any existing event type is captured as, so it cannot make an existing
-    #     regression pass silently (CLAUDE.md §8).
+    # 7b. Issue #481 / Issue #666: coordinator-originated events (e.g.
+    #     _emit_incident()'s incident_detected, occupancy_transition/
+    #     rapid_override_after_automation from _detect_and_emit_incidents()) call
+    #     self._emit_event() DIRECTLY — a bound coordinator method — while
+    #     engine-originated events reach the identical coordinator._emit_event()
+    #     only via automation_engine._emit_event_callback. In real production both
+    #     paths funnel into the same method (coordinator.py wires
+    #     automation_engine._emit_event_callback = self._emit_event), which is also
+    #     the ONLY place _feed_lifecycle_fsms_from_event() is called — the real
+    #     side effect that feeds the nat-vent/door-window/override-grace shadow
+    #     FSMs their event-driven transitions.
+    #
+    #     Issue #666: this used to point automation_engine._emit_event_callback at
+    #     a bare local function that only appended to the flat scenario event_log,
+    #     bypassing coordinator._emit_event (and therefore
+    #     _feed_lifecycle_fsms_from_event()) entirely for every engine-originated
+    #     event. The accompanying comment claimed this was "purely additive" and
+    #     "does not change what any existing event type is captured as" — false:
+    #     it silently dropped the FSM-feed side effect for the whole coordinator-
+    #     level Tier A suite, which is exactly why #647 (a real fix to this event-
+    #     feed wiring) could ship with green tests and still leave the live bug
+    #     class (#613/#633/#637/#647) unresolved — no test in this harness could
+    #     ever have caught a regression there. Fix: wrap the REAL
+    #     coordinator._emit_event once, point automation_engine._emit_event_callback
+    #     at the wrapped version (mirroring production's own wiring exactly), and
+    #     have the wrapper append to the flat event_log as an additional step, not
+    #     a replacement one.
     _coordinator_emit_event = coordinator._emit_event
 
     def _emit_event_and_capture(event_type: str, data: dict) -> None:
@@ -210,6 +214,7 @@ def build_headless_coordinator(
         _emit_event(event_type, data)
 
     coordinator._emit_event = _emit_event_and_capture
+    coordinator.automation_engine._emit_event_callback = _emit_event_and_capture
 
     # 8. Replicate __init__.py's exact startup sequence (__init__.py:396-405):
     #      coordinator = ClimateAdvisorCoordinator(hass, dict(entry.data))


### PR DESCRIPTION
## Summary

- Live logs show \`Nat-vent FSM disagreement (#633)\`/\`Door/window FSM disagreement (#637)\` warnings firing continuously since at least 2026-08-15 06:30:43, surviving multiple restarts. Occupant impact: **none** — production's real HVAC pause/nat-vent state was correct throughout, confirmed via REST-history status and coordinator debug logs. This is shadow-diagnostic-only, but it's the 3rd occurrence of this bug class (#613 → #647 → this).
- Root cause: \`tools/sim_harness/build_coordinator.py\` pointed \`automation_engine._emit_event_callback\` at a bare local function instead of the real \`coordinator._emit_event()\` — the only place \`_feed_lifecycle_fsms_from_event()\` runs in production. This silently defeated event-driven FSM-feed coverage for the entire coordinator-level Tier A suite (including \`test_shadow_engine_live.py\`), which is why #647 — merged the day before this incident, explicitly about closing this exact gap — could ship green and still leave the live bug unresolved.
- Also fixes a real, independently-confirmed sibling gap: \`check_natural_vent_conditions()\`'s \`CEILING_THRESHOLD\` exit branch never passed \`event_type=\` to \`_exit_nat_vent()\`, unlike every sibling exit branch (added project-wide by #649, missed here).

## Investigation

Five-whys, evidence-first (full notes in the session's plan file):
1. Ruled out production being wrong.
2. Ruled out a logic bug in \`door_window_fsm.py\`'s pure transition functions — direct unit testing with real input values proved the pure logic correct.
3. Reproduced the live symptom via the real Tier-A harness, and in investigating *why*, found the harness itself was the actual defect — restoring real wiring and replaying the identical scenario, the FSM correctly reached \`PAUSED_IDLE\`, matching production.

## Test plan

- [x] Full test suite (4861 passed, 6 skipped) with \`-W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning\`
- [x] New \`tests/test_shadow_fsm_harness_event_coverage.py\`: replays the real incident sequence, includes a positive control (bypassing the callback reproduces the bug) and an explicit revert test (stashing the harness fix reproduces the exact live disagreement; restoring it passes)
- [x] \`ruff check\` / \`ruff format\` clean
- [x] \`tools/simulate.py\`: 81/81 golden + 7/7 pending scenarios pass, \`--check-integrity\` clean
- [x] \`test_version_sync.py\` passes (0.6.30)