### PR TITLE
Fix #691: add nat-vent FSM-state-to-flags projection layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.41] — 2026-08-19
+
+- Fix #691: no user-visible change. Adds a new internal method that will let the nat-vent state-machine engine (still not authoritative over any real decision today) eventually drive real fan state the same proven way the door/window engine already does. Not yet connected to anything — preparation work only.
+
 ## [0.6.40] — 2026-08-19
 
 - Fix #687: no user-visible change. The nat-vent diagnostic engine (used to validate a future state-machine switchover, not authoritative over any real fan/HVAC decision today) couldn't see when a manual fan override or grace period was active, so it reported "would activate" for the full duration of any manual override — the single largest diagnostic-disagreement bucket found this session. It now correctly recognizes both.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -6269,6 +6269,30 @@ class AutomationEngine:
             )
         )
 
+    def _apply_nat_vent_fsm_state(self, state: NatVentLifecycleState) -> None:
+        """Write ``_natural_vent_active``/``_nat_vent_soft_start``/``_paused_by_door``
+        from a ``nat_vent_fsm.transition()`` result (Issue #594 Phase R, Phase 2f).
+
+        Inverse of ``nat_vent_lifecycle_state``'s derivation — see
+        ``nat_vent_lifecycle.py``'s ``derive_nat_vent_lifecycle_state()``.
+        Deliberately does NOT touch ``_nat_vent_outdoor_exit_time`` — the FSM's
+        ``to_state`` alone cannot distinguish "just entered lockout" from
+        "already mid-lockout," and only the outdoor-reversal exit path
+        (``_exit_nat_vent(set_outdoor_exit_time=True)``) has the information
+        needed to arm it, same exclusion-list treatment as door/window's
+        ``_grace_end_time``.
+
+        Not yet called from any production code path — added ahead of the
+        wiring work that will invoke it, matching the same additive-first
+        pattern already used for Issue #687's override/grace awareness.
+        """
+        self._natural_vent_active = state in (
+            NatVentLifecycleState.ACTIVE_FULL_GATE,
+            NatVentLifecycleState.ACTIVE_SOFT_START,
+        )
+        self._nat_vent_soft_start = state == NatVentLifecycleState.ACTIVE_SOFT_START
+        self._paused_by_door = state == NatVentLifecycleState.PAUSED_REACTIVATION_LOCKOUT
+
     def _build_door_window_fsm_inputs(self, *, now: datetime):
         """Build the door/window FSM's input snapshot from current engine state
         (Issue #594 Phase R, Step 2).

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,16 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.40"
+VERSION = "0.6.41"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.41": [
+        "Fix #691: no user-visible change. Adds a new internal method that will"
+        " let the nat-vent state-machine engine (still not authoritative over"
+        " any real decision today) eventually drive real fan state the same"
+        " proven way the door/window engine already does. Not yet connected to"
+        " anything — preparation work only.",
+    ],
     "0.6.40": [
         "Fix #687: no user-visible change. The nat-vent diagnostic engine (used"
         " to validate a future state-machine switchover, not authoritative over"
@@ -2018,6 +2025,28 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    691: {
+        "version_fixed": "0.6.41",
+        "title": (
+            "Added _apply_nat_vent_fsm_state() — nat-vent's FSM-state-to-flags"
+            " projection layer, mirroring the door/window engine's existing"
+            " _apply_door_window_fsm_state() pattern"
+        ),
+        "scope_covered": (
+            "automation.py: new AutomationEngine._apply_nat_vent_fsm_state()"
+            " derives _natural_vent_active/_nat_vent_soft_start/_paused_by_door"
+            " from a NatVentLifecycleState value. Deliberately excludes"
+            " _nat_vent_outdoor_exit_time — the enum's to_state alone cannot"
+            " distinguish 'just entered lockout' from 'already mid-lockout,'"
+            " same exclusion-list treatment as door/window's _grace_end_time."
+            " Purely additive — zero call sites anywhere in the codebase"
+            " (confirmed by grep), not wired into any production path yet;"
+            " that wiring is a separate, future phase. Registered in the"
+            " shadow-engine flag-mutation coverage registry (test_shadow_"
+            "engine_coverage.py) as 'internal', matching the same category"
+            " already used for its door/window and override/grace siblings."
+        ),
+    },
     687: {
         "version_fixed": "0.6.40",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.40"
+  "version": "0.6.41"
 }

--- a/tests/test_door_window.py
+++ b/tests/test_door_window.py
@@ -793,6 +793,85 @@ class TestResolveDoorWindowPauseFlagsDispatcher:
         assert engine.door_window_lifecycle_state == DoorWindowLifecycleState.GRACE
 
 
+class TestApplyNatVentFsmState:
+    """Tests for AutomationEngine._apply_nat_vent_fsm_state() (Issue #691).
+
+    This method is new, additive code with zero call sites in production yet
+    (Issue #594 Phase R, Phase 2f) -- these tests exercise it directly by
+    invoking it on a bare engine and asserting the three flags it writes,
+    plus the exclusion-list proof for _nat_vent_outdoor_exit_time.
+    """
+
+    def _make_engine(self) -> AutomationEngine:
+        engine = object.__new__(AutomationEngine)
+        engine._natural_vent_active = None
+        engine._nat_vent_soft_start = None
+        engine._paused_by_door = None
+        engine._nat_vent_outdoor_exit_time = "SENTINEL_UNTOUCHED"
+        return engine
+
+    def test_active_full_gate_sets_active_only(self):
+        from custom_components.climate_advisor.nat_vent_lifecycle import (
+            NatVentLifecycleState,
+        )
+
+        engine = self._make_engine()
+        engine._apply_nat_vent_fsm_state(NatVentLifecycleState.ACTIVE_FULL_GATE)
+
+        assert engine._natural_vent_active is True
+        assert engine._nat_vent_soft_start is False
+        assert engine._paused_by_door is False
+
+    def test_active_soft_start_sets_active_and_soft_start(self):
+        from custom_components.climate_advisor.nat_vent_lifecycle import (
+            NatVentLifecycleState,
+        )
+
+        engine = self._make_engine()
+        engine._apply_nat_vent_fsm_state(NatVentLifecycleState.ACTIVE_SOFT_START)
+
+        assert engine._natural_vent_active is True
+        assert engine._nat_vent_soft_start is True
+        assert engine._paused_by_door is False
+
+    def test_inactive_clears_all_three_flags(self):
+        from custom_components.climate_advisor.nat_vent_lifecycle import (
+            NatVentLifecycleState,
+        )
+
+        engine = self._make_engine()
+        engine._apply_nat_vent_fsm_state(NatVentLifecycleState.INACTIVE)
+
+        assert engine._natural_vent_active is False
+        assert engine._nat_vent_soft_start is False
+        assert engine._paused_by_door is False
+
+    def test_paused_reactivation_lockout_sets_paused_only(self):
+        from custom_components.climate_advisor.nat_vent_lifecycle import (
+            NatVentLifecycleState,
+        )
+
+        engine = self._make_engine()
+        engine._apply_nat_vent_fsm_state(NatVentLifecycleState.PAUSED_REACTIVATION_LOCKOUT)
+
+        assert engine._natural_vent_active is False
+        assert engine._nat_vent_soft_start is False
+        assert engine._paused_by_door is True
+
+    def test_outdoor_exit_time_untouched_by_any_state(self):
+        """Regression guard for the documented exclusion: no state value may
+        write _nat_vent_outdoor_exit_time -- only _exit_nat_vent(set_outdoor_exit_time=True)
+        may do that, per this method's own docstring."""
+        from custom_components.climate_advisor.nat_vent_lifecycle import (
+            NatVentLifecycleState,
+        )
+
+        for state in NatVentLifecycleState:
+            engine = self._make_engine()
+            engine._apply_nat_vent_fsm_state(state)
+            assert engine._nat_vent_outdoor_exit_time == "SENTINEL_UNTOUCHED"
+
+
 class TestGracePeriodDuration:
     """Tests for configurable grace period durations."""
 

--- a/tests/test_shadow_engine_coverage.py
+++ b/tests/test_shadow_engine_coverage.py
@@ -100,6 +100,12 @@ _COVERAGE_REGISTRY: dict[str, str] = {
         "branches of handle_manual_override_during_pause (mirrored) and resume_from_pause "
         "(mirrored) — the inverse of door_window_lifecycle_state's derivation"
     ),
+    "_apply_nat_vent_fsm_state": (
+        "internal: Issue #594 Phase R Phase 2f helper, added ahead of any production wiring — "
+        "has zero call sites as of Issue #691 (see that issue's own docstring). Same "
+        "additive-first pattern as _apply_door_window_fsm_state above; will be reclassified "
+        "when a future issue wires it into a real entry point"
+    ),
     "_clear_fan_flags_and_start_grace": (
         "internal: called only from on_fan_turned_off (mirrored) and _reconcile_fan_physical_drift (internal)"
     ),


### PR DESCRIPTION
## Summary
- Fixes #691: adds \`AutomationEngine._apply_nat_vent_fsm_state()\`, deriving \`_natural_vent_active\`/\`_nat_vent_soft_start\`/\`_paused_by_door\` from a \`NatVentLifecycleState\` value — mirroring the door/window engine's already-proven \`_apply_door_window_fsm_state()\` pattern exactly.
- Deliberately excludes \`_nat_vent_outdoor_exit_time\`: the enum's \`to_state\` alone cannot distinguish "just entered lockout" from "already mid-lockout" — same exclusion-list treatment as door/window's \`_grace_end_time\`.
- **Purely additive** — zero call sites anywhere in the codebase (independently re-confirmed by grep during verification), not wired into any production path. That wiring is a separate, later phase (Phase 2b).
- Registered in the shadow-engine flag-mutation coverage registry (\`test_shadow_engine_coverage.py\`) as \`"internal"\` — required by an existing test gate, verified via revert-test to be genuinely necessary, using the same category its door/window and override/grace siblings already use.
- Part of epic #594 Phase R (Phase 2f in the consolidated plan).

## Two things flagged for the future wiring phase (Phase 2b), not fixed here since this method has zero call sites today
- Applying \`PAUSED_REACTIVATION_LOCKOUT\` doesn't round-trip back to the same state via \`nat_vent_lifecycle_state\` unless \`_nat_vent_outdoor_exit_time\` is also separately armed and unexpired.
- \`_paused_by_door\` is shared with the door/window FSM's own projection method — wiring both in without care could let nat-vent's projection clear a real door/window pause.

## Test plan
- [x] 5 new tests covering all 4 relevant enum states plus a sentinel proof that \`_nat_vent_outdoor_exit_time\` is genuinely untouched (independently strengthened by the Verification pass to iterate the full enum, not just 4 hand-picked members)
- [x] Independently re-verified by a separate Verification agent, including confirming zero call sites via its own grep and confirming the registry addition was proven necessary by revert-test
- [x] Full suite: 4934 passed / 6 skipped
- [x] \`tools/simulate.py\` full golden suite: 81/81 passed (pure no-op regression check, as expected for unwired code)
- [x] \`ruff check\`/\`ruff format\` clean
- [x] \`test_version_sync.py\` passes (0.6.40 → 0.6.41)