### PR TITLE
Fix #680: restart clean-slate reset bypasses the override/grace FSM dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.38] — 2026-08-19
+
+- Fix #680: no user-visible change. Closes a minor structural gap in the override/grace FSM dispatcher (Issue #664): the restart clean-slate reset directly assigned its 3 governed flags instead of routing through the single dispatch point every other real call site uses. Both paths already produced the same clean-slate result, so there was no behavioral bug — this closes the "exactly one writer" gap before it's relied upon.
+
 ## [0.6.37] — 2026-08-19
 
 - Fix #679: no user-visible change. Closes another instance of the same shadow-diagnostic gap class as #676: the Issue #508 stuck-grace backstop correctly notified the override/grace diagnostic FSM when force-cancelling an orphaned grace, but never the door/window diagnostic FSM, which could show a stale "disagreement" for up to 10 minutes after a real recovery. Real HVAC/fan behavior was always correct throughout; only the diagnostic mirror could drift.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -7949,16 +7949,48 @@ class AutomationEngine:
         self._manual_override_mode = None
         self._manual_override_source = None
         self._manual_override_time = None
-        self._override_confirm_pending = False
         self._override_confirm_time = None
         self._override_confirm_mode = None
         self._override_confirm_source = None
-        self._grace_active = False
         self._grace_end_time = None
         self._grace_duration_seconds = None
         self._last_resume_source = None
         self._last_grace_trigger = None
-        self._grace_protects_override = False
+
+        # Issue #680: route the 3 FSM-modeled flags (_override_confirm_pending /
+        # _grace_active / _grace_protects_override) through
+        # _resolve_override_grace_fsm_state() instead of assigning them directly. That
+        # dispatcher's own docstring (Issue #664) claims to be the single writer of these
+        # 3 flags across every real override/grace call site — this direct assignment was
+        # a third, ungoverned writer, bypassing it. Closest semantic match is
+        # GRACE_TIMER_EXPIRED (grace ending with nothing left to protect) — same reasoning
+        # coordinator._check_orphaned_grace() already uses for this event kind.
+        # origin_state is passed explicitly (unlike most real call sites, which default to
+        # a live read) because there is no real prior FSM-tracked transition to read here —
+        # nothing survives a restart — so the origin modeled is the synthetic "nothing was
+        # running" state restart itself guarantees, not whichever residual value these
+        # fields happened to carry from __init__.
+        #
+        # Both branches land on the identical clean-slate result for this specific call:
+        # - FSM branch: transition((IDLE, NONE), GRACE_TIMER_EXPIRED) hits
+        #   _transition_from_no_grace()'s fallthrough ("unreachable_no_grace" — grace can't
+        #   expire with none active) and returns the origin state unchanged, i.e. (IDLE,
+        #   NONE) — which _apply_override_grace_fsm_state() writes back as
+        #   confirm_pending=False, grace_active=False, grace_protects_override=False.
+        # - legacy branch: clears all 3 flags directly to the same False/False/False.
+        # This is a pure "route through the dispatcher" change — the clean-slate restart
+        # POLICY is unchanged; override/grace/pause state is still always cleared on restart.
+        def _legacy_clear_all_override_grace_flags() -> None:
+            self._legacy_clear_confirm_flag()
+            self._legacy_clear_grace_flags()
+
+        from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
+        self._resolve_override_grace_fsm_state(
+            kind=_OGFEventKind.GRACE_TIMER_EXPIRED,
+            legacy=_legacy_clear_all_override_grace_flags,
+            origin_state=(OverrideConfirmState.IDLE, GraceState.NONE),
+        )
         # Issue #327: fan override cleared on restart — no grace timer to reschedule.
         # reconcile_fan_on_startup() runs shortly after and decides adopt-on / turn-off.
         self._fan_override_active = False

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.37"
+VERSION = "0.6.38"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.38": [
+        "Fix #680: no user-visible change. Closes a minor structural gap in the"
+        " override/grace FSM dispatcher (Issue #664): the restart clean-slate reset"
+        " directly assigned its 3 governed flags instead of routing through the"
+        " single dispatch point every other real call site uses. Both paths already"
+        " produced the same clean-slate result, so there was no behavioral bug —"
+        " this closes the 'exactly one writer' gap before it's relied upon.",
+    ],
     "0.6.37": [
         "Fix #679: no user-visible change. Closes another instance of the same"
         " shadow-diagnostic gap class as #676: the Issue #508 stuck-grace backstop"
@@ -1991,6 +1999,25 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    680: {
+        "version_fixed": "0.6.38",
+        "title": (
+            "Restart clean-slate reset bypassed the override/grace FSM dispatcher,"
+            " leaving a third, ungoverned writer of _override_confirm_pending/"
+            "_grace_active/_grace_protects_override alongside the FSM and legacy"
+            " branches"
+        ),
+        "scope_covered": (
+            "automation.py: AutomationEngine.restore_state()'s clean-slate block now"
+            " routes through _resolve_override_grace_fsm_state(kind="
+            "GRACE_TIMER_EXPIRED, origin_state=(OverrideConfirmState.IDLE,"
+            " GraceState.NONE)) instead of assigning the 3 flags directly. Both the"
+            " FSM branch (transition() falls through to the origin state unchanged"
+            " for this event/state combination) and the legacy branch produce the"
+            " identical all-clear result — the clean-slate restart policy itself is"
+            " unchanged, only how the flags get cleared."
+        ),
+    },
     679: {
         "version_fixed": "0.6.37",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.37"
+  "version": "0.6.38"
 }

--- a/tests/test_action_tracking.py
+++ b/tests/test_action_tracking.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import sys
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.climate_advisor.automation import AutomationEngine
 from custom_components.climate_advisor.classifier import DayClassification
@@ -172,3 +172,51 @@ class TestActionTracking:
         assert engine._manual_override_active is False
         assert engine._manual_override_mode is None
         assert engine._manual_override_time is None
+
+    def test_restore_state_clears_override_grace_fsm_flags_legacy(self):
+        """Issue #680: restore_state()'s clean-slate reset of the 3 FSM-modeled flags
+        (_override_confirm_pending/_grace_active/_grace_protects_override) must still
+        land on the same all-clear result now that it routes through
+        _resolve_override_grace_fsm_state() instead of assigning them directly.
+        This is a behavior-preservation test — the observable outcome (all 3 flags
+        False after restore) must be identical to before the fix. Default engine
+        config leaves _override_grace_fsm_authoritative False, so this exercises the
+        legacy() closure branch.
+        """
+        engine = _make_automation_engine()
+        # Pre-set the 3 flags to non-clean values, as if a real override/grace session
+        # was somehow live at construction time — restore_state() must still land on
+        # all-clear regardless of these starting values.
+        engine._override_confirm_pending = True
+        engine._grace_active = True
+        engine._grace_protects_override = True
+
+        engine.restore_state({})
+
+        assert engine._override_confirm_pending is False
+        assert engine._grace_active is False
+        assert engine._grace_protects_override is False
+
+    def test_restore_state_clears_override_grace_fsm_flags_authoritative(self):
+        """Issue #680: with _override_grace_fsm_authoritative=True, restore_state()'s
+        clean-slate reset must route through _apply_override_grace_fsm_state() (the FSM
+        branch of _resolve_override_grace_fsm_state()) and produce the identical
+        all-clear result as the legacy branch — proving the switch genuinely governs
+        which computation determines these 3 flags, rather than the direct assignments
+        existing independently of it.
+        """
+        engine = _make_automation_engine()
+        engine._override_grace_fsm_authoritative = True
+        engine._override_confirm_pending = True
+        engine._grace_active = True
+        engine._grace_protects_override = True
+
+        with patch.object(
+            engine, "_apply_override_grace_fsm_state", wraps=engine._apply_override_grace_fsm_state
+        ) as spy:
+            engine.restore_state({})
+
+        spy.assert_called_once()
+        assert engine._override_confirm_pending is False
+        assert engine._grace_active is False
+        assert engine._grace_protects_override is False


### PR DESCRIPTION
## Summary
- Fixes #680: \`restore_state()\`'s clean-slate block directly assigned \`_override_confirm_pending\`/\`_grace_active\`/\`_grace_protects_override\`, bypassing \`_resolve_override_grace_fsm_state()\` — the single dispatch point every other real override/grace call site uses (Issue #664).
- Low risk today: both the FSM branch and the legacy branch produce the identical all-clear result for this event (verified by tracing \`transition()\`'s actual fallthrough behavior, not just asserted) — this isn't a behavioral bug. It closes the "exactly one writer" gap before epic #594 Phase R's live-verification window relies on that guarantee being true everywhere.
- Routes the reset through the dispatcher with an explicit \`origin_state=(OverrideConfirmState.IDLE, GraceState.NONE)\`, since nothing survives a restart to read — using a live-read default here would have silently broken clean-slate for a residual \`PENDING\` state. The clean-slate restart *policy* itself is unchanged; only *how* the flags get cleared changed.
- Part of epic #594 Phase R (Phase 0c in the consolidated plan).

## Test plan
- [x] Behavior-preservation test: all 3 flags still land on \`False\` after \`restore_state()\`, legacy path
- [x] New test proving the FSM branch is actually invoked (spy on \`_apply_override_grace_fsm_state\`) when \`_override_grace_fsm_authoritative=True\`
- [x] Independently re-verified: both branches trace to the identical clean-slate result (transition table fallthrough confirmed line-by-line)
- [x] Full suite: 4919 passed / 6 skipped, including all restart/restore_state-related test files by name
- [x] \`ruff check\`/\`ruff format\` clean
- [x] \`test_version_sync.py\` passes (0.6.37 → 0.6.38)