### PR TITLE
Fix #757: sensor.py still read nat-vent's removed diagnostic keys

### DIFF
--- a/custom_components/climate_advisor/sensor.py
+++ b/custom_components/climate_advisor/sensor.py
@@ -497,10 +497,15 @@ class ClimateAdvisorShadowEngineStatusSensor(ClimateAdvisorBaseSensor):
         if diag is None:
             return {}
         return {
-            "production_state": diag["production_state"],
-            "shadow_state": diag["shadow_state"],
-            "nat_vent_fsm_state": diag.get("nat_vent_fsm_state"),
             "checked_at": diag["checked_at"],
+            # Issue #613/#633: nat-vent's own production/shadow/FSM state fields
+            # ("production_state"/"shadow_state"/"nat_vent_fsm_state") used to be
+            # exposed here. Issue #757 Phase 6 Step 5 removed them along with their
+            # underlying coordinator.shadow_engine_diagnostic computation (nat-vent's
+            # dispatcher is now unconditionally FSM-authoritative in production, and
+            # the diagnostic machinery feeding these keys — including the independent
+            # _evaluate_nat_vent_fsm()/_nat_vent_fsm_state replica — had zero other
+            # consumers). Same removal shape as door/window's Step 4 below.
             # Issue #660: door/window's own production/shadow/FSM state fields used to
             # be exposed here (Step 1b). Issue #757 Phase 6 Step 4 removed them along
             # with their underlying coordinator.shadow_engine_diagnostic computation

--- a/tests/test_shadow_engine_sensor.py
+++ b/tests/test_shadow_engine_sensor.py
@@ -49,40 +49,27 @@ class TestExtraStateAttributes:
         sensor = _make_sensor(None)
         assert sensor.extra_state_attributes == {}
 
-    def test_reports_both_states_and_timestamp(self) -> None:
+    def test_reports_timestamp(self) -> None:
         sensor = _make_sensor(
             {
-                "production_state": "active",
-                "shadow_state": "idle",
                 "agrees": False,
                 "checked_at": "2026-08-08T12:00:00",
             }
         )
         attrs = sensor.extra_state_attributes
-        assert attrs["production_state"] == "active"
-        assert attrs["shadow_state"] == "idle"
         assert attrs["checked_at"] == "2026-08-08T12:00:00"
 
-    def test_reports_nat_vent_fsm_state_when_present(self) -> None:
-        """Issue #633: the independent nat-vent FSM's own tracked state."""
-        sensor = _make_sensor(
-            {
-                "production_state": "active_full_gate",
-                "shadow_state": "active_full_gate",
-                "nat_vent_fsm_state": "inactive",
-                "agrees": False,
-                "checked_at": "2026-08-08T12:00:00",
-            }
-        )
-        assert sensor.extra_state_attributes["nat_vent_fsm_state"] == "inactive"
-
-    def test_nat_vent_fsm_state_absent_before_first_fsm_evaluation(self) -> None:
-        """A diagnostic recomputed from a mirrored call other than
-        check_natural_vent_conditions (v1 scope) never populated the FSM key."""
-        sensor = _make_sensor(
-            {"production_state": "active", "shadow_state": "idle", "agrees": False, "checked_at": "t"}
-        )
-        assert sensor.extra_state_attributes["nat_vent_fsm_state"] is None
+    # Issue #757 Phase 6 Step 5: test_reports_both_states_and_timestamp (renamed
+    # test_reports_timestamp above, "production_state"/"shadow_state" assertions
+    # dropped), test_reports_nat_vent_fsm_state_when_present, and
+    # test_nat_vent_fsm_state_absent_before_first_fsm_evaluation were removed —
+    # nat-vent's own production/shadow/FSM state fields were removed from
+    # ClimateAdvisorShadowEngineStatusSensor.extra_state_attributes along with their
+    # underlying coordinator.shadow_engine_diagnostic computation (nat-vent's
+    # dispatcher is now unconditionally FSM-authoritative in production, and the
+    # diagnostic machinery feeding these keys — including the independent
+    # _evaluate_nat_vent_fsm()/_nat_vent_fsm_state replica — had zero other
+    # consumers). Same removal shape as door/window's Step 4 below.
 
     # Issue #757 Phase 6 Step 4: test_reports_door_window_fields_when_present and
     # test_door_window_fields_absent_before_first_evaluation (Issue #660) were removed


### PR DESCRIPTION
## Summary

Follow-up hotfix to Phase 6 Step 5 (PR #766, merged and deployed). \`ClimateAdvisorShadowEngineStatusSensor.extra_state_attributes\` in \`sensor.py\` still indexed \`diag["production_state"]\`/\`diag["shadow_state"]\`/\`diag.get("nat_vent_fsm_state")\` directly — Step 5 removed those keys from \`coordinator.shadow_engine_diagnostic\` (nat-vent's dispatcher is now unconditionally FSM-authoritative) but missed this one remaining consumer, since \`sensor.py\` wasn't touched in that PR's diff.

**Live impact, confirmed via \`ha_logs.py\` immediately post-deploy**: \`Unexpected error updating listener ... File sensor.py, line 500, in extra_state_attributes\` on every coordinator update cycle. No HVAC control impact — this sensor is diagnostic-only — but a real, continuously-firing error that needed fixing before the deploy could be called clean.

Fix mirrors the removal shape door/window's Step 4 already established for its own analogous fields in the same method (see the comment immediately below in the diff).

## Test plan

- [x] Full test suite green (5170 passed, 6 skipped)
- [x] \`ruff check\`/\`format\` clean
- [x] \`python tools/simulate.py\` full golden-corpus green (91/91)