### PR TITLE
Fix #679: stuck-grace backstop doesn't notify the door/window FSM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.37] — 2026-08-19
+
+- Fix #679: no user-visible change. Closes another instance of the same shadow-diagnostic gap class as #676: the Issue #508 stuck-grace backstop correctly notified the override/grace diagnostic FSM when force-cancelling an orphaned grace, but never the door/window diagnostic FSM, which could show a stale "disagreement" for up to 10 minutes after a real recovery. Real HVAC/fan behavior was always correct throughout; only the diagnostic mirror could drift.
+
 ## [0.6.36] — 2026-08-19
 
 - Fix #677: after a restart that lands in the middle of an active QuietCool RF remote timer, Climate Advisor now reads the remote's own live state to recognize the timer is still running and re-arms the correct remaining time, instead of forgetting about it. Previously, when the physical timer later shut the fan off naturally, CA misread it as a fresh manual power-off and started a fresh 3-hour lockout — blocking free cooling for hours even with ideal outdoor air.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.36"
+VERSION = "0.6.37"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.37": [
+        "Fix #679: no user-visible change. Closes another instance of the same"
+        " shadow-diagnostic gap class as #676: the Issue #508 stuck-grace backstop"
+        " correctly notified the override/grace diagnostic FSM when force-cancelling"
+        " an orphaned grace, but never the door/window diagnostic FSM, which could"
+        " show a stale 'disagreement' for up to 10 minutes after a real recovery."
+        " Real HVAC/fan behavior was always correct throughout; only the diagnostic"
+        " mirror could drift.",
+    ],
     "0.6.36": [
         "Fix #677: after a restart that lands in the middle of an active QuietCool RF"
         " remote timer, Climate Advisor now reads the remote's own live state to"
@@ -1982,6 +1991,21 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    679: {
+        "version_fixed": "0.6.37",
+        "title": (
+            "Issue #508's stuck-grace backstop notified the override/grace"
+            " diagnostic FSM when force-cancelling an orphaned grace, but never the"
+            " door/window diagnostic FSM, which also reads grace_active"
+        ),
+        "scope_covered": (
+            "coordinator.py: _check_orphaned_grace() now also calls"
+            " self._evaluate_door_window_fsm('_check_orphaned_grace',"
+            " event_kind=DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED), mirroring the"
+            " existing override/grace FSM call in the same function. Diagnostic-only"
+            " — _evaluate_door_window_fsm() never writes back to production."
+        ),
+    },
     677: {
         "version_fixed": "0.6.36",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -2765,6 +2765,20 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 "Override/grace FSM evaluation (orphaned-grace-driven) failed (isolated, no production impact): %s",
                 fsm_exc,
             )
+        # Issue #679: derive_door_window_lifecycle_state() also takes grace_active as an
+        # input, but this method previously only notified the override/grace FSM above —
+        # leaving the door/window FSM's tracked state stale (stuck at whatever it was
+        # showing pre-force-cancel) until an unrelated later event happened to resync it.
+        # Same closest-semantic-match reasoning as the override/grace call above.
+        from .door_window_fsm import DoorWindowFsmEventKind as _DWFEventKind
+
+        try:
+            self._evaluate_door_window_fsm("_check_orphaned_grace", event_kind=_DWFEventKind.GRACE_TIMER_EXPIRED)
+        except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
+            _LOGGER.warning(
+                "Door/window FSM evaluation (orphaned-grace-driven) failed (isolated, no production impact): %s",
+                fsm_exc,
+            )
         self._emit_event(
             "stuck_grace_recovered",
             {"grace_end_time": _grace_end, "reason": "grace_without_override"},

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.36"
+  "version": "0.6.37"
 }

--- a/tests/test_grace_stuck.py
+++ b/tests/test_grace_stuck.py
@@ -508,6 +508,57 @@ class TestOrphanedGraceDetection:
         coord._emit_event.assert_called_once()
 
 
+class TestOrphanedGraceRefreshesDoorWindowFsm:
+    """Issue #679: ``_check_orphaned_grace()`` force-cancels a stuck grace and notifies
+    the override/grace diagnostic FSM (Issue #639), but ``derive_door_window_lifecycle_state()``
+    also takes ``grace_active`` as an input — this method previously never told the
+    door/window diagnostic FSM (Issue #637) that ``grace_active`` had just flipped to
+    False, leaving ``coordinator._door_window_fsm_state`` stuck at whatever stale value
+    it held (e.g. ``GRACE``/``PAUSED_DURING_GRACE``) for up to 10 minutes, until an
+    unrelated later event happened to resync it.
+
+    Occupant impact: purely diagnostic (this FSM never writes back to production HVAC/
+    fan/grace/override decisions) — but a stale door/window FSM state means the Debug
+    tab's shadow-engine comparison misreports the door/window pause lifecycle as still
+    mid-grace right after the real grace was force-cancelled, which would misdirect any
+    developer using that diagnostic to debug a real grace/pause issue.
+
+    Uses the real headless coordinator (production ``AutomationEngine`` + the real
+    ``transition()`` function), not a mocked engine — a ``MagicMock`` automation_engine
+    can't produce real ``DoorWindowFsmInputs``, so asserting the FSM's *computed* output
+    state requires the real production engine, per CLAUDE.md's no-mirror-tests doctrine.
+    """
+
+    def test_door_window_fsm_state_resyncs_immediately_after_orphaned_grace_cancel(self) -> None:
+        from custom_components.climate_advisor.door_window_lifecycle import DoorWindowLifecycleState
+        from tools.sim_harness.build_coordinator import build_headless_coordinator
+
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        ae = coordinator.automation_engine
+
+        # Build the exact stuck-grace shape _check_orphaned_grace() self-heals: grace
+        # active, protecting an override, but no override actually active anymore.
+        ae._grace_active = True
+        ae._grace_protects_override = True
+        ae._manual_override_active = False
+        ae._fan_override_active = False
+        ae._grace_end_time = "2024-01-15T09:00:00+00:00"
+
+        # Simulate the door/window FSM having been left at a stale mid-grace value by
+        # an earlier event, before this method's fix would have refreshed it. GRACE (not
+        # PAUSED_DURING_GRACE) matches the realistic orphaned-grace shape: no door/window
+        # is paused (ae._paused_by_door is False, matching production's real state here),
+        # just a grace timer left dangling with nothing left to protect.
+        coordinator._door_window_fsm_state = DoorWindowLifecycleState.GRACE
+
+        coordinator._check_orphaned_grace()
+
+        # Without the fix, this stays PAUSED_DURING_GRACE — derive_door_window_lifecycle_state()
+        # is never re-run, so the diagnostic FSM keeps reporting stale grace state even
+        # though ae._grace_active is now False.
+        assert coordinator._door_window_fsm_state == DoorWindowLifecycleState.NORMAL
+
+
 class TestGraceProtectsOverrideClassification:
     """automation._start_grace_period() sets _grace_protects_override from `trigger`
     membership in _GRACE_TRIGGERS_PROTECTING_OVERRIDE (Issue #530) — centralized


### PR DESCRIPTION
## Summary
- Fixes #679: \`_check_orphaned_grace()\` (the Issue #508 stuck-grace self-heal backstop) force-cancels an orphaned grace and correctly notifies the override/grace diagnostic FSM (Issue #639) — but never the door/window diagnostic FSM (Issue #637), which also reads \`grace_active\`. Confirmed live in production logs: the door/window FSM reported a stale \`grace\` state for up to 10 minutes after a real stuck-grace recovery.
- Adds a matching \`self._evaluate_door_window_fsm(...)\` call, mirroring the existing override/grace call exactly (same event kind reasoning, same isolate-and-log try/except pattern).
- Diagnostic-only — \`_evaluate_door_window_fsm()\` never writes back to production. Zero effect on any real HVAC/fan/grace/override decision.
- Same DRY-gap shape as #676 (a flag mutation with an unnotified FSM consumer) — third instance of this pattern found this week.
- Part of epic #594 Phase R (Phase 0b in the consolidated plan).

## Test plan
- [x] New test in \`tests/test_grace_stuck.py\` using the real headless production coordinator (not mocks) — asserts the door/window FSM resyncs to \`NORMAL\` in the same call, not a subsequent tick
- [x] Revert-check performed: confirmed the pre-fix code path leaves the FSM stale
- [x] Full suite independently re-verified: 4897 passed / 6 skipped
- [x] \`ruff check\`/\`ruff format\` clean
- [x] \`test_version_sync.py\` passes (0.6.36 → 0.6.37)