### PR TITLE
Fix #685: debounce shadow-diagnostic disagreement warnings to filter cascade noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.39] — 2026-08-19
+
+- Fix #685: no user-visible change. The shadow-diagnostic "disagreement" warning (used to validate the new state-machine engines against the existing production logic before any future switchover) used to fire the instant a real multi-step transition briefly looked different between the two computations, even when both settled on the same answer within seconds. It now only logs once a disagreement has genuinely persisted for 60 seconds, so the diagnostic signal reflects real problems instead of momentary timing noise.
+
 ## [0.6.38] — 2026-08-19
 
 - Fix #680: no user-visible change. Closes a minor structural gap in the override/grace FSM dispatcher (Issue #664): the restart clean-slate reset directly assigned its 3 governed flags instead of routing through the single dispatch point every other real call site uses. Both paths already produced the same clean-slate result, so there was no behavioral bug — this closes the "exactly one writer" gap before it's relied upon.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,19 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.38"
+VERSION = "0.6.39"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.39": [
+        "Fix #685: no user-visible change. The shadow-diagnostic 'disagreement'"
+        " warning (used to validate the new state-machine engines against the"
+        " existing production logic before any future switchover) used to fire the"
+        " instant a real multi-step transition briefly looked different between the"
+        " two computations, even when both settled on the same answer within"
+        " seconds. It now only logs once a disagreement has genuinely persisted for"
+        " 60 seconds, so the diagnostic signal reflects real problems instead of"
+        " momentary timing noise.",
+    ],
     "0.6.38": [
         "Fix #680: no user-visible change. Closes a minor structural gap in the"
         " override/grace FSM dispatcher (Issue #664): the restart clean-slate reset"
@@ -1999,6 +2009,29 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    685: {
+        "version_fixed": "0.6.39",
+        "title": (
+            "Shadow-diagnostic disagreement WARNINGs fired instantly on any"
+            " transient mismatch during a real multi-step production transition,"
+            " producing false-alarm noise that undermined the A/B validation signal"
+        ),
+        "scope_covered": (
+            "coordinator.py: new _shadow_diag_update_axis() tracks wall-clock"
+            " elapsed time (not a snapshot count — proven necessary, since duplicate"
+            " disagreement snapshots during a real cascade fire 1-2ms apart) since a"
+            " continuous disagreement streak began, per comparison axis. All 6 axes"
+            " (mirror, fsm, door_window_mirror, door_window_fsm,"
+            " override_grace_mirror, override_grace_fsm) now only log a WARNING"
+            " once a streak exceeds SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S=60 seconds."
+            " A new 'debounce' sub-dict and 'cumulative_reset_date' key were added"
+            " to _shadow_engine_diagnostic (additive only — no existing key removed"
+            " or renamed), plus a daily-reset cumulative-seconds-of-disagreement"
+            " counter per axis, surfaced additively on"
+            " ClimateAdvisorShadowEngineStatusSensor. Diagnostic-only — no"
+            " production HVAC/fan/grace/override logic touched."
+        ),
+    },
     680: {
         "version_fixed": "0.6.38",
         "title": (
@@ -7688,6 +7721,15 @@ NAT_VENT_REACTIVATION_LOCKOUT_S = 300
 
 CONF_NAT_VENT_HYSTERESIS_F = "nat_vent_hysteresis_f"
 CONF_NAT_VENT_REACTIVATION_LOCKOUT_S = "nat_vent_reactivation_lockout_s"
+
+# Issue #685: shadow-engine diagnostic cascade-noise debounce. Real multi-step
+# production transitions can fire several distinct top-level automation-engine
+# method calls in a fast cascade (confirmed via live log evidence: a 2026-08-19
+# 04:55:20-04:55:31 cascade hit 4 comparison axes, resolved in 11.71s). A WARNING
+# is only logged once a comparison axis has continuously disagreed for this many
+# wall-clock seconds — not a count of consecutive snapshots, since duplicate
+# mirrored calls can fire 1-2ms apart during a real cascade.
+SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S = 60  # Issue #685: cascade-noise debounce, see investigation evidence
 
 # Issue #641: hard safety floor on CA-issued fan (WHF/HVAC-fan) toggle frequency —
 # defense-in-depth against ANY future oscillation bug (not tied to one root cause),

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -172,6 +172,7 @@ from .const import (
     REJECT_WINDOW_TOO_SHORT,
     REMOTE_BURST_WINDOW_SECONDS,
     REMOTE_SPEED_SENSOR_OBJECT_ID_HINTS,
+    SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S,
     TEMP_SOURCE_CLIMATE_FALLBACK,
     TEMP_SOURCE_INPUT_NUMBER,
     TEMP_SOURCE_SENSOR,
@@ -259,6 +260,18 @@ _LOGGER = logging.getLogger(__name__)
 # Degrees below comfort_heat at which outdoor temp is too cold to recommend opening windows.
 # With default comfort_heat=70°F this means outdoor must be ≥ 55°F for windows to be recommended.
 _WINDOWS_EXTREME_COLD_MARGIN = 15.0
+
+# Issue #685: the 6 comparison axes tracked by _update_shadow_engine_diagnostic()'s
+# wall-clock cascade-noise debounce (mirror + FSM comparisons for nat-vent,
+# door/window, and override/grace).
+_SHADOW_DIAG_AXES = (
+    "mirror",
+    "fsm",
+    "door_window_mirror",
+    "door_window_fsm",
+    "override_grace_mirror",
+    "override_grace_fsm",
+)
 
 # Maximum rejection events retained per obs_type in the in-memory rejection log.
 # Matches the per-obs-type cap enforced by LearningState.rejection_log on load.
@@ -623,6 +636,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         # See docs/02-ARCHITECTURE-REFERENCE.md "Engine Callback Isolation".
         self._shadow_event_log: list[dict[str, Any]] = []
         self._shadow_engine_diagnostic: dict[str, Any] | None = None
+        # Issue #685: wall-clock cascade-noise debounce state for the 6 comparison
+        # axes above — see _shadow_diag_update_axis() and SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S.
+        self._shadow_diag_disagreement_since: dict[str, datetime | None] = dict.fromkeys(_SHADOW_DIAG_AXES)
+        self._shadow_diag_cumulative_seconds: dict[str, float] = dict.fromkeys(_SHADOW_DIAG_AXES, 0.0)
+        self._shadow_diag_cumulative_date: date = dt_util.now().date()
         # Issue #633: the unified nat-vent FSM's own independently-tracked state —
         # never written onto either engine, purely a third comparison point. Starts
         # INACTIVE unconditionally (same clean-slate convention as restore_state()'s
@@ -1332,6 +1350,26 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         state = self.hass.states.get(self.automation_engine.climate_entity)
         return state.state if state else None
 
+    def _shadow_diag_update_axis(self, axis: str, agrees: bool, now: datetime) -> tuple[float, bool]:
+        """Update the wall-clock disagreement streak for one comparison axis and
+        return (seconds_disagreeing_now, sustained). Cascade-noise fix (Issue #685):
+        time-based, not count-based — duplicate mirrored calls fire sub-millisecond
+        apart during a real cascade (confirmed via live log evidence), so a
+        consecutive-snapshot counter would trip immediately on the exact noise this
+        exists to suppress.
+        """
+        since = self._shadow_diag_disagreement_since[axis]
+        if not agrees:
+            if since is None:
+                since = now
+                self._shadow_diag_disagreement_since[axis] = since
+            duration = (now - since).total_seconds()
+            return duration, duration >= SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S
+        if since is not None:
+            self._shadow_diag_cumulative_seconds[axis] += (now - since).total_seconds()
+            self._shadow_diag_disagreement_since[axis] = None
+        return 0.0, False
+
     def _update_shadow_engine_diagnostic(self) -> None:
         """Recompute production/shadow nat-vent lifecycle state agreement (Issue #613),
         plus (Issue #633) the independent nat-vent FSM's agreement with production.
@@ -1344,6 +1382,14 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         from .nat_vent_lifecycle import NatVentLifecycleInputs, derive_nat_vent_lifecycle_state
 
         now = dt_util.now()
+
+        # Issue #685: lazy daily reset of cumulative disagreement seconds, same
+        # style as claude_api.py's _reset_daily_counters_if_needed() — self-heals
+        # across HA restarts that cross midnight, no scheduled callback needed.
+        today = now.date()
+        if today != self._shadow_diag_cumulative_date:
+            self._shadow_diag_cumulative_seconds = dict.fromkeys(_SHADOW_DIAG_AXES, 0.0)
+            self._shadow_diag_cumulative_date = today
 
         def _state_for(ae: AutomationEngine) -> str:
             inputs = NatVentLifecycleInputs(
@@ -1406,6 +1452,24 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             and override_grace_mirror_agrees
             and override_grace_fsm_agrees
         )
+
+        # Issue #685: wall-clock debounce per axis — a WARNING only fires once a
+        # comparison axis has continuously disagreed for SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S.
+        mirror_duration, mirror_sustained = self._shadow_diag_update_axis("mirror", mirror_agrees, now)
+        fsm_duration, fsm_sustained = self._shadow_diag_update_axis("fsm", fsm_agrees, now)
+        door_window_mirror_duration, door_window_mirror_sustained = self._shadow_diag_update_axis(
+            "door_window_mirror", door_window_mirror_agrees, now
+        )
+        door_window_fsm_duration, door_window_fsm_sustained = self._shadow_diag_update_axis(
+            "door_window_fsm", door_window_fsm_agrees, now
+        )
+        override_grace_mirror_duration, override_grace_mirror_sustained = self._shadow_diag_update_axis(
+            "override_grace_mirror", override_grace_mirror_agrees, now
+        )
+        override_grace_fsm_duration, override_grace_fsm_sustained = self._shadow_diag_update_axis(
+            "override_grace_fsm", override_grace_fsm_agrees, now
+        )
+
         self._shadow_engine_diagnostic = {
             "production_state": production_state,
             "shadow_state": shadow_state,
@@ -1422,42 +1486,81 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             "override_grace_fsm_agrees": override_grace_fsm_agrees,
             "agrees": agrees,
             "checked_at": now.isoformat(),
+            "debounce": {
+                "mirror": {
+                    "disagreement_seconds": mirror_duration,
+                    "sustained": mirror_sustained,
+                    "cumulative_seconds_today": self._shadow_diag_cumulative_seconds["mirror"],
+                },
+                "fsm": {
+                    "disagreement_seconds": fsm_duration,
+                    "sustained": fsm_sustained,
+                    "cumulative_seconds_today": self._shadow_diag_cumulative_seconds["fsm"],
+                },
+                "door_window_mirror": {
+                    "disagreement_seconds": door_window_mirror_duration,
+                    "sustained": door_window_mirror_sustained,
+                    "cumulative_seconds_today": self._shadow_diag_cumulative_seconds["door_window_mirror"],
+                },
+                "door_window_fsm": {
+                    "disagreement_seconds": door_window_fsm_duration,
+                    "sustained": door_window_fsm_sustained,
+                    "cumulative_seconds_today": self._shadow_diag_cumulative_seconds["door_window_fsm"],
+                },
+                "override_grace_mirror": {
+                    "disagreement_seconds": override_grace_mirror_duration,
+                    "sustained": override_grace_mirror_sustained,
+                    "cumulative_seconds_today": self._shadow_diag_cumulative_seconds["override_grace_mirror"],
+                },
+                "override_grace_fsm": {
+                    "disagreement_seconds": override_grace_fsm_duration,
+                    "sustained": override_grace_fsm_sustained,
+                    "cumulative_seconds_today": self._shadow_diag_cumulative_seconds["override_grace_fsm"],
+                },
+            },
+            "cumulative_reset_date": self._shadow_diag_cumulative_date.isoformat(),
         }
-        if not mirror_agrees:
+        if mirror_sustained:
             _LOGGER.warning(
-                "Shadow engine disagreement (Issue #613): production=%s shadow=%s",
+                "Shadow engine disagreement (Issue #613): production=%s shadow=%s (sustained %.0fs)",
                 production_state,
                 shadow_state,
+                mirror_duration,
             )
-        if not fsm_agrees:
+        if fsm_sustained:
             _LOGGER.warning(
-                "Nat-vent FSM disagreement (Issue #633): production=%s fsm=%s",
+                "Nat-vent FSM disagreement (Issue #633): production=%s fsm=%s (sustained %.0fs)",
                 production_state,
                 fsm_state,
+                fsm_duration,
             )
-        if not door_window_mirror_agrees:
+        if door_window_mirror_sustained:
             _LOGGER.warning(
-                "Door/window shadow engine disagreement (Issue #637): production=%s shadow=%s",
+                "Door/window shadow engine disagreement (Issue #637): production=%s shadow=%s (sustained %.0fs)",
                 door_window_production_state,
                 door_window_shadow_state,
+                door_window_mirror_duration,
             )
-        if not door_window_fsm_agrees:
+        if door_window_fsm_sustained:
             _LOGGER.warning(
-                "Door/window FSM disagreement (Issue #637): production=%s fsm=%s",
+                "Door/window FSM disagreement (Issue #637): production=%s fsm=%s (sustained %.0fs)",
                 door_window_production_state,
                 door_window_fsm_state,
+                door_window_fsm_duration,
             )
-        if not override_grace_mirror_agrees:
+        if override_grace_mirror_sustained:
             _LOGGER.warning(
-                "Override/grace shadow engine disagreement (Issue #639): production=%s shadow=%s",
+                "Override/grace shadow engine disagreement (Issue #639): production=%s shadow=%s (sustained %.0fs)",
                 override_grace_production_state,
                 override_grace_shadow_state,
+                override_grace_mirror_duration,
             )
-        if not override_grace_fsm_agrees:
+        if override_grace_fsm_sustained:
             _LOGGER.warning(
-                "Override/grace FSM disagreement (Issue #639): production=%s fsm=%s",
+                "Override/grace FSM disagreement (Issue #639): production=%s fsm=%s (sustained %.0fs)",
                 override_grace_production_state,
                 override_grace_fsm_state,
+                override_grace_fsm_duration,
             )
 
     @property

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.38"
+  "version": "0.6.39"
 }

--- a/custom_components/climate_advisor/sensor.py
+++ b/custom_components/climate_advisor/sensor.py
@@ -531,4 +531,9 @@ class ClimateAdvisorShadowEngineStatusSensor(ClimateAdvisorBaseSensor):
             "override_grace_fsm_state": diag.get("override_grace_fsm_state"),
             "override_grace_mirror_agrees": diag.get("override_grace_mirror_agrees"),
             "override_grace_fsm_agrees": diag.get("override_grace_fsm_agrees"),
+            # Issue #685: cascade-noise wall-clock debounce state per comparison axis
+            # (disagreement_seconds, sustained, cumulative_seconds_today), plus the
+            # date the cumulative counters last reset. Additive only.
+            "debounce": diag.get("debounce"),
+            "cumulative_reset_date": diag.get("cumulative_reset_date"),
         }

--- a/tests/test_door_window_fsm_shadow_wiring.py
+++ b/tests/test_door_window_fsm_shadow_wiring.py
@@ -11,10 +11,24 @@ Mirrors ``tests/test_nat_vent_fsm_shadow_wiring.py``'s structure.
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
-from custom_components.climate_advisor.door_window_lifecycle import DoorWindowLifecycleState
 from tools.sim_harness._loop import run_coro
 from tools.sim_harness.build_coordinator import build_headless_coordinator
+from tools.sim_harness.ha_stubs import install_ha_stubs
+
+install_ha_stubs()
+
+from custom_components.climate_advisor.const import SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S  # noqa: E402
+from custom_components.climate_advisor.door_window_lifecycle import DoorWindowLifecycleState  # noqa: E402
+
+# Issue #685: build_headless_coordinator's stub environment leaves
+# homeassistant.util.dt.now() returning a MagicMock (never exercised
+# arithmetically before this issue's wall-clock debounce). Tests that exercise
+# a disagreement path — where the debounce helper subtracts two "now" values —
+# must patch coordinator.dt_util.now to a real, fixed datetime.
+_FIXED_NOW = datetime(2026, 8, 19, 12, 0, 0, tzinfo=UTC)
 
 
 def _run(coro):
@@ -106,10 +120,15 @@ class TestFsmStateTracking:
 
 class TestDiagnosticIntegration:
     def test_diagnostic_includes_door_window_fsm_state(self) -> None:
+        """Issue #685: patches dt_util.now — the noop'd shadow handler leaves the
+        shadow/production door-window state disagreeing, which now exercises the
+        debounce helper's datetime arithmetic (raises against the stub
+        environment's default MagicMock clock without a fixed patch)."""
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
 
         _noop_shadow_methods(coordinator, "handle_door_window_open")
-        _run(coordinator._mirror_to_shadow("handle_door_window_open", "binary_sensor.test"))
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            _run(coordinator._mirror_to_shadow("handle_door_window_open", "binary_sensor.test"))
 
         diag = coordinator.shadow_engine_diagnostic
         assert diag is not None
@@ -118,6 +137,9 @@ class TestDiagnosticIntegration:
         assert "door_window_fsm_agrees" in diag
 
     def test_positive_control_fsm_disagreement_is_detected(self) -> None:
+        """Issue #685: patches dt_util.now to a real fixed datetime because the
+        debounce helper now subtracts two "now" values, which raises against the
+        stub environment's default MagicMock clock when a disagreement occurs."""
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator(
             climate_state="cool", climate_attributes={"current_temperature": 76.0}
         )
@@ -127,7 +149,8 @@ class TestDiagnosticIntegration:
         coordinator.automation_engine._paused_by_door = False
 
         _noop_shadow_methods(coordinator, "handle_door_window_open")
-        _run(coordinator._mirror_to_shadow("handle_door_window_open", "binary_sensor.test"))
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            _run(coordinator._mirror_to_shadow("handle_door_window_open", "binary_sensor.test"))
 
         diag = coordinator.shadow_engine_diagnostic
         assert diag is not None
@@ -143,11 +166,44 @@ class TestDiagnosticIntegration:
         coordinator.automation_engine.update_outdoor_temp(90.0)
         coordinator.config["comfort_cool"] = 78.0
         coordinator.automation_engine._paused_by_door = False
+        # Issue #685: WARNING now only fires once the axis has continuously
+        # disagreed for SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S — seed the streak as
+        # already past threshold so this test still exercises a real, persistent
+        # divergence (its original intent) rather than a fresh, momentary one.
+        coordinator._shadow_diag_disagreement_since["door_window_fsm"] = _FIXED_NOW - timedelta(
+            seconds=SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S + 1
+        )
 
         _noop_shadow_methods(coordinator, "handle_door_window_open")
-        with caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"):
+        with (
+            patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW),
+            caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"),
+        ):
             _run(coordinator._mirror_to_shadow("handle_door_window_open", "binary_sensor.test"))
         assert any("Door/window FSM disagreement" in r.message for r in caplog.records)
+
+    def test_fresh_door_window_fsm_disagreement_does_not_log_warning(self, caplog) -> None:
+        """Issue #685: the actual bug fix — a single-tick, fresh door/window FSM
+        disagreement must NOT log a WARNING. Without the debounce, this fires
+        immediately."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator(
+            climate_state="cool", climate_attributes={"current_temperature": 76.0}
+        )
+        coordinator.automation_engine.update_outdoor_temp(90.0)
+        coordinator.config["comfort_cool"] = 78.0
+        coordinator.automation_engine._paused_by_door = False
+
+        _noop_shadow_methods(coordinator, "handle_door_window_open")
+        with (
+            patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW),
+            caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"),
+        ):
+            _run(coordinator._mirror_to_shadow("handle_door_window_open", "binary_sensor.test"))
+        assert not any("Door/window FSM disagreement" in r.message for r in caplog.records)
+        diag = coordinator.shadow_engine_diagnostic
+        assert diag is not None
+        assert diag["debounce"]["door_window_fsm"]["sustained"] is False
+        assert 0.0 <= diag["debounce"]["door_window_fsm"]["disagreement_seconds"] < 1.0
 
 
 class TestIsolation:

--- a/tests/test_nat_vent_fsm_shadow_wiring.py
+++ b/tests/test_nat_vent_fsm_shadow_wiring.py
@@ -14,10 +14,24 @@ correctly across calls, disagreement detection works, and isolation holds
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
-from custom_components.climate_advisor.nat_vent_lifecycle import NatVentLifecycleState
 from tools.sim_harness._loop import run_coro
 from tools.sim_harness.build_coordinator import build_headless_coordinator
+from tools.sim_harness.ha_stubs import install_ha_stubs
+
+install_ha_stubs()
+
+from custom_components.climate_advisor.const import SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S  # noqa: E402
+from custom_components.climate_advisor.nat_vent_lifecycle import NatVentLifecycleState  # noqa: E402
+
+# Issue #685: build_headless_coordinator's stub environment leaves
+# homeassistant.util.dt.now() returning a MagicMock (never exercised
+# arithmetically before this issue's wall-clock debounce). Tests that exercise
+# a disagreement path — where the debounce helper subtracts two "now" values —
+# must patch coordinator.dt_util.now to a real, fixed datetime.
+_FIXED_NOW = datetime(2026, 8, 19, 12, 0, 0, tzinfo=UTC)
 
 
 def _run(coro):
@@ -105,7 +119,12 @@ class TestDiagnosticIntegration:
         """Forces a real divergence: production is (incorrectly, for this test)
         marked active while conditions clearly favor the FSM staying inactive —
         confirms the diagnostic's overall agrees flag reflects it and the
-        disagreement is logged distinctly from the mirror-based one."""
+        disagreement is logged distinctly from the mirror-based one.
+
+        Issue #685: patches dt_util.now to a real fixed datetime because the
+        debounce helper now subtracts two "now" values, which raises against the
+        stub environment's default MagicMock clock.
+        """
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator(
             climate_attributes={"current_temperature": 70.0}
         )
@@ -116,7 +135,8 @@ class TestDiagnosticIntegration:
             return None
 
         coordinator.shadow_automation_engine.check_natural_vent_conditions = _noop
-        _run(coordinator._mirror_to_shadow("check_natural_vent_conditions"))
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            _run(coordinator._mirror_to_shadow("check_natural_vent_conditions"))
 
         diag = coordinator.shadow_engine_diagnostic
         assert diag is not None
@@ -125,6 +145,35 @@ class TestDiagnosticIntegration:
         assert diag["production_state"] == NatVentLifecycleState.ACTIVE_FULL_GATE.value
 
     def test_disagreement_logs_distinct_warning(self, caplog) -> None:
+        """Issue #685: a WARNING only fires once the fsm axis has continuously
+        disagreed for SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S — seed the streak as
+        already past threshold so this test still proves a real, persistent
+        divergence gets reported."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator(
+            climate_attributes={"current_temperature": 70.0}
+        )
+        coordinator.automation_engine.update_outdoor_temp(80.0)
+        coordinator.automation_engine._natural_vent_active = True
+        coordinator._shadow_diag_disagreement_since["fsm"] = _FIXED_NOW - timedelta(
+            seconds=SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S + 1
+        )
+
+        async def _noop(*args, **kwargs):
+            return None
+
+        coordinator.shadow_automation_engine.check_natural_vent_conditions = _noop
+        with (
+            patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW),
+            caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"),
+        ):
+            _run(coordinator._mirror_to_shadow("check_natural_vent_conditions"))
+        assert any("Nat-vent FSM disagreement" in r.message for r in caplog.records)
+
+    def test_fresh_disagreement_does_not_log_warning(self, caplog) -> None:
+        """Issue #685 regression test: the actual bug fix — a single-tick, fresh
+        FSM disagreement (the shape of a real multi-step production cascade's
+        momentary, self-resolving divergence) must NOT log a WARNING. Without the
+        debounce, this would fire immediately."""
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator(
             climate_attributes={"current_temperature": 70.0}
         )
@@ -135,9 +184,16 @@ class TestDiagnosticIntegration:
             return None
 
         coordinator.shadow_automation_engine.check_natural_vent_conditions = _noop
-        with caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"):
+        with (
+            patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW),
+            caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"),
+        ):
             _run(coordinator._mirror_to_shadow("check_natural_vent_conditions"))
-        assert any("Nat-vent FSM disagreement" in r.message for r in caplog.records)
+        assert not any("Nat-vent FSM disagreement" in r.message for r in caplog.records)
+        diag = coordinator.shadow_engine_diagnostic
+        assert diag is not None
+        assert diag["debounce"]["fsm"]["sustained"] is False
+        assert 0.0 <= diag["debounce"]["fsm"]["disagreement_seconds"] < 1.0
 
 
 class TestIsolation:

--- a/tests/test_override_grace_fsm_shadow_wiring.py
+++ b/tests/test_override_grace_fsm_shadow_wiring.py
@@ -17,12 +17,28 @@ dict at the ``_mirror_to_shadow()`` call site; every override/grace *exit* path
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
-from custom_components.climate_advisor.const import CONF_OVERRIDE_CONFIRM_PERIOD
-from custom_components.climate_advisor.override_grace_fsm import OverrideGraceFsmEventKind
-from custom_components.climate_advisor.override_grace_lifecycle import GraceState, OverrideConfirmState
 from tools.sim_harness._loop import run_coro
 from tools.sim_harness.build_coordinator import build_headless_coordinator
+from tools.sim_harness.ha_stubs import install_ha_stubs
+
+install_ha_stubs()
+
+from custom_components.climate_advisor.const import (  # noqa: E402
+    CONF_OVERRIDE_CONFIRM_PERIOD,
+    SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S,
+)
+from custom_components.climate_advisor.override_grace_fsm import OverrideGraceFsmEventKind  # noqa: E402
+from custom_components.climate_advisor.override_grace_lifecycle import GraceState, OverrideConfirmState  # noqa: E402
+
+# Issue #685: build_headless_coordinator's stub environment leaves
+# homeassistant.util.dt.now() returning a MagicMock (never exercised
+# arithmetically before this issue's wall-clock debounce). Tests that exercise
+# a disagreement path — where the debounce helper subtracts two "now" values —
+# must patch coordinator.dt_util.now to a real, fixed datetime.
+_FIXED_NOW = datetime(2026, 8, 19, 12, 0, 0, tzinfo=UTC)
 
 
 def _run(coro):
@@ -203,10 +219,15 @@ class TestUnprotectedGraceStartedEventWiring:
 
 class TestDiagnosticIntegration:
     def test_diagnostic_includes_override_grace_fsm_state(self) -> None:
+        """Issue #685: patches dt_util.now — the noop'd shadow handler leaves
+        production/shadow override-grace state disagreeing, which now exercises
+        the debounce helper's datetime arithmetic (raises against the stub
+        environment's default MagicMock clock without a fixed patch)."""
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
 
         _noop_shadow_methods(coordinator, "resume_from_pause")
-        _run(coordinator._mirror_to_shadow("resume_from_pause"))
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            _run(coordinator._mirror_to_shadow("resume_from_pause"))
 
         diag = coordinator.shadow_engine_diagnostic
         assert diag is not None
@@ -229,7 +250,8 @@ class TestDiagnosticIntegration:
         coordinator.automation_engine._grace_protects_override = True
 
         _noop_shadow_methods(coordinator, "resume_from_pause")
-        _run(coordinator._mirror_to_shadow("resume_from_pause"))
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            _run(coordinator._mirror_to_shadow("resume_from_pause"))
 
         diag = coordinator.shadow_engine_diagnostic
         assert diag is not None
@@ -244,15 +266,16 @@ class TestDiagnosticIntegration:
         coordinator.automation_engine._grace_protects_override = False
 
         _noop_shadow_methods(coordinator, "resume_from_pause")
-        _run(coordinator._mirror_to_shadow("resume_from_pause"))
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            _run(coordinator._mirror_to_shadow("resume_from_pause"))
 
-        # Shadow engine never actually ran resume_from_pause() (noop'd above), so
-        # its own flags stay whatever _sync_shadow_inputs() raw-copied from
-        # production just before the noop ran (i.e. now in sync). Force a genuine
-        # shadow-mirror disagreement by directly diverging the shadow's flag AFTER
-        # that sync already happened, then recompute the diagnostic.
-        coordinator.shadow_automation_engine._grace_active = False
-        coordinator._update_shadow_engine_diagnostic()
+            # Shadow engine never actually ran resume_from_pause() (noop'd above), so
+            # its own flags stay whatever _sync_shadow_inputs() raw-copied from
+            # production just before the noop ran (i.e. now in sync). Force a genuine
+            # shadow-mirror disagreement by directly diverging the shadow's flag AFTER
+            # that sync already happened, then recompute the diagnostic.
+            coordinator.shadow_automation_engine._grace_active = False
+            coordinator._update_shadow_engine_diagnostic()
 
         diag = coordinator.shadow_engine_diagnostic
         assert diag is not None
@@ -273,7 +296,8 @@ class TestDiagnosticIntegration:
 
         coordinator.automation_engine.handle_fan_manual_override(fan_before="auto", fan_after="on")
         _noop_shadow_methods(coordinator, "handle_fan_manual_override")
-        _run(coordinator._mirror_to_shadow("handle_fan_manual_override", fan_before="auto", fan_after="on"))
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            _run(coordinator._mirror_to_shadow("handle_fan_manual_override", fan_before="auto", fan_after="on"))
 
         diag = coordinator.shadow_engine_diagnostic
         assert diag is not None
@@ -285,11 +309,41 @@ class TestDiagnosticIntegration:
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
         coordinator.automation_engine._grace_active = True
         coordinator.automation_engine._grace_protects_override = True
+        # Issue #685: WARNING now only fires once the axis has continuously
+        # disagreed for SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S — seed the streak as
+        # already past threshold so this test still exercises a real, persistent
+        # divergence (its original intent) rather than a fresh, momentary one.
+        coordinator._shadow_diag_disagreement_since["override_grace_fsm"] = _FIXED_NOW - timedelta(
+            seconds=SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S + 1
+        )
 
         _noop_shadow_methods(coordinator, "resume_from_pause")
-        with caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"):
+        with (
+            patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW),
+            caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"),
+        ):
             coordinator._update_shadow_engine_diagnostic()
         assert any("Override/grace FSM disagreement" in r.message for r in caplog.records)
+
+    def test_fresh_override_grace_fsm_disagreement_does_not_log_warning(self, caplog) -> None:
+        """Issue #685: the actual bug fix — a single-tick, fresh override/grace FSM
+        disagreement must NOT log a WARNING. Without the debounce, this fires
+        immediately."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.automation_engine._grace_active = True
+        coordinator.automation_engine._grace_protects_override = True
+
+        _noop_shadow_methods(coordinator, "resume_from_pause")
+        with (
+            patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW),
+            caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"),
+        ):
+            coordinator._update_shadow_engine_diagnostic()
+        assert not any("Override/grace FSM disagreement" in r.message for r in caplog.records)
+        diag = coordinator.shadow_engine_diagnostic
+        assert diag is not None
+        assert diag["debounce"]["override_grace_fsm"]["sustained"] is False
+        assert 0.0 <= diag["debounce"]["override_grace_fsm"]["disagreement_seconds"] < 1.0
 
 
 class TestIsolation:

--- a/tests/test_shadow_engine_live.py
+++ b/tests/test_shadow_engine_live.py
@@ -40,7 +40,9 @@ Issue #673 (third coverage-gap follow-up, Phase 2) adds:
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime, timedelta
 from typing import Any
+from unittest.mock import patch
 
 from tools.sim_harness._loop import run_coro
 from tools.sim_harness.build_coordinator import build_headless_coordinator
@@ -49,6 +51,14 @@ from tools.sim_harness.ha_stubs import install_ha_stubs
 install_ha_stubs()
 
 from custom_components.climate_advisor.automation import AutomationEngine  # noqa: E402
+from custom_components.climate_advisor.const import SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S  # noqa: E402
+
+# Issue #685: build_headless_coordinator's stub environment leaves
+# homeassistant.util.dt.now() returning a MagicMock (never exercised
+# arithmetically before this issue's wall-clock debounce). Tests that exercise
+# a disagreement path — where the debounce helper subtracts two "now" values —
+# must patch coordinator.dt_util.now to a real, fixed datetime.
+_FIXED_NOW = datetime(2026, 8, 19, 12, 0, 0, tzinfo=UTC)
 
 
 class TestShadowEngineConstruction:
@@ -209,22 +219,58 @@ class TestShadowEngineDiagnostic:
 
     def test_positive_control_disagreement_is_detected(self) -> None:
         """Forces a real divergence (shadow thinks nat-vent is active, production
-        doesn't) and confirms the diagnostic — and its WARNING log — catch it."""
+        doesn't) and confirms the diagnostic — and its WARNING log — catch it.
+
+        Issue #685: patches dt_util.now to a real fixed datetime because the
+        debounce helper now subtracts two "now" values, which raises against the
+        stub environment's default MagicMock clock — a change from this test's
+        original form, needed only because a disagreement path is exercised.
+        """
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
         coordinator.shadow_automation_engine._natural_vent_active = True
         coordinator.automation_engine._natural_vent_active = False
-        coordinator._update_shadow_engine_diagnostic()
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            coordinator._update_shadow_engine_diagnostic()
         diag = coordinator.shadow_engine_diagnostic
         assert diag["agrees"] is False
         assert diag["production_state"] != diag["shadow_state"]
 
     def test_disagreement_logs_warning(self, caplog) -> None:
+        """Issue #685: a WARNING only fires once the mirror axis has continuously
+        disagreed for SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S — seed the streak as
+        already past threshold so this test still proves a real, persistent
+        divergence gets reported."""
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
         coordinator.shadow_automation_engine._natural_vent_active = True
         coordinator.automation_engine._natural_vent_active = False
-        with caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"):
+        coordinator._shadow_diag_disagreement_since["mirror"] = _FIXED_NOW - timedelta(
+            seconds=SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S + 1
+        )
+        with (
+            patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW),
+            caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"),
+        ):
             coordinator._update_shadow_engine_diagnostic()
         assert any("Shadow engine disagreement" in r.message for r in caplog.records)
+
+    def test_fresh_disagreement_does_not_log_warning(self, caplog) -> None:
+        """Issue #685: the actual bug fix — a single-tick, fresh disagreement
+        (the shape of a real multi-step production cascade's momentary,
+        self-resolving divergence, confirmed via live log evidence) must NOT log
+        a WARNING. Without the debounce, this fires immediately."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.shadow_automation_engine._natural_vent_active = True
+        coordinator.automation_engine._natural_vent_active = False
+        with (
+            patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW),
+            caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"),
+        ):
+            coordinator._update_shadow_engine_diagnostic()
+        assert not any("Shadow engine disagreement" in r.message for r in caplog.records)
+        diag = coordinator.shadow_engine_diagnostic
+        assert diag is not None
+        assert diag["debounce"]["mirror"]["sustained"] is False
+        assert 0.0 <= diag["debounce"]["mirror"]["disagreement_seconds"] < 1.0
 
 
 class TestShadowEngineShutdown:


### PR DESCRIPTION
## Summary
- Fixes #685: \`_update_shadow_engine_diagnostic()\` logged a WARNING the instant any of 6 comparison axes disagreed, even when the mismatch was a momentary artifact of a real multi-step production transition. Confirmed via live log evidence: a single real cascade hit 4 axes and resolved within 11.71s, with duplicate log lines firing 1-2ms apart. This noise erodes trust in the signal epic #594 Phase R depends on to gate any future switchover to authoritative FSM control.
- Adds a **wall-clock time-based** debounce (proven necessary over a naive count-based approach — the 1-2ms duplicate timing would trip a snapshot counter before a cascade even finishes): a WARNING now only fires once a disagreement has persisted 60+ continuous seconds, applied uniformly to all 6 comparison axes.
- Threshold justified with real margin on both sides: 5x above the largest observed cascade (11.71s), 9-20x below both a confirmed real sustained mismatch (522s) and the historical #676 case (1200s+) — genuinely stuck cases still surface within ~1 minute of onset, not masked.
- Purely additive to \`_shadow_engine_diagnostic\`'s schema (new \`debounce\` sub-dict + \`cumulative_reset_date\` key) — no existing key changed, so \`sensor.py\`'s only consumer needs zero changes to keep working.
- Diagnostic-only. No production HVAC/fan/grace/override logic touched.
- Part of epic #594 Phase R (Phase 0d in the consolidated plan).

## Test plan
- [x] 4 pre-existing "disagreement logs warning" tests updated to seed a past-threshold disagreement streak, preserving original intent (persistent divergence still logs)
- [x] 4 new regression tests proving a *fresh* single-tick disagreement does NOT log, independently revert-verified by a separate Verification agent (reverting the gate condition made the new tests fail with the exact WARNING leaking through)
- [x] Full suite independently re-verified: 4923 passed / 6 skipped
- [x] \`tools/simulate.py\` full golden suite: 81/81 passed
- [x] \`ruff check\`/\`ruff format\` clean
- [x] \`test_version_sync.py\` passes (0.6.38 → 0.6.39)
- [x] Independently checked for edit-race damage (two agents briefly worked the same worktree during implementation) — confirmed clean, no duplicated/half-applied code