### PR TITLE
Fix #690: consolidate duplicate outdoor-rise-exit boundary logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.42] — 2026-08-19
+
+- Fix #690: two separate places that decide when to end a natural-ventilation session (a fast check and a slower 30-minute check) used to disagree by one degree of temperature precision at the exact moment outdoor and indoor temperatures matched — the fast check would end the session, the slow one wouldn't, for up to 30 minutes. Both now agree and end the session at the same instant once free cooling is genuinely gone. Rare edge case; no change for the common case where temperatures aren't at exact equality.
+
 ## [0.6.41] — 2026-08-19
 
 - Fix #691: no user-visible change. Adds a new internal method that will let the nat-vent state-machine engine (still not authoritative over any real decision today) eventually drive real fan state the same proven way the door/window engine already does. Not yet connected to anything — preparation work only.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -3773,7 +3773,7 @@ class AutomationEngine:
 
                 if exit_decision.reason == NatVentExitReason.OUTDOOR_RISE:
                     _LOGGER.info(
-                        "Natural vent exit: outdoor %.1f°F > indoor %.1f°F — airflow reversed",
+                        "Natural vent exit: outdoor %.1f°F >= indoor %.1f°F — airflow reversed",
                         outdoor,
                         indoor,
                     )
@@ -3781,8 +3781,10 @@ class AutomationEngine:
                     # built for (Issue #115/#411). Issue #641 later extended the same
                     # treatment to PROACTIVE_FLOOR and CEILING_THRESHOLD above/below, once
                     # both were found to hand off into the identical paused-reactivation race.
+                    # Issue #690: boundary is now non-strict (>=, via is_outdoor_rise_exit()) —
+                    # this text is user-visible on the Debug tab via _last_action_reason.
                     await self._exit_nat_vent(
-                        reason=(f"nat vent exit: outdoor {outdoor:.1f}°F > indoor {indoor:.1f}°F — airflow reversed"),
+                        reason=(f"nat vent exit: outdoor {outdoor:.1f}°F >= indoor {indoor:.1f}°F — airflow reversed"),
                         set_outdoor_exit_time=True,
                         event_type="nat_vent_outdoor_rise_exit",
                         event_payload={

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,19 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.41"
+VERSION = "0.6.42"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.42": [
+        "Fix #690: two separate places that decide when to end a natural-"
+        "ventilation session (a fast check and a slower 30-minute check) used"
+        " to disagree by one degree of temperature precision at the exact"
+        " moment outdoor and indoor temperatures matched — the fast check"
+        " would end the session, the slow one wouldn't, for up to 30 minutes."
+        " Both now agree and end the session at the same instant once free"
+        " cooling is genuinely gone. Rare edge case; no change for the"
+        " common case where temperatures aren't at exact equality.",
+    ],
     "0.6.41": [
         "Fix #691: no user-visible change. Adds a new internal method that will"
         " let the nat-vent state-machine engine (still not authoritative over"
@@ -2025,6 +2035,26 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    690: {
+        "version_fixed": "0.6.42",
+        "title": (
+            "Fast-loop and slow-loop nat-vent outdoor-rise exit checks used"
+            " different boundary comparisons (>= vs >), disagreeing for up to"
+            " 30 minutes at exact outdoor==indoor temperature equality"
+        ),
+        "scope_covered": (
+            "New is_outdoor_rise_exit(indoor, outdoor) in"
+            " fan_thermostat_decision.py (same module as the existing shared"
+            " resolve_hard_exit_floor()) — non-strict (>=). Both"
+            " fan_thermostat_check()'s fast-loop Check 1 and"
+            " nat_vent_exit.py's OUTDOOR_RISE check now delegate to it."
+            " nat_vent_exit.py's check changes from strict (>) to non-strict"
+            " (>=) — a deliberate, real behavior change at exact equality."
+            " automation.py's Debug-tab-visible exit reason string corrected"
+            " to match (was still displaying '>' after the boundary became"
+            " non-strict)."
+        ),
+    },
     691: {
         "version_fixed": "0.6.41",
         "title": (

--- a/custom_components/climate_advisor/fan_thermostat_decision.py
+++ b/custom_components/climate_advisor/fan_thermostat_decision.py
@@ -98,6 +98,22 @@ def resolve_hard_exit_floor(
     return comfort_heat_raw
 
 
+def is_outdoor_rise_exit(*, indoor: float | None, outdoor: float | None) -> bool:
+    """The airflow-reversed / free-cooling-gone condition: outdoor temp has
+    risen to meet or exceed indoor, so venting no longer helps (Issue #690 —
+    single source of truth, consolidating two prior copies: this module's
+    Check 1 free-cooling-direction guard and nat_vent_exit.py's OUTDOOR_RISE
+    check, which disagreed at the exact-equality boundary).
+
+    Non-strict (``>=``): equality means no cooling benefit remains, matching
+    Check 1's existing non-strict boundary (Issue #327) rather than
+    OUTDOOR_RISE's previous strict ``>`` (Issue #690 fix — at outdoor==indoor
+    the exit now also fires, slightly earlier than before for the slow-loop
+    OUTDOOR_RISE path).
+    """
+    return outdoor is not None and indoor is not None and outdoor >= indoor
+
+
 def _resolve_vent_floor(inputs: FanThermostatInputs) -> float:
     """Pure reimplementation of Check 2's floor resolution — delegates to
     resolve_hard_exit_floor(), the single source of truth (Issue #456)."""
@@ -118,7 +134,9 @@ def decide_fan_thermostat_check(inputs: FanThermostatInputs) -> FanThermostatOut
     # --- Check 1: free-cooling direction guard (Issue #327) ---
     # Non-strict >=, NO hysteresis — this boundary is deliberately different
     # from the reactivation gate's strict < with configurable hysteresis.
-    if inputs.outdoor is not None and inputs.indoor is not None and inputs.outdoor >= inputs.indoor:
+    # Delegates to is_outdoor_rise_exit(), the single source of truth shared
+    # with nat_vent_exit.py's OUTDOOR_RISE check (Issue #690).
+    if is_outdoor_rise_exit(indoor=inputs.indoor, outdoor=inputs.outdoor):
         if inputs.natural_vent_active:
             return FanThermostatOutcome.STOP_VIA_NAT_VENT_EXIT
         return FanThermostatOutcome.STOP_DEACTIVATE

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.41"
+  "version": "0.6.42"
 }

--- a/custom_components/climate_advisor/nat_vent_exit.py
+++ b/custom_components/climate_advisor/nat_vent_exit.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 
-from .fan_thermostat_decision import resolve_hard_exit_floor
+from .fan_thermostat_decision import is_outdoor_rise_exit, resolve_hard_exit_floor
 
 # Mirrors custom_components.climate_advisor.const.MIN_VIABLE_NAT_VENT_HOURS —
 # duplicated here (a plain float constant, not logic), matching nat_vent_gate.py's
@@ -150,7 +150,15 @@ def decide_nat_vent_exit(inputs: NatVentExitInputs) -> NatVentExitDecision:
                     )
 
     # 4. Outdoor-rise exit (Issue #115) — airflow reversed.
-    if inputs.outdoor is not None and inputs.indoor is not None and inputs.outdoor > inputs.indoor:
+    # Delegates to is_outdoor_rise_exit(), the single source of truth shared
+    # with fan_thermostat_decision.py's Check 1 (Issue #690). BEHAVIOR CHANGE:
+    # this boundary was previously strict (>), disagreeing with Check 1's
+    # non-strict (>=) at exact outdoor==indoor equality — the fast-loop path
+    # would stop nat-vent one tick before this slow-loop path did. Now
+    # non-strict to match: at equality, no cooling benefit remains, so this
+    # exit now also fires immediately rather than waiting for the next check
+    # (comfort-floor/ceiling-threshold) to catch it.
+    if is_outdoor_rise_exit(indoor=inputs.indoor, outdoor=inputs.outdoor):
         return NatVentExitDecision(reason=NatVentExitReason.OUTDOOR_RISE)
 
     # 5. Ceiling-threshold exit — outdoor too warm.

--- a/tests/test_fan_thermostat_decision.py
+++ b/tests/test_fan_thermostat_decision.py
@@ -12,6 +12,7 @@ from custom_components.climate_advisor.fan_thermostat_decision import (
     FanThermostatOutcome,
     _resolve_vent_floor,
     decide_fan_thermostat_check,
+    is_outdoor_rise_exit,
     resolve_hard_exit_floor,
 )
 
@@ -119,6 +120,32 @@ class TestCheck2CooledToFloor:
 
     def test_none_indoor_never_triggers_check2(self):
         assert decide_fan_thermostat_check(_inputs(indoor=None, outdoor=65.0)) == FanThermostatOutcome.KEEP
+
+
+class TestIsOutdoorRiseExitConsolidation:
+    """Issue #690: is_outdoor_rise_exit() is the single source of truth for the
+    airflow-reversed / free-cooling-gone condition, consolidating this module's
+    own Check 1 (previously non-strict >=) and nat_vent_exit.py's OUTDOOR_RISE
+    check (previously strict >), which disagreed at exact temperature equality."""
+
+    def test_outdoor_below_indoor_is_not_reversed(self):
+        assert is_outdoor_rise_exit(indoor=74.0, outdoor=70.0) is False
+
+    def test_outdoor_equals_indoor_is_reversed(self):
+        """The boundary fix: equality now counts as reversed for BOTH call sites."""
+        assert is_outdoor_rise_exit(indoor=74.0, outdoor=74.0) is True
+
+    def test_outdoor_above_indoor_is_reversed(self):
+        assert is_outdoor_rise_exit(indoor=74.0, outdoor=75.0) is True
+
+    def test_none_indoor_is_not_reversed(self):
+        assert is_outdoor_rise_exit(indoor=None, outdoor=75.0) is False
+
+    def test_none_outdoor_is_not_reversed(self):
+        assert is_outdoor_rise_exit(indoor=74.0, outdoor=None) is False
+
+    def test_both_none_is_not_reversed(self):
+        assert is_outdoor_rise_exit(indoor=None, outdoor=None) is False
 
 
 class TestResolveHardExitFloorConsolidation:

--- a/tests/test_nat_vent_activation.py
+++ b/tests/test_nat_vent_activation.py
@@ -335,11 +335,16 @@ class TestNatVentOutdoorRiseExit:
         assert rise_events[0][1]["outdoor"] == 74.5
         assert rise_events[0][1]["indoor"] == 74.0
 
-    def test_outdoor_equal_indoor_does_not_exit(self):
-        """outdoor 74.0F == indoor 74.0F (boundary) → directional exit does NOT fire (Bug #313 fix).
+    def test_outdoor_equal_indoor_does_exit(self):
+        """outdoor 74.0F == indoor 74.0F (boundary) → directional exit DOES fire (Issue #690).
 
-        Equal temps mean neutral airflow — not reversed — so nat vent should stay active.
-        The exit condition is strict: outdoor > indoor (not >=).
+        Originally (Bug #313) this boundary was strict (outdoor > indoor, not >=), on the
+        reasoning that equal temps mean neutral airflow. Issue #690 found this disagreed with
+        fan_thermostat_decision.py's Check 1, which used non-strict >= for the identical
+        real-world condition (free-cooling-gone) — the fast-loop tick-level check would stop
+        nat-vent one tick before this slow-loop path did. Both call sites now delegate to
+        is_outdoor_rise_exit(), which is non-strict: at equality no cooling benefit remains,
+        so the exit fires immediately rather than waiting for a subsequent check to catch it.
         """
         engine = _make_engine(indoor_f=74.0)
         engine._natural_vent_active = True
@@ -353,9 +358,9 @@ class TestNatVentOutdoorRiseExit:
         with patch(_DT_NOW_PATH, return_value=datetime(2026, 4, 20, 20, 0, 0)):
             asyncio.run(engine.check_natural_vent_conditions())
 
-        assert engine._natural_vent_active is True, "nat vent must stay active when outdoor == indoor"
+        assert engine._natural_vent_active is False, "nat vent must exit when outdoor == indoor (Issue #690)"
         rise_events = [e for e in events if e[0] == "nat_vent_outdoor_rise_exit"]
-        assert len(rise_events) == 0, "nat_vent_outdoor_rise_exit must not fire on equal temps"
+        assert len(rise_events) == 1, "nat_vent_outdoor_rise_exit must fire on equal temps (Issue #690)"
 
     def test_outdoor_rise_exit_fires_before_threshold_exit(self):
         """outdoor 74.5F >= indoor 74.0F but still below threshold 75F — directional exit fires first."""
@@ -1289,28 +1294,32 @@ class TestIssue641ExitReactivationFlipFlop:
 
 
 # ---------------------------------------------------------------------------
-# Bug #313 Fix — equal outdoor==indoor should NOT exit nat vent
+# Bug #313 / Issue #690 — outdoor==indoor exit boundary
 # ---------------------------------------------------------------------------
 
 
 class TestNatVentExitEqualTemps:
-    """Bug #313: outdoor >= indoor exit condition must be strict (>), not >=.
+    """Bug #313 originally made this exit strict (outdoor > indoor, not >=), reasoning
+    that equal temps mean neutral airflow. Issue #690 revisited this: the tick-level
+    fast-loop check (fan_thermostat_decision.py's Check 1) had always used non-strict
+    >= for the identical real-world condition (free-cooling-gone/airflow-reversed),
+    so at exact equality the fast-loop path would stop nat-vent one tick before this
+    slow-loop path did. Both call sites now delegate to the shared
+    is_outdoor_rise_exit() (non-strict >=), so equality now exits on both paths.
 
-    Equal temps mean neutral airflow — not reversed.  Exiting nat vent when
-    outdoor == indoor causes the occupant to lose free cooling unnecessarily
-    every time a sensor read happens to land on exactly the same value as indoor.
-
-    These three tests document the correct post-fix semantics:
-      1. Equal temps → nat vent STAYS active  (was wrong: exited)
+    These three tests document the current, consolidated semantics:
+      1. outdoor == indoor → nat vent EXITS   (Issue #690 — boundary now matches Check 1)
       2. outdoor > indoor → nat vent exits     (regression guard, unchanged)
       3. outdoor < indoor → nat vent stays     (regression guard, unchanged)
     """
 
-    def test_equal_temps_does_not_exit_nat_vent(self):
-        """outdoor == indoor (72.0 == 72.0) → nat vent stays active after fix.
+    def test_equal_temps_exits_nat_vent(self):
+        """outdoor == indoor (72.0 == 72.0) → nat vent exits (Issue #690).
 
-        Before the fix (outdoor >= indoor) this test FAILS because the engine
-        exits nat vent on equal temps.  After the fix (outdoor > indoor) it passes.
+        Before Issue #690 (outdoor > indoor, strict) this test asserted the opposite —
+        nat vent stayed active at equality. The consolidated is_outdoor_rise_exit()
+        boundary is now non-strict (>=), matching fan_thermostat_decision.py's Check 1:
+        at equality, no cooling benefit remains, so both call sites now exit.
         """
         engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=72.0)
         engine._natural_vent_active = True
@@ -1325,12 +1334,10 @@ class TestNatVentExitEqualTemps:
         with patch(_DT_NOW_PATH, return_value=datetime(2026, 4, 20, 20, 0, 0)):
             asyncio.run(engine.check_natural_vent_conditions())
 
-        # Equal temps → airflow is neutral, not reversed → do NOT exit
-        assert engine._natural_vent_active is True, (
-            "nat vent should stay active when outdoor == indoor (neutral airflow)"
-        )
+        # Equal temps → no cooling benefit remains → exit (Issue #690)
+        assert engine._natural_vent_active is False, "nat vent must exit when outdoor == indoor (Issue #690)"
         rise_events = [e for e in events if e[0] == "nat_vent_outdoor_rise_exit"]
-        assert len(rise_events) == 0, "nat_vent_outdoor_rise_exit must NOT fire on equal temps"
+        assert len(rise_events) == 1, "nat_vent_outdoor_rise_exit must fire on equal temps (Issue #690)"
 
     def test_outdoor_above_indoor_exits_nat_vent(self):
         """outdoor > indoor (73.0 > 72.0) → nat vent exits (regression guard).

--- a/tests/test_nat_vent_exit.py
+++ b/tests/test_nat_vent_exit.py
@@ -167,9 +167,14 @@ class TestOutdoorRiseExit:
         decision = decide_nat_vent_exit(_inputs(indoor=74.0, outdoor=74.5))
         assert decision.reason == NatVentExitReason.OUTDOOR_RISE
 
-    def test_no_fire_when_outdoor_equals_indoor(self) -> None:
+    def test_fires_when_outdoor_equals_indoor(self) -> None:
+        """Issue #690: boundary was previously strict (>), so outdoor==indoor did
+        NOT fire OUTDOOR_RISE here — disagreeing with fan_thermostat_decision.py's
+        Check 1, which already used non-strict (>=) for the same real-world
+        condition. Now non-strict here too: at equality no cooling benefit
+        remains, so the exit fires immediately instead of waiting a tick."""
         decision = decide_nat_vent_exit(_inputs(indoor=74.0, outdoor=74.0))
-        assert decision.reason == NatVentExitReason.NONE
+        assert decision.reason == NatVentExitReason.OUTDOOR_RISE
 
     def test_takes_priority_over_ceiling_threshold(self) -> None:
         # outdoor > indoor AND outdoor > threshold -- outdoor-rise checked first.

--- a/tests/test_nat_vent_fsm.py
+++ b/tests/test_nat_vent_fsm.py
@@ -375,10 +375,16 @@ class TestSoftStartEscalation:
         assert t.exit_reason is None
 
     def test_stays_soft_start_when_full_gate_still_not_met(self) -> None:
-        # outdoor == indoor (parity only) -> full gate condition still fails.
+        # Issue #690: outdoor==indoor parity now fires the OUTDOOR_RISE exit (the
+        # is_outdoor_rise_exit() consolidation made that boundary non-strict), so it
+        # no longer isolates "full gate not met" from "exit chain not triggered."
+        # Use the hysteresis band instead: outdoor=73.5 is within [indoor-hysteresis,
+        # indoor) = [73.0, 74.0) -> full gate's stricter `outdoor < indoor - hysteresis`
+        # still fails (73.5 is not < 73.0), while outdoor < indoor keeps the exit
+        # chain's OUTDOOR_RISE check (outdoor >= indoor) from firing either.
         t = transition(
             NatVentLifecycleState.ACTIVE_SOFT_START,
-            _tick(indoor=74.0, outdoor=74.0, comfort_heat_raw=68.0, comfort_cool=90.0, hysteresis=0.0),
+            _tick(indoor=74.0, outdoor=73.5, comfort_heat_raw=68.0, comfort_cool=90.0, hysteresis=1.0),
         )
         assert not t.changed
         assert t.to_state == NatVentLifecycleState.ACTIVE_SOFT_START


### PR DESCRIPTION
## Summary
- Fixes #690: \`fan_thermostat_decision.py\`'s fast-loop check and \`nat_vent_exit.py\`'s \`OUTDOOR_RISE\` check both hand-computed the same real-world condition (airflow reversed, free cooling gone) with a boundary mismatch — one used \`outdoor >= indoor\`, the other \`outdoor > indoor\`. Confirmed as a true duplicate via production's own code comments and an already-shipped fix's changelog entry (\`KNOWN_FIXES[641]\`).
- Extracts a shared \`is_outdoor_rise_exit()\` into \`fan_thermostat_decision.py\` (the same module \`resolve_hard_exit_floor()\` already established as the shared home for cross-cutting nat-vent exit conditions). Both call sites now delegate to it.
- **Real, deliberate behavior change**: at exact temperature equality, the slow-loop exit chain now correctly triggers (previously it wouldn't, due to the strict \`>\`) — both loops now agree at the boundary instead of disagreeing for up to 30 minutes.
- Corrected a Debug-tab-visible reason string that still said ">" after the boundary became non-strict.
- Part of epic #594 Phase R (Phase 2e — turned out smaller and lower-risk than originally scoped: no new FSM event kind needed at all, just a shared pure-function extraction).

## Test plan
- [x] 6 new direct unit tests for \`is_outdoor_rise_exit()\` (below/at/above boundary, all None permutations)
- [x] 4 pre-existing tests updated for the boundary change — independently re-verified by a separate Verification agent, which did the arithmetic itself to confirm each was a legitimate correction, not a weakening (including one genuine test-premise collision in an unrelated soft-start test, independently confirmed by executing both input sets through the real \`transition()\`)
- [x] Full suite: 4940 passed / 6 skipped (baseline 4934 + 6 new)
- [x] \`tools/simulate.py\` full golden suite: 81/81 passed
- [x] \`ruff check\`/\`ruff format\` clean
- [x] \`test_version_sync.py\` passes (0.6.41 → 0.6.42)