### PR TITLE
Fix #687: nat-vent diagnostic FSM blind to override/grace state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.40] — 2026-08-19
+
+- Fix #687: no user-visible change. The nat-vent diagnostic engine (used to validate a future state-machine switchover, not authoritative over any real fan/HVAC decision today) couldn't see when a manual fan override or grace period was active, so it reported "would activate" for the full duration of any manual override — the single largest diagnostic-disagreement bucket found this session. It now correctly recognizes both.
+
 ## [0.6.39] — 2026-08-19
 
 - Fix #685: no user-visible change. The shadow-diagnostic "disagreement" warning (used to validate the new state-machine engines against the existing production logic before any future switchover) used to fire the instant a real multi-step transition briefly looked different between the two computations, even when both settled on the same answer within seconds. It now only logs once a disagreement has genuinely persisted for 60 seconds, so the diagnostic signal reflects real problems instead of momentary timing noise.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.39"
+VERSION = "0.6.40"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.40": [
+        "Fix #687: no user-visible change. The nat-vent diagnostic engine (used"
+        " to validate a future state-machine switchover, not authoritative over"
+        " any real fan/HVAC decision today) couldn't see when a manual fan"
+        " override or grace period was active, so it reported 'would activate'"
+        " for the full duration of any manual override — the single largest"
+        " diagnostic-disagreement bucket found this session. It now correctly"
+        " recognizes both.",
+    ],
     "0.6.39": [
         "Fix #685: no user-visible change. The shadow-diagnostic 'disagreement'"
         " warning (used to validate the new state-machine engines against the"
@@ -2009,6 +2018,30 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    687: {
+        "version_fixed": "0.6.40",
+        "title": (
+            "Nat-vent diagnostic FSM blind to manual override/grace state,"
+            " reporting 'would activate' for the full duration of any manual"
+            " override window"
+        ),
+        "scope_covered": (
+            "nat_vent_fsm.py: NatVentFsmInputs gained override_active/"
+            "grace_active fields; both _transition_from_inactive() and"
+            " _transition_from_active() now short-circuit to INACTIVE while"
+            " either is true, before any gate/exit math runs. coordinator.py:"
+            " _evaluate_nat_vent_fsm() populates the new fields from"
+            " ae._fan_override_active/_manual_override_active/_grace_active."
+            " Diagnostic-only — self._nat_vent_fsm_state is never written back"
+            " to production; the existing narrow _natvent_fsm_authoritative"
+            " production feature (soft-start escalation only) is provably"
+            " unaffected, since its own input-construction call site in"
+            " automation.py does not pass the new fields, which default to"
+            " False. Known remaining gap tracked separately in Issue #688: the"
+            " short-circuit doesn't yet model the Issue #134"
+            " overheat-during-grace exception."
+        ),
+    },
     685: {
         "version_fixed": "0.6.39",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1149,6 +1149,8 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     config.get(CONF_NAT_VENT_REACTIVATION_LOCKOUT_S, NAT_VENT_REACTIVATION_LOCKOUT_S)
                 ),
                 now=now,
+                override_active=bool(ae._fan_override_active or ae._manual_override_active),
+                grace_active=bool(ae._grace_active),
             ),
         )
         result = transition(self._nat_vent_fsm_state, event)

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.39"
+  "version": "0.6.40"
 }

--- a/custom_components/climate_advisor/nat_vent_fsm.py
+++ b/custom_components/climate_advisor/nat_vent_fsm.py
@@ -51,6 +51,32 @@ itself.
 **Cross-lifecycle inputs.** ``paused_by_door`` is a state *read* from the
 door/window lifecycle (Issue #631's "communicating automata" design) — legacy
 flag-derived today, unchanged in shape once door/window gets its own FSM.
+
+**Override/grace awareness (Issue #687, Phase 2a).** ``override_active``
+(``AutomationEngine._fan_override_active`` or ``_manual_override_active``) and
+``grace_active`` (``AutomationEngine._grace_active``) are now read inputs too.
+While either is true, both ``_transition_from_inactive()`` and
+``_transition_from_active()`` short-circuit straight to ``INACTIVE`` before any
+gate/exit math runs. This mirrors production's real guarding, but split across
+two different call sites, not one: ``_activate_fan()``'s own early return
+("Fan override active — skipping fan activation") checks only
+``_fan_override_active``; the ``_grace_active`` guard is separately enforced in
+``check_natural_vent_conditions()``. Previously the FSM had no way to see
+either flag and would report ``ACTIVE_FULL_GATE`` for the full duration of a
+manual override/grace window while production correctly stayed inactive —
+confirmed live as the single largest disagreement bucket in a night of logs
+(38 of 114 disagreement lines). This closes that specific gap; it does not
+implement any other new decision authority (see epic #594 Phase R for the
+larger authority question).
+
+**Known remaining edge (diagnostic-only, zero occupant impact — tracked in
+Issue #688):** production's grace guard has an Issue #134 exception that
+*allows* nat-vent to engage during grace when indoor exceeds ``comfort_cool``
+(overheat protection). This short-circuit does not model that exception —
+it always returns ``INACTIVE`` while ``grace_active`` is true. This trades the
+38-line disagreement bucket above for a narrower, rarer one; since this
+tracker is never written back to production, occupant behavior is unaffected
+either way.
 """
 
 from __future__ import annotations
@@ -120,6 +146,16 @@ class NatVentFsmInputs:
     outdoor_exit_time: datetime | None
     lockout_seconds: float
     now: datetime
+    # Default False (rather than requiring every existing construction site to be
+    # updated) is a deliberate choice: automation.py's own
+    # ``_build_nat_vent_fsm_inputs()`` construction site is out of scope for this
+    # fix (Issue #687, Phase 2a is confined to nat_vent_fsm.py + how
+    # coordinator.py feeds it — see that issue's scope note). A default lets this
+    # dataclass change land without touching production automation.py logic;
+    # coordinator.py's own construction site is updated explicitly below to pass
+    # real values rather than relying on the default.
+    override_active: bool = False
+    grace_active: bool = False
 
 
 @dataclass(frozen=True)
@@ -189,6 +225,21 @@ def _soft_start_inputs(inputs: NatVentFsmInputs, *, full_gate_active: bool) -> N
 
 
 def _transition_from_active(current_state: NatVentLifecycleState, event: NatVentFsmEvent) -> NatVentTransition:
+    # Issue #687 (Phase 2a): a manual override or grace period wins over everything
+    # else in this function, including the lockout-recognition check right below it.
+    # Mirrors production's real guarding, split across two call sites: override
+    # is _activate_fan()'s own early return ("Fan override active — skipping fan
+    # activation"); grace is enforced separately in check_natural_vent_conditions()
+    # (minus its Issue #134 overheat-during-grace exception — see module docstring,
+    # tracked in Issue #688). Placed first, before any other branch.
+    if event.inputs.override_active or event.inputs.grace_active:
+        return NatVentTransition(
+            from_state=current_state,
+            to_state=NatVentLifecycleState.INACTIVE,
+            event_kind=event.kind,
+            at=event.inputs.now,
+        )
+
     # Issue #672: before anything else, recognize a door-pause/reactivation-lockout
     # condition — the one thing this branch previously had NO way to ever detect once
     # wrongly active. _transition_from_inactive() already checks this same condition on
@@ -250,6 +301,19 @@ def _transition_from_active(current_state: NatVentLifecycleState, event: NatVent
 
 def _transition_from_inactive(current_state: NatVentLifecycleState, event: NatVentFsmEvent) -> NatVentTransition:
     inputs = event.inputs
+
+    # Issue #687 (Phase 2a): same override/grace short-circuit as
+    # _transition_from_active() — see that function's comment for the production
+    # mirror this reflects. Placed first, before the lockout check, so an
+    # override/grace window can never be masked by (or race with) lockout state.
+    if inputs.override_active or inputs.grace_active:
+        return NatVentTransition(
+            from_state=current_state,
+            to_state=NatVentLifecycleState.INACTIVE,
+            event_kind=event.kind,
+            at=inputs.now,
+        )
+
     if inputs.paused_by_door and is_reactivation_locked_out(
         outdoor_exit_time=inputs.outdoor_exit_time, now=inputs.now, lockout_seconds=inputs.lockout_seconds
     ):

--- a/tests/test_nat_vent_fsm.py
+++ b/tests/test_nat_vent_fsm.py
@@ -59,6 +59,8 @@ def _inputs(
     outdoor_exit_time: datetime | None = None,
     lockout_seconds: float = 300.0,
     now: datetime = _NOW,
+    override_active: bool = False,
+    grace_active: bool = False,
 ) -> NatVentFsmInputs:
     return NatVentFsmInputs(
         indoor=indoor,
@@ -81,6 +83,8 @@ def _inputs(
         outdoor_exit_time=outdoor_exit_time,
         lockout_seconds=lockout_seconds,
         now=now,
+        override_active=override_active,
+        grace_active=grace_active,
     )
 
 
@@ -273,6 +277,87 @@ class TestActiveBranchLockoutRecognition:
             ),
         )
         assert t.to_state != NatVentLifecycleState.PAUSED_REACTIVATION_LOCKOUT
+
+
+class TestOverrideGraceShortCircuit:
+    """Issue #687 (Phase 2a): a manual override or grace period must win over
+    the gate/exit math entirely, mirroring production's own early return in
+    ``_activate_fan()`` ("Fan override active — skipping fan activation") —
+    which never reaches the gate math this FSM otherwise re-derives every
+    tick. Confirmed live: for the full duration of a manual RF-remote override
+    grace, the FSM previously reported ``ACTIVE_FULL_GATE`` while production
+    correctly stayed inactive (38 of 114 disagreement lines in one night)."""
+
+    def test_inactive_with_override_active_and_favorable_gate_stays_inactive(self) -> None:
+        # Conditions alone (indoor 75, outdoor 65, comfort_heat 68) would activate
+        # full gate per test_activates_full_gate_when_conditions_favorable above —
+        # override_active must suppress that entirely.
+        t = transition(
+            NatVentLifecycleState.INACTIVE,
+            _tick(indoor=75.0, outdoor=65.0, comfort_heat_raw=68.0, override_active=True),
+        )
+        assert t.to_state == NatVentLifecycleState.INACTIVE
+        assert not t.changed
+
+    def test_inactive_with_grace_active_and_favorable_gate_stays_inactive(self) -> None:
+        t = transition(
+            NatVentLifecycleState.INACTIVE,
+            _tick(indoor=75.0, outdoor=65.0, comfort_heat_raw=68.0, grace_active=True),
+        )
+        assert t.to_state == NatVentLifecycleState.INACTIVE
+        assert not t.changed
+
+    def test_active_full_gate_transitions_to_inactive_when_override_becomes_active(self) -> None:
+        # Nothing in the exit chain would otherwise trigger an exit (matches
+        # test_stays_active_when_nothing_triggers_exit's conditions) — override
+        # must force INACTIVE anyway, not "stay in whatever active state it was in".
+        t = transition(
+            NatVentLifecycleState.ACTIVE_FULL_GATE,
+            _tick(indoor=72.0, outdoor=65.0, override_active=True),
+        )
+        assert t.to_state == NatVentLifecycleState.INACTIVE
+        assert t.changed
+
+    def test_active_soft_start_transitions_to_inactive_when_grace_becomes_active(self) -> None:
+        t = transition(
+            NatVentLifecycleState.ACTIVE_SOFT_START,
+            _tick(indoor=72.0, outdoor=65.0, grace_active=True),
+        )
+        assert t.to_state == NatVentLifecycleState.INACTIVE
+        assert t.changed
+
+    def test_override_short_circuit_takes_priority_over_lockout_recognition(self) -> None:
+        # Even when paused_by_door + an unexpired lockout window are ALSO present
+        # (which would otherwise route to PAUSED_REACTIVATION_LOCKOUT per
+        # TestActiveBranchLockoutRecognition), override_active must win and land
+        # on plain INACTIVE, not PAUSED_REACTIVATION_LOCKOUT.
+        now = datetime(2026, 1, 1, 12, 0, 30, tzinfo=UTC)
+        exit_time = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        t = transition(
+            NatVentLifecycleState.ACTIVE_SOFT_START,
+            _tick(
+                indoor=75.0,
+                outdoor=65.0,
+                comfort_heat_raw=68.0,
+                paused_by_door=True,
+                outdoor_exit_time=exit_time,
+                now=now,
+                lockout_seconds=300.0,
+                override_active=True,
+            ),
+        )
+        assert t.to_state == NatVentLifecycleState.INACTIVE
+
+    def test_both_flags_false_leaves_favorable_conditions_unaffected(self) -> None:
+        """Regression-safety proof: with override_active/grace_active both False
+        (the default), behavior is byte-for-byte the existing pre-#687 path —
+        same assertion as test_activates_full_gate_when_conditions_favorable."""
+        t = transition(
+            NatVentLifecycleState.INACTIVE,
+            _tick(indoor=75.0, outdoor=65.0, comfort_heat_raw=68.0, override_active=False, grace_active=False),
+        )
+        assert t.to_state == NatVentLifecycleState.ACTIVE_FULL_GATE
+        assert t.changed
 
 
 class TestSoftStartEscalation:


### PR DESCRIPTION
## Summary
- Fixes #687: \`_evaluate_nat_vent_fsm()\`/\`NatVentFsmInputs\` never saw \`_fan_override_active\`/\`_manual_override_active\`/\`_grace_active\`, so the diagnostic FSM reported \`active_full_gate\` for the entire duration of any manual override while production correctly stayed inactive — the single largest disagreement bucket found this session (38 of 114 lines in one night's logs).
- Adds \`override_active\`/\`grace_active\` fields to \`NatVentFsmInputs\`; short-circuits both \`_transition_from_inactive()\`/\`_transition_from_active()\` to \`INACTIVE\` while either is true.
- Diagnostic-only. \`self._nat_vent_fsm_state\` is never written back to production. The existing narrow \`_natvent_fsm_authoritative\` production feature (soft-start escalation only) is provably unaffected — its input-construction call site in \`automation.py\` doesn't pass the new fields, which default to \`False\`, confirmed via that feature's own corpus equivalence tests staying green.
- **Known remaining gap, filed as #688, not fixed here**: the short-circuit doesn't yet model the Issue #134 overheat-during-grace exception (production allows nat-vent to engage during grace when indoor exceeds \`comfort_cool\`). Diagnostic-only, zero occupant impact either way — trades the 38-line bucket for a narrower, rarer one.
- Part of epic #594 Phase R (Phase 2a — must land before the rest of the nat-vent build-out, since routing more decision points through \`transition()\` is unsafe until the FSM can see the same guards production already has).

## Test plan
- [x] 6 new tests in \`tests/test_nat_vent_fsm.py\` covering both short-circuit branches, ordering vs. lockout recognition, and a regression-safety proof (both flags false → unaffected)
- [x] Independently re-verified by a separate Verification agent, including confirming \`automation.py\` is genuinely untouched and the existing live switch's behavior is provably unaffected by construction (not just by test)
- [x] Full suite: 4929 passed / 6 skipped
- [x] \`tools/simulate.py\` full golden suite: 81/81 passed
- [x] \`ruff check\`/\`ruff format\` clean
- [x] \`test_version_sync.py\` passes (0.6.39 → 0.6.40)