### PR TITLE
Fix #677: read live RF-remote-timer state at restart to prevent spurious 3h lockout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.36] — 2026-08-19
+
+- Fix #677: after a restart that lands in the middle of an active QuietCool RF remote timer, Climate Advisor now reads the remote's own live state to recognize the timer is still running and re-arms the correct remaining time, instead of forgetting about it. Previously, when the physical timer later shut the fan off naturally, CA misread it as a fresh manual power-off and started a fresh 3-hour lockout — blocking free cooling for hours even with ideal outdoor air.
+
 ## [0.6.35] — 2026-08-18
 
 - Fix #676: no user-visible change. Closes a second, separate shadow-diagnostic gap found immediately after #672/#673 shipped: when a grace period expired with a door/window sensor still open and free-cooling conditions happened to be favorable, natural ventilation correctly resumed and the pause was correctly cleared, but the shadow diagnostic engine was never told about it and could show a stuck false "disagreement" for 20+ minutes. Real HVAC/fan behavior was always correct throughout; only the diagnostic mirror could drift.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -4399,6 +4399,7 @@ class AutomationEngine:
         any_sensor_open: bool,
         trigger: str = "startup",
         recent_hvac_session_ended: bool = False,
+        remote_timer_provenance: tuple[float, float] | None = None,
     ) -> None:
         """Reconcile fan state on HA startup / coalesce window (Issue #327).
 
@@ -4447,6 +4448,13 @@ class AutomationEngine:
                                     since a legitimate active/just-finished cooling or heating
                                     session must never be interrupted by this reconcile
                                     (Issue #618).
+            remote_timer_provenance: ``(remaining_seconds, token_hours)`` from the coordinator's
+                                    live read of the RF remote entity's still-unexpired
+                                    re-announced timer token (Issue #677), or None. Pre-filtered
+                                    to "still valid" by the caller — this method does not
+                                    re-check expiry. None (the default, and the case for every
+                                    pre-#677 caller) leaves this method's behavior byte-for-byte
+                                    identical to before Issue #677.
         """
         # Issue #561: reentrancy guard — this method is called from 4 independent sites
         # with no coordination between them. Two overlapping calls previously each
@@ -4468,6 +4476,7 @@ class AutomationEngine:
                 any_sensor_open=any_sensor_open,
                 trigger=trigger,
                 recent_hvac_session_ended=recent_hvac_session_ended,
+                remote_timer_provenance=remote_timer_provenance,
             )
         finally:
             self._reconcile_fan_in_progress = False
@@ -4481,10 +4490,42 @@ class AutomationEngine:
         any_sensor_open: bool,
         trigger: str,
         recent_hvac_session_ended: bool = False,
+        remote_timer_provenance: tuple[float, float] | None = None,
     ) -> None:
         """Body of reconcile_fan_on_startup(), run under its reentrancy guard (Issue #561)."""
         fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
         archetype = fan_mode
+
+        # Issue #677: a live-re-announced, still-unexpired RF remote timer takes priority
+        # over the adopt-on/turn-off nat-vent logic below. Without this, the natural
+        # hardware shutoff hours later is read as a fresh, unexplained manual action by
+        # on_fan_turned_off() (a brand-new 3-hour "manual" grace, blocking nat-vent
+        # reactivation despite favorable outdoor air) — this restores the SAME grace CA
+        # would have already been honoring had the restart not wiped its in-memory
+        # bookkeeping, sized to the timer's remaining duration. Only acts when the fan is
+        # still physically running; if it already read off, provenance is provided but
+        # deliberately ignored here — falls through to the unchanged turn-off/no-op path.
+        # When remote_timer_provenance is None (every pre-#677 caller, and every restart
+        # with no live remote timer token), this branch is skipped entirely and the rest of
+        # this method is byte-for-byte unchanged from before Issue #677.
+        if remote_timer_provenance is not None and thermostat_fan_running:
+            _remaining_seconds, _token_hours = remote_timer_provenance
+            _LOGGER.info(
+                "Fan reconcile: live RF remote timer still valid at restart (%sh token,"
+                " %.0fs remaining) and fan is still running — re-arming manual override"
+                " instead of treating this as an unexplained fan state (archetype=%s)",
+                _token_hours,
+                _remaining_seconds,
+                archetype,
+            )
+            self.handle_fan_manual_override(
+                fan_before="on",
+                fan_after="on",
+                duration_override=_remaining_seconds,
+                remote_timer_hours=_token_hours,
+                is_remote_event=True,
+            )
+            return
 
         if not thermostat_fan_running:
             # Fan is off — ensure CA flags are clean (defence in depth), and release any

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.35"
+VERSION = "0.6.36"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.36": [
+        "Fix #677: after a restart that lands in the middle of an active QuietCool RF"
+        " remote timer, Climate Advisor now reads the remote's own live state to"
+        " recognize the timer is still running and re-arms the correct remaining"
+        " time, instead of forgetting about it. Previously, when the physical timer"
+        " later shut the fan off naturally, CA misread it as a fresh manual power-off"
+        " and started a fresh 3-hour lockout — blocking free cooling for hours even"
+        " with ideal outdoor air.",
+    ],
     "0.6.35": [
         "Fix #676: no user-visible change. Closes a second, separate shadow-diagnostic"
         " gap found immediately after #672/#673 shipped: when a grace period expired"
@@ -1973,6 +1982,32 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    677: {
+        "version_fixed": "0.6.36",
+        "title": (
+            "Restart mid-RF-timer wiped CA's memory of an active QuietCool remote"
+            " timer session, causing a spurious 3-hour manual grace lockout when the"
+            " hardware timer naturally elapsed hours later"
+        ),
+        "scope_covered": (
+            "coordinator.py: new _read_live_remote_timer_provenance(), called from"
+            " _do_startup_coalesce() before reconcile_fan_on_startup(). Reads the"
+            " configured fan_remote_entity's live HA state (which re-announces its"
+            " last retained event_type after a restart), parses the timer token +"
+            " press timestamp via the existing fan_status.parse_remote_timer_event(),"
+            " and computes the token's own natural expiry — no new persisted CA state."
+            " automation.py: reconcile_fan_on_startup()/_reconcile_fan_on_startup_locked()"
+            " gained a new optional remote_timer_provenance parameter; when present and"
+            " unexpired and the fan is still physically running, calls the existing"
+            " handle_fan_manual_override(duration_override=remaining_seconds,"
+            " is_remote_event=True, remote_timer_hours=token_hours) to re-arm a grace"
+            " period sized to the timer's actual remaining time. When provenance is"
+            " None (the common case — no active timer, unconfigured, or already"
+            " expired), behavior is byte-for-byte unchanged. The existing"
+            " _timer_boundary_settle_until mechanism (Issue #530) then arms naturally"
+            " when the re-armed grace expires, exactly as it would with no restart."
+        ),
+    },
     676: {
         "version_fixed": "0.6.35",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -2670,6 +2670,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             fan_mode_attr=_fan_mode_reconcile,
             hvac_action_attr=_hvac_action_reconcile,
         )
+        # Issue #677: live read (not persisted state) of whatever timer token the RF remote
+        # entity is still re-announcing at restart — lets reconcile re-arm the remaining
+        # grace instead of misreading the eventual natural hardware shutoff as a fresh
+        # manual action hours later. See _read_live_remote_timer_provenance()'s docstring.
+        _remote_timer_provenance = self._read_live_remote_timer_provenance()
         _LOGGER.debug("[coalesce-diag] before reconcile_fan_on_startup()")
         await self.automation_engine.reconcile_fan_on_startup(
             indoor=indoor,
@@ -2677,6 +2682,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             thermostat_fan_running=_thermostat_fan_running,
             any_sensor_open=self._any_sensor_open(),
             trigger="ha_restart",
+            remote_timer_provenance=_remote_timer_provenance,
         )
         # Issue #615: this exact call site is what tonight's bug reproduces — the
         # startup-time fan reconciliation that can set _natural_vent_active=True from
@@ -2688,6 +2694,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             thermostat_fan_running=_thermostat_fan_running,
             any_sensor_open=self._any_sensor_open(),
             trigger="ha_restart",
+            remote_timer_provenance=_remote_timer_provenance,
         )
         _LOGGER.debug("[coalesce-diag] after reconcile_fan_on_startup()")
 
@@ -5609,6 +5616,81 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         if state is None or state.state in ("unknown", "unavailable"):
             return None
         return state.state
+
+    def _read_live_remote_timer_provenance(self) -> tuple[float, float] | None:
+        """Read the QuietCool RF remote's live re-announced timer state at restart (Issue #677).
+
+        The clean-slate restart policy (#282/#327) never persists CA's own
+        ``_fan_remote_timer_hours``/``_grace_active``/``_timer_boundary_settle_until`` —
+        deliberately unchanged here, this reads nothing new into ``climate_advisor_state.json``.
+        But the ``fan_remote_entity`` (the same ``event.*`` entity ``_async_fan_remote_changed()``
+        listens to) independently re-announces its last retained ``event_type`` as the ESPHome
+        device reconnects after restart (see docs/fan-remote-spec.md § Restart Behavior, already
+        relied on by Issue #491's startup-coalescing suppression). This is a LIVE read of that
+        re-announcement — the same category of live-entity read ``_do_startup_coalesce()``
+        already performs for the thermostat mode/fan mode — not new persisted state.
+
+        Without this, when the physical hardware timer naturally shuts the fan off hours after
+        a restart wiped CA's in-memory timer bookkeeping, ``on_fan_turned_off()`` starts a fresh
+        3-hour "manual" grace period with no memory this was expected, blocking nat-vent
+        reactivation for hours despite favorable outdoor air (Issue #677).
+
+        Returns ``(remaining_seconds, token_hours)`` if a genuine, still-unexpired timer token
+        is currently retained by the entity, else ``None`` — mirrors ``_read_fan_remote_speed()``'s
+        "returns None on anything not applicable" convention. Never raises: any parse failure or
+        missing data degrades to None rather than affecting startup.
+        """
+        try:
+            remote_entity_id = self.config.get(CONF_FAN_REMOTE_ENTITY)
+            if not remote_entity_id:
+                return None
+            state = self.hass.states.get(remote_entity_id)
+            if state is None or state.state in ("unknown", "unavailable"):
+                _LOGGER.debug(
+                    "RF timer provenance: fan_remote_entity %s unavailable at startup — nothing to resume",
+                    remote_entity_id,
+                )
+                return None
+            event_type = state.attributes.get("event_type")
+            is_timer, token_hours = parse_remote_timer_event(event_type)
+            if not is_timer or token_hours is None:
+                # Not a timer token, or `timer_none` (no fixed duration to resume from) —
+                # both degrade to "nothing to resume", matching parse_remote_timer_event()'s
+                # own contract.
+                _LOGGER.debug(
+                    "RF timer provenance: event_type=%s is not a resumable timer token — nothing to resume",
+                    event_type,
+                )
+                return None
+            press_time = dt_util.parse_datetime(state.state)
+            if press_time is None:
+                _LOGGER.debug("RF timer provenance: could not parse press timestamp %r", state.state)
+                return None
+            expires_at = press_time + timedelta(hours=token_hours)
+            now = dt_util.now()
+            if now >= expires_at:
+                # The timer's own natural end already passed — this is what makes a long
+                # power outage self-resolving; no separate TTL constant needed.
+                _LOGGER.info(
+                    "RF timer provenance: %sh timer pressed at %s already expired before restart — nothing to resume",
+                    token_hours,
+                    state.state,
+                )
+                return None
+            remaining_seconds = (expires_at - now).total_seconds()
+            _LOGGER.info(
+                "RF timer provenance: live re-announced %sh timer still has %.0fs remaining at"
+                " restart — will re-arm on reconcile if fan is still physically running",
+                token_hours,
+                remaining_seconds,
+            )
+            return remaining_seconds, token_hours
+        except Exception:
+            _LOGGER.debug(
+                "RF timer provenance read failed — treating as no active timer",
+                exc_info=True,
+            )
+            return None
 
     async def _async_reassert_setpoint_after_fan_off(self) -> None:
         """Re-assert CA's intended setpoint after an ecobee fan-off echo (Issue #359 Fix A).

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.35"
+  "version": "0.6.36"
 }

--- a/tests/test_fan_remote.py
+++ b/tests/test_fan_remote.py
@@ -1057,3 +1057,247 @@ class TestFanRemoteEchoGuard:
         asyncio.run(_dispatch_and_flush(coord, _make_fake_event(new_state)))
 
         ae.handle_fan_manual_override.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 8. _read_live_remote_timer_provenance() (Issue #677)
+# ---------------------------------------------------------------------------
+
+_PATCH_COORDINATOR_PARSE_DATETIME = "custom_components.climate_advisor.coordinator.dt_util.parse_datetime"
+
+
+def _make_provenance_coord(config: dict | None = None, *, remote_state: MagicMock | None = None) -> MagicMock:
+    """Minimal coordinator stub for _read_live_remote_timer_provenance() (Issue #677).
+
+    Mirrors _make_coordinator_stub()'s minimal-stub + importlib pattern (avoids stale
+    __globals__ from test_occupancy.py's module deletion) but only needs hass.states.get
+    and self.config -- the method under test performs no other coordinator access.
+    """
+    config = config if config is not None else {CONF_FAN_REMOTE_ENTITY: "event.quietcool_remote"}
+    hass = MagicMock()
+    hass.states = MagicMock()
+    hass.states.get = MagicMock(return_value=remote_state)
+
+    coord = MagicMock()
+    coord.hass = hass
+    coord.config = config
+
+    mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+    coord._read_live_remote_timer_provenance = types.MethodType(
+        mod.ClimateAdvisorCoordinator._read_live_remote_timer_provenance, coord
+    )
+    return coord
+
+
+def _patched_dt():
+    """dt_util.now/parse_datetime are bare MagicMocks in the stub env; give them real
+    behavior anchored to _FIXED_NOW, matching the pattern test_startup_coalesce.py already
+    uses for this same stub gap."""
+    return (
+        patch(_PATCH_COORDINATOR_DT_NOW, return_value=_FIXED_NOW),
+        patch(_PATCH_COORDINATOR_PARSE_DATETIME, side_effect=lambda s: datetime.fromisoformat(s)),
+    )
+
+
+class TestReadLiveRemoteTimerProvenance:
+    """coordinator._read_live_remote_timer_provenance() (Issue #677).
+
+    Live read (not persisted state) of the RF remote entity's re-announced timer token at
+    restart -- the entity re-announces its last retained event_type as the ESPHome device
+    reconnects (docs/fan-remote-spec.md § Restart Behavior; already relied on by Issue #491's
+    startup-coalescing suppression). This lets startup reconcile re-arm the remaining grace
+    instead of misreading the timer's eventual natural hardware shutoff, hours later, as a
+    fresh unexplained manual action (Issue #677's occupant-facing bug: nat-vent locked out
+    for a fresh 3h "manual" grace despite favorable outdoor air).
+    """
+
+    def test_valid_unexpired_token_returns_remaining_seconds_and_hours(self):
+        # timer_8h pressed 1 hour before "now" -> 7 hours (25200s) remaining.
+        press_time = (_FIXED_NOW - timedelta(hours=1)).isoformat()
+        state = _make_fake_state(press_time, {"event_type": "timer_8h"})
+        coord = _make_provenance_coord(remote_state=state)
+
+        p1, p2 = _patched_dt()
+        with p1, p2:
+            result = coord._read_live_remote_timer_provenance()
+
+        assert result is not None
+        remaining_seconds, token_hours = result
+        assert token_hours == 8.0
+        assert remaining_seconds == 7 * 3600
+
+    def test_expired_token_returns_none(self):
+        # timer_2h pressed 3 hours before "now" -- the timer's own natural end already
+        # passed, which is what makes a long power outage self-resolving.
+        press_time = (_FIXED_NOW - timedelta(hours=3)).isoformat()
+        state = _make_fake_state(press_time, {"event_type": "timer_2h"})
+        coord = _make_provenance_coord(remote_state=state)
+
+        p1, p2 = _patched_dt()
+        with p1, p2:
+            result = coord._read_live_remote_timer_provenance()
+
+        assert result is None
+
+    def test_no_fan_remote_entity_configured_returns_none(self):
+        coord = _make_provenance_coord(config={})
+        result = coord._read_live_remote_timer_provenance()
+        assert result is None
+        coord.hass.states.get.assert_not_called()
+
+    def test_malformed_event_type_returns_none(self):
+        state = _make_fake_state(_FIXED_NOW.isoformat(), {"event_type": "not_a_real_token"})
+        coord = _make_provenance_coord(remote_state=state)
+
+        p1, p2 = _patched_dt()
+        with p1, p2:
+            result = coord._read_live_remote_timer_provenance()
+
+        assert result is None
+
+    def test_missing_event_type_returns_none(self):
+        state = _make_fake_state(_FIXED_NOW.isoformat(), {})
+        coord = _make_provenance_coord(remote_state=state)
+
+        p1, p2 = _patched_dt()
+        with p1, p2:
+            result = coord._read_live_remote_timer_provenance()
+
+        assert result is None
+
+    def test_timer_none_token_returns_none(self):
+        """timer_none has no fixed duration to resume from -- degrades to None just like a
+        non-timer token, matching parse_remote_timer_event()'s own (True, None) contract."""
+        state = _make_fake_state(_FIXED_NOW.isoformat(), {"event_type": "timer_none"})
+        coord = _make_provenance_coord(remote_state=state)
+
+        p1, p2 = _patched_dt()
+        with p1, p2:
+            result = coord._read_live_remote_timer_provenance()
+
+        assert result is None
+
+    def test_entity_unavailable_returns_none(self):
+        state = _make_fake_state("unavailable", {"event_type": "timer_8h"})
+        coord = _make_provenance_coord(remote_state=state)
+
+        result = coord._read_live_remote_timer_provenance()
+
+        assert result is None
+
+    def test_entity_unknown_returns_none(self):
+        state = _make_fake_state("unknown", {"event_type": "timer_8h"})
+        coord = _make_provenance_coord(remote_state=state)
+
+        result = coord._read_live_remote_timer_provenance()
+
+        assert result is None
+
+    def test_entity_missing_returns_none(self):
+        coord = _make_provenance_coord(remote_state=None)
+        result = coord._read_live_remote_timer_provenance()
+        assert result is None
+
+    def test_unparseable_timestamp_returns_none(self):
+        state = _make_fake_state("not-a-timestamp", {"event_type": "timer_8h"})
+        coord = _make_provenance_coord(remote_state=state)
+
+        p1, p2 = _patched_dt()
+        with p1, p2:
+            result = coord._read_live_remote_timer_provenance()
+
+        assert result is None
+
+    def test_never_raises_on_unexpected_exception(self):
+        """The function must degrade to None on any failure, never affect startup -- confirm
+        a state.attributes access blowing up is swallowed, not propagated."""
+        state = MagicMock()
+        state.state = _FIXED_NOW.isoformat()
+        type(state).attributes = property(lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
+        coord = _make_provenance_coord(remote_state=state)
+
+        p1, p2 = _patched_dt()
+        with p1, p2:
+            result = coord._read_live_remote_timer_provenance()
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 9. reconcile_fan_on_startup(remote_timer_provenance=...) (Issue #677)
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileFanOnStartupRemoteTimerProvenance:
+    """automation.reconcile_fan_on_startup()'s new remote_timer_provenance branch (Issue #677).
+
+    This is the revert-test: without Step 3's new branch in
+    _reconcile_fan_on_startup_locked(), a valid provenance tuple would simply be ignored and
+    fall through to the pre-existing adopt-on/turn-off nat-vent logic, so
+    handle_fan_manual_override() would never be called here -- these assertions would fail
+    against the pre-fix code.
+    """
+
+    def test_valid_provenance_and_fan_running_rearms_manual_override(self):
+        ae = _make_automation_engine()
+        ae.handle_fan_manual_override = MagicMock()
+
+        asyncio.run(
+            ae.reconcile_fan_on_startup(
+                indoor=75.0,
+                outdoor=70.0,
+                thermostat_fan_running=True,
+                any_sensor_open=True,
+                trigger="ha_restart",
+                remote_timer_provenance=(25200.0, 8.0),
+            )
+        )
+
+        ae.handle_fan_manual_override.assert_called_once_with(
+            fan_before="on",
+            fan_after="on",
+            duration_override=25200.0,
+            remote_timer_hours=8.0,
+            is_remote_event=True,
+        )
+
+    def test_provenance_present_but_fan_off_takes_no_special_action(self):
+        """Fan already reads off -- provenance is provided but deliberately ignored; falls
+        through to the existing no-fan/turn-off path instead of re-arming an override for a
+        fan that isn't running."""
+        ae = _make_automation_engine()
+        ae.handle_fan_manual_override = MagicMock()
+
+        asyncio.run(
+            ae.reconcile_fan_on_startup(
+                indoor=75.0,
+                outdoor=70.0,
+                thermostat_fan_running=False,
+                any_sensor_open=True,
+                trigger="ha_restart",
+                remote_timer_provenance=(25200.0, 8.0),
+            )
+        )
+
+        ae.handle_fan_manual_override.assert_not_called()
+
+    def test_provenance_none_is_byte_for_byte_unchanged(self):
+        """Critical regression-safety property: remote_timer_provenance=None (every
+        pre-#677 caller, and every restart with no live remote timer token) must not call
+        handle_fan_manual_override() from this new branch -- the rest of the method's
+        pre-existing adopt-on/turn-off logic runs exactly as before."""
+        ae = _make_automation_engine()
+        ae.handle_fan_manual_override = MagicMock()
+
+        asyncio.run(
+            ae.reconcile_fan_on_startup(
+                indoor=75.0,
+                outdoor=70.0,
+                thermostat_fan_running=True,
+                any_sensor_open=True,
+                trigger="ha_restart",
+                remote_timer_provenance=None,
+            )
+        )
+
+        ae.handle_fan_manual_override.assert_not_called()

--- a/tools/sim_harness/outcomes.py
+++ b/tools/sim_harness/outcomes.py
@@ -902,6 +902,53 @@ def check_assertion(
                 return False
         return expect
 
+    # --- remote_timer_rearmed_after_restart (Issue #677) ---
+    # Positive GUARANTEE: after an HA restart wipes CA's in-memory RF-timer bookkeeping
+    # (_fan_remote_timer_hours/_grace_active/_timer_boundary_settle_until — the existing
+    # clean-slate policy, Issue #282/#327, deliberately unchanged), a QuietCool RF remote
+    # timer token the fan_remote_entity is still live-re-announcing (ESPHome reconnect
+    # behavior, docs/fan-remote-spec.md § Restart Behavior) must be re-armed as a manual
+    # override with the SAME remote_timer_hours the physical remote originally selected —
+    # proving coordinator._read_live_remote_timer_provenance()'s live read at startup
+    # coalesce actually drove a fresh handle_fan_manual_override() call (Issue #677), not
+    # merely computed a value that was silently discarded. Scans event_log for a SECOND
+    # fan_manual_override event (remote_timer_hours matching, if given) at/after "since"
+    # (the restart boundary) — "since" is required so this can't accidentally match the
+    # original pre-restart press event, which also carries the same remote_timer_hours.
+    # Payload: {"since": <ISO>, "remote_timer_hours": <float, optional>}.
+    # §8 justification: brand-new event field (remote_timer_hours already existed on
+    # fan_manual_override, Issue #486/#495) read by a brand-new assertion type — no
+    # existing outcome/decision semantics touched.
+    if expect == "remote_timer_rearmed_after_restart":
+        since = assertion.get("since")
+        expected_hours = assertion.get("remote_timer_hours")
+        for ev_type, ev_payload, ev_ts in result.event_log:
+            if ev_type != "fan_manual_override" or ev_ts is None:
+                continue
+            if since is not None and _naive_iso(ev_ts) < since:
+                continue
+            if expected_hours is not None and ev_payload.get("remote_timer_hours") != expected_hours:
+                continue
+            return "remote_timer_rearmed_after_restart"
+        return False
+
+    # --- no_new_manual_override_after (Issue #677) ---
+    # Negative GUARANTEE, same shape as hvac_mode_never_commanded/override_not_detected
+    # above: proves no NEW fan_manual_override event fires at/after "since" — the
+    # occupant-facing guarantee that the RF timer's own natural hardware shutoff, hours
+    # later, is never misread by CA as a fresh, unexplained manual action (the Issue #677
+    # bug: a brand-new configured-default grace period — up to hours long — with no memory
+    # the timer was already running and about to end on schedule, blocking nat-vent
+    # reactivation despite favorable outdoor air). Payload: {"since": <ISO>}.
+    if expect == "no_new_manual_override_after":
+        since = assertion.get("since")
+        for ev_type, _ev_payload, ev_ts in result.event_log:
+            if ev_type != "fan_manual_override" or ev_ts is None or since is None:
+                continue
+            if _naive_iso(ev_ts) >= since:
+                return False
+        return expect
+
     return False
 
 

--- a/tools/sim_harness/run_production.py
+++ b/tools/sim_harness/run_production.py
@@ -810,6 +810,24 @@ def _dispatch_event(
         # No engine-only equivalent — command-only/bare-engine mode has no
         # _async_fan_entity_changed listener to dispatch to at all.
 
+    elif etype == "external_entity_state_change":
+        # Issue #677: generalizes external_fan_state_change above to set an arbitrary
+        # entity's state AND attributes — needed to model the QuietCool RF remote's
+        # event.* entity (fan_remote_entity) re-announcing a still-valid timer_* token
+        # after a restart, which coordinator._read_live_remote_timer_provenance() reads
+        # live from hass.states.get() during startup coalescing. Unlike
+        # external_fan_state_change (hardcoded empty attributes dict, sufficient for a
+        # plain on/off fan entity), this entity's decoded command lives in
+        # attributes["event_type"] and its state field IS the press timestamp (see
+        # docs/fan-remote-spec.md § Firmware Event Contract) — both need to be settable.
+        # Only meaningful with use_coordinator=True — same rationale as
+        # external_fan_state_change.
+        entity_id = event.get("entity")
+        new_state = event.get("state", "unknown")
+        attributes = event.get("attributes", {})
+        if entity_id and coordinator is not None:
+            fake_hass.states.async_set(entity_id, new_state, attributes)
+
     elif etype == "pre_cool":
         # Issue #258: Dispatch the pre-cool trigger to the production engine.
         # nat_vent_just_closed=True when the event marks the post-nat-vent trigger;

--- a/tools/simulations/pending/issue_677_rf_timer_restart_resume.json
+++ b/tools/simulations/pending/issue_677_rf_timer_restart_resume.json
@@ -1,0 +1,104 @@
+{
+  "name": "issue_677_rf_timer_restart_resume",
+  "description": "Issue #677: an HA restart mid-QuietCool-RF-timer session wiped CA's in-memory RF-timer bookkeeping. Without a live re-read of the remote entity's still-valid re-announced timer token at startup coalescing, the eventual natural hardware shutoff hours later was misread as a fresh, unexplained manual fan action — starting a brand-new configured-default grace period (potentially hours long) that locked whole-house-fan/nat-vent free cooling out the next morning despite favorable outdoor air.",
+  "source": "synthetic",
+  "issue": 677,
+  "notes": [
+    "Occupant impact: the user presses the QuietCool wall remote's 8-hour timer to run the whole-house fan overnight. A routine software restart mid-session (e.g. an integration update) silently forgets that a timer is running. When the fan's own hardware timer naturally turns it off hours later, without this fix CA has zero memory this was expected and treats it as a surprise manual action, arming a fresh multi-hour grace period that keeps the AC/nat-vent locked out the next morning even though outdoor conditions are ideal for free cooling.",
+    "Fix (coordinator._read_live_remote_timer_provenance(), Issue #677): _do_startup_coalesce() now performs one additional LIVE read (not new persisted state — climate_advisor_state.json is unchanged) of the configured fan_remote_entity's current HA state immediately before its existing reconcile_fan_on_startup() call. The QuietCool ESPHome device re-announces its last retained event_type as it reconnects post-restart (docs/fan-remote-spec.md § Restart Behavior — already relied on by Issue #491's startup-coalescing suppression for the live-press path). If that re-announced token is a still-unexpired timer (computed from the press timestamp + the token's own duration, entirely from live data — no new TTL constant), reconcile_fan_on_startup()'s new remote_timer_provenance branch (automation.py, checked before the existing adopt-on/turn-off nat-vent logic) re-arms handle_fan_manual_override() with duration_override set to the REMAINING seconds and remote_timer_hours set to the token's hours — restoring _fan_remote_timer_hours, which is what Issue #530's existing _timer_boundary_settle_until mechanism depends on to recognize the eventual natural hardware shutoff as the tail of the SAME timer session rather than a fresh event.",
+    "(a) Scenario effectiveness: without Step 3 (the remote_timer_provenance branch in automation.py's _reconcile_fan_on_startup_locked), remote_timer_provenance is computed by the coordinator but never acted on — reconcile_fan_on_startup() falls straight into the pre-existing adopt-on/turn-off nat-vent logic, no second fan_manual_override event is ever emitted post-restart, and _fan_remote_timer_hours stays None. remote_timer_rearmed_after_restart would find no matching event and fail (return False) — directly proven via a standalone revert-test during development (temporarily short-circuiting the branch made the equivalent unit-level assertion in tests/test_fan_remote.py::TestReconcileFanOnStartupRemoteTimerProvenance fail with 'Expected mock to be called once. Called 0 times.'). Without Step 1 (_read_live_remote_timer_provenance() itself), remote_timer_provenance would always be None regardless of a live remote press, silently disabling the whole feature — this scenario's restart+coalesce sequence exercises the real live-read call site, not a mocked value.",
+    "(b) Docs-production alignment: docs/fan-remote-spec.md § Restart Behavior already documented that the remote entity re-announces its retained event_type post-restart and that _suppress_during_startup_coalescing() covers the live-press misread case; this fix's rationale (reading that same live re-announcement specifically for provenance recovery, not live-press suppression) is a natural extension of already-documented firmware behavior, not a new undocumented assumption.",
+    "(c) User outcome if this scenario's assertions fail in the future: after any restart during an active RF-remote whole-house-fan timer session, the eventual natural hardware shutoff would again be misread as a fresh manual fan action, arming an unwarranted grace period and denying the occupant free cooling for its full duration the next time conditions are favorable — silently reverting to the exact Issue #677 defect.",
+    "Scope note: this scenario deliberately does NOT model a door/window sensor or assert nat-vent's full reactivation sequence. The re-armed override's natural expiry (in sync with the physical hardware shutoff) feeds Issue #530's existing _timer_boundary_settle_until mechanism, whose own downstream behavior (settle-window fan-off handling, post-grace fan reconcile) already has dedicated coverage elsewhere. What THIS scenario proves — and what Issue #677's fix actually changes — is narrower and more direct: that the override/grace/_fan_remote_timer_hours bookkeeping Issue #530's mechanism depends on is correctly re-armed after a restart in the first place, and that no fresh, unexplained fan_manual_override event (the concrete mechanism of the reported hours-long lockout) is ever emitted for the natural hardware shutoff. remote_timer_rearmed_after_restart and no_new_manual_override_after are new, purely additive assertion types in tools/sim_harness/outcomes.py — CLAUDE.md's test-infrastructure-change rule (§8): they read only the pre-existing remote_timer_hours field of the pre-existing fan_manual_override event (Issue #486/#495), so no prior scenario's semantics changed. The generalized external_entity_state_change harness event type (tools/sim_harness/run_production.py) is likewise purely additive — a strict superset of external_fan_state_change (which continues unchanged) needed only because the RF remote entity's decoded command lives in attributes['event_type'], not the bare state string external_fan_state_change hardcodes to an empty attributes dict.",
+    "Correction made during authoring: an earlier draft of this scenario also asserted hvac_mode_never_commanded (forbidden cool/heat) across the WHOLE scenario, mirroring restart_whf_ac_mutex_backstop_race.json's own use of that assertion. Running it (python tools/simulate.py --pending -v) surfaced that this scenario's timeline legitimately commands cool mode again once the settle-window mechanism ends the session at 04:00:35 — this scenario's monitored window sensor is never opened, so once the RF-timer session correctly concludes there is no free-cooling condition left and the automation is SUPPOSED to resume cooling per its current hot-day classification. That is correct behavior, not a regression; a whole-scenario hvac_mode_never_commanded assertion would have encoded a wrong expectation (the AC permanently stranded off) rather than protecting the real guarantee (no AC/fan fight WHILE the session is active). Removed rather than papering over with a broader-scoped variant — restart_whf_ac_mutex_backstop_race.json already owns that guarantee for its own restart-timing bug, at an assertion time still inside the active session window; this scenario's own two assertions (remote_timer_rearmed_after_restart, no_new_manual_override_after) are the ones that actually exercise Issue #677's fix."
+  ],
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 74,
+    "natural_vent_delta": 3.0,
+    "door_window_sensors": ["binary_sensor.window"],
+    "fan_mode": "whole_house_fan",
+    "fan_entity": "fan.whf",
+    "fan_state_feedback": true,
+    "fan_remote_entity": "event.quietcool_remote"
+  },
+  "use_coordinator": true,
+  "skip_startup_coalesce": true,
+  "events": [
+    {
+      "time": "2026-08-11T20:00:00",
+      "type": "external_fan_state_change",
+      "entity": "fan.whf",
+      "state": "off",
+      "note": "Seeds a real prior state for fan.whf -- _async_fan_entity_changed requires both old_state and new_state to be non-None to evaluate a transition (mirrors restart_whf_ac_mutex_backstop_race.json's identical seeding rationale)."
+    },
+    {
+      "time": "2026-08-11T20:00:05",
+      "type": "classification",
+      "day_type": "hot",
+      "hvac_mode": "cool",
+      "windows_recommended": false,
+      "note": "Hot evening, thermostat commanded to cool -- gives the WHF override below a real prior HVAC mode to capture/suppress via _pre_fan_hvac_mode."
+    },
+    {
+      "time": "2026-08-11T20:00:10",
+      "type": "temp_update",
+      "indoor_f": 78.0,
+      "outdoor_f": 68.0,
+      "note": "Evening: outdoor well below indoor -- realistic conditions for choosing to run the whole-house fan overnight (not itself asserted on by this scenario -- see notes' scope note)."
+    },
+    {
+      "time": "2026-08-11T20:00:30",
+      "type": "external_fan_state_change",
+      "entity": "fan.whf",
+      "state": "on",
+      "note": "User turns the whole-house fan on via the QuietCool RF remote's 8-hour timer button."
+    },
+    {
+      "time": "2026-08-11T20:00:35",
+      "type": "external_entity_state_change",
+      "entity": "event.quietcool_remote",
+      "state": "2026-08-11T20:00:35+00:00",
+      "attributes": {"event_type": "timer_8h"},
+      "note": "The RF remote's decoded firmware event: state is the press timestamp, attributes.event_type carries the selected 8-hour timer token (docs/fan-remote-spec.md). Real coordinator listener (_async_fan_remote_changed) processes this and, after the burst-combining window elapses (REMOTE_BURST_WINDOW_SECONDS=1.5s, well before the next event 9m25s later), calls handle_fan_manual_override(duration_override=28800, remote_timer_hours=8.0, is_remote_event=True) -- setting _fan_override_active=True, _fan_remote_timer_hours=8.0, and a grace period running to 2026-08-12T04:00:35."
+    },
+    {
+      "time": "2026-08-11T20:10:00",
+      "type": "simulate_restart",
+      "note": "Models an HA restart 10 minutes into the 8-hour timer session -- e.g. a routine integration update. engine.restore_state(engine.get_serializable_state()) wipes _fan_override_active/_fan_remote_timer_hours/_grace_active/_timer_boundary_settle_until (Issue #282/#327 clean-slate policy, deliberately unchanged by this fix) but the fan.whf and event.quietcool_remote entities' live HA state is untouched by restart -- fan.whf is still 'on' and event.quietcool_remote still holds its last-retained timer_8h token, exactly matching the real ESPHome device's post-restart reconnect/re-announce behavior this fix reads from."
+    },
+    {
+      "time": "2026-08-11T20:10:01",
+      "type": "startup_coalesce",
+      "note": "Real coordinator._do_startup_coalesce() entry point. With the Issue #677 fix: reads event.quietcool_remote live (_read_live_remote_timer_provenance()), computes remaining_seconds = (2026-08-11T20:00:35 + 8h) - 2026-08-11T20:10:01 = ~28234s, and — since the archetype-aware physical-state read confirms fan.whf is still physically 'on' — reconcile_fan_on_startup()'s new branch re-arms handle_fan_manual_override(duration_override=~28234, remote_timer_hours=8.0, is_remote_event=True) BEFORE the pre-existing adopt-on/turn-off nat-vent logic ever runs. Without the fix, remote_timer_provenance is never computed/passed and this reconcile falls straight into the pre-existing logic with no memory of the live timer at all."
+    },
+    {
+      "time": "2026-08-12T04:00:36",
+      "type": "external_fan_state_change",
+      "entity": "fan.whf",
+      "state": "off",
+      "note": "The QuietCool hardware's own internal timer clock naturally turns the fan off, ~8 hours after the original press (2026-08-11T20:00:35 + 8h = 2026-08-12T04:00:35) -- independent of and not synchronized to CA's software grace clock. With the fix, CA's re-armed grace (armed at restart to the correct REMAINING duration) expires at essentially this same real moment, so _on_grace_expired() has already cleared the override and armed the Issue #530 _timer_boundary_settle_until window by the time this physical transition arrives -- recognized as the tail of the same timer session, not a fresh event. Without the fix, no override/grace was ever tracked post-restart at all, so this physical off-transition reaches _async_fan_entity_changed()'s normal override-detection path with zero timer memory."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-08-11T20:10:01",
+      "expect": "remote_timer_rearmed_after_restart",
+      "since": "2026-08-11T20:10:01",
+      "remote_timer_hours": 8.0,
+      "reason": "The startup-coalesce reconcile must re-arm a fan_manual_override carrying the SAME 8-hour token the physical remote originally selected, proving _read_live_remote_timer_provenance()'s live read actually drove a real handle_fan_manual_override() call rather than merely computing a value that was silently discarded. 'since' is pinned to the restart/coalesce timestamp so this cannot accidentally match the original pre-restart press event, which also carries remote_timer_hours=8.0."
+    },
+    {
+      "at": "2026-08-12T04:01:00",
+      "expect": "no_new_manual_override_after",
+      "since": "2026-08-11T20:10:02",
+      "reason": "No SECOND fan_manual_override event may ever fire after the coalesce-time re-arm (which itself lands at 20:10:01, one second before this window starts) -- including at/after the RF timer's natural hardware shutoff at 04:00:36. A fresh fan_manual_override here is exactly the Issue #677 defect: the natural, expected shutoff being misread as a brand-new unexplained manual action and locking out free cooling behind an unwarranted fresh grace period."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "After the Issue #677 fix, an HA restart mid-QuietCool-RF-timer session no longer causes the timer's natural hardware shutoff to be misread as a fresh manual action -- the live re-announced timer token is re-armed with the correct remaining duration at startup coalescing, so the existing Issue #530 timer-boundary mechanism (not a fresh multi-hour grace) handles the eventual natural shutoff.",
+    "observed_behavior": "A second fan_manual_override event (remote_timer_hours=8.0) fires at startup coalescing immediately after the restart; no further fan_manual_override event fires for the rest of the scenario, including at the RF timer's natural hardware shutoff at 04:00:36 — instead, the re-armed grace expires in sync at 04:00:35, the Issue #530 settle window absorbs the physical off-transition, and the session ends cleanly (nat_vent_reconcile_exit / fan_untracked_cleared), after which the automation legitimately resumes its current hot-day cool classification since no window was ever open to warrant continued free cooling.",
+    "expected_behavior": "A live, still-valid RF remote timer token surviving in HA state (not CA's own wiped bookkeeping) across a restart must be re-armed as the SAME override with the correct remaining duration, so the timer's own eventual natural end is never re-interpreted as a fresh, unexplained manual fan action."
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #677: a restart landing mid-RF-timer wiped Climate Advisor's memory of an active QuietCool remote timer session. When the physical timer later shut the fan off naturally, CA misread it as a fresh manual power-off and started a fresh 3-hour lockout, blocking free cooling for hours despite ideal outdoor air.
- Adds `_read_live_remote_timer_provenance()` (coordinator.py), called from `_do_startup_coalesce()` — reads the `fan_remote_entity`'s live, restart-reannounced HA state, parses the retained timer token + press timestamp, and computes the token's own natural expiry. No new persisted CA state.
- Threads the result into `reconcile_fan_on_startup()`/`_reconcile_fan_on_startup_locked()` (automation.py): if a still-valid timer is found and the fan is still running, re-arms a grace period for the *remaining* time via the existing `handle_fan_manual_override()` entry point. When no timer is active (the common case), behavior is byte-for-byte unchanged — verified: the diff contains zero deletion lines.
- Part of epic #594 Phase R (Phase 0a in the consolidated plan).

## Test plan
- [x] New unit tests in `tests/test_fan_remote.py` (provenance parser: valid/expired/unconfigured/malformed/unavailable/unparseable; reconcile branch: re-arms/no-ops/unchanged-when-None)
- [x] New pending golden scenario `tools/simulations/pending/issue_677_rf_timer_restart_resume.json`, verified passing
- [x] Full suite: 4916 passed / 6 skipped (independently re-verified by a separate agent)
- [x] `tools/simulate.py` full golden suite: 81/81 passed
- [x] Revert-test performed: the new re-arm assertion fails without the fix, passes with it
- [x] `ruff check`/`ruff format` clean
- [x] `test_version_sync.py` passes (0.6.35 → 0.6.36)