### PR TITLE
Fix #755: arm reactivation lockout on fan_thermostat_check's cooled-to-floor exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.75] — 2026-08-29
+
+- Fix #755: closes a gap where the whole-house fan (or HVAC fan) could briefly turn back on right after stopping because indoor cooled to your comfort floor. The fast, tick-level check that stops the fan at the floor now waits out the same 5-minute cooldown other stop reasons already respect, instead of letting the fan restart the moment indoor ticks up by even 1°F.
+
 ## [0.6.74] — 2026-08-27
 
 - Feat #757: no user-visible change. Strangler-fig graduation Phase 6 Step 8 — collapses the dual-engine shadow-comparison shell. With every subsystem's legacy/FSM cutover flag already gone (Steps 1-7), the coordinator's two live AutomationEngine instances had become behaviorally identical, so the second (shadow) instance, its diagnostic sensor, its primary-switch entity, and the comparison plumbing between them are no longer needed. One internal safety detail: 8 call sites that fed the override/grace FSM as a side effect of the now-removed mirroring call were rewired to feed it directly, so that FSM keeps receiving the same events it always did. Also removed a dead historical-scenario tool mode whose only data source (the shadow-comparison diagnostic) no longer exists.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -4976,8 +4976,19 @@ class AutomationEngine:
                 "fan_mode": self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED),
                 "fan_device": _fan_device_label(self.config),
             }
+        # Issue #755: previously omitted set_outdoor_exit_time here on the same
+        # "self-complementary at a fixed reading" reasoning already disproven for
+        # nat_vent_temperature_check()'s COMFORT_FLOOR exit (Issue #696) — indoor
+        # legitimately drifts across vent_floor_ftc between ticks in production, so exit
+        # and re-entry are not actually self-complementary. This tick-level check runs on
+        # every sensor update (not just the 30-min cycle #696 hit), so the exposure window
+        # is at least as wide. Arm the same 300s lockout as this method's other two exit
+        # branches above, so a sensor-still-open pause here gets the same anti-flap
+        # protection at the idle-open re-entry path check_natural_vent_conditions() already
+        # consults (fixed by #696).
         await self._exit_nat_vent(
             reason=f"fan thermostat check — {stop_reason}",
+            set_outdoor_exit_time=True,
             event_type=_event_type,
             event_payload=_event_payload,
         )

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,16 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.74"
+VERSION = "0.6.75"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.75": [
+        "Fix #755: closes a gap where the whole-house fan (or HVAC fan) could briefly"
+        " turn back on right after stopping because indoor cooled to your comfort"
+        " floor. The fast, tick-level check that stops the fan at the floor now waits"
+        " out the same 5-minute cooldown other stop reasons already respect, instead"
+        " of letting the fan restart the moment indoor ticks up by even 1°F.",
+    ],
     "0.6.74": [
         "Feat #757: no user-visible change. Strangler-fig graduation Phase 6 Step 8"
         " — collapses the dual-engine shadow-comparison shell. With every subsystem's"
@@ -2359,6 +2366,42 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    755: {
+        "version_fixed": "0.6.75",
+        "title": (
+            "Closed a sibling gap to #696, found during that fix's own blast-radius"
+            " check and filed separately rather than expanding its scope:"
+            " fan_thermostat_check()'s STOP_COOLED_TO_FLOOR exit (Check 2, 'cooled to"
+            " target') never armed the nat-vent reactivation lockout"
+            " (_nat_vent_outdoor_exit_time), on the same 'self-complementary at a fixed"
+            " reading' reasoning #696 already disproved for"
+            " nat_vent_temperature_check()'s COMFORT_FLOOR exit — indoor legitimately"
+            " drifts across the floor between ticks in production. The idle-open"
+            " re-entry path #696 fixed to consult is_reactivation_locked_out() was a"
+            " no-op for this exit specifically because the lockout timer was never set."
+            " fan_thermostat_check() also runs on every indoor/outdoor sensor update"
+            " (not just the 5-min backstop), so the exposure window was at least as"
+            " wide as #696's. Fix: armed set_outdoor_exit_time=True on this exit,"
+            " matching its two sibling branches in the same method. Investigation also"
+            " confirmed this was the only remaining registry entry using the disproven"
+            " reasoning — no further blast radius. No new pending/golden simulation"
+            " scenario was added: tools/simulations/unsupported/"
+            " issue_620_fast_loop_floor_exit_pauses_with_window_open.json already"
+            " documents 4 failed attempts (Issue #620) to isolate this exact code path"
+            " end-to-end in the harness (nat_vent_temperature_check() intercepts it"
+            " first whenever nat-vent is active), so a direct unit test"
+            " (test_stop_cooled_to_floor_arms_reactivation_lockout in"
+            " tests/test_fan_control.py) was added instead, following that precedent."
+        ),
+        "scope_covered": (
+            "custom_components/climate_advisor/automation.py"
+            " fan_thermostat_check() STOP_COOLED_TO_FLOOR branch;"
+            " nat_vent_reactivation_lockout.py docstring correction;"
+            " tests/test_nat_vent_exit_lockout_coverage.py registry entry"
+            " (fan_thermostat_check, 3); tests/test_fan_control.py new unit test;"
+            " docs/nat-vent-lifecycle-spec.md"
+        ),
+    },
     757: {
         "version_fixed": "0.6.66-0.6.69",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.74"
+  "version": "0.6.75"
 }

--- a/custom_components/climate_advisor/nat_vent_reactivation_lockout.py
+++ b/custom_components/climate_advisor/nat_vent_reactivation_lockout.py
@@ -2,10 +2,11 @@
 
 Guards against rapid re-activation flapping right after an exit that arms
 `_nat_vent_outdoor_exit_time` (originally only the outdoor-warm-rise exit; as
-of Issue #641/#696 also the proactive-floor, ceiling-threshold, and
-comfort-floor exits — see `_exit_nat_vent()` call sites in `automation.py` for
-the current, authoritative list, since it has grown more than once and this
-docstring should not be trusted as the enumeration).
+of Issue #641/#696/#755 also the proactive-floor, ceiling-threshold,
+comfort-floor, and fan_thermostat_check()'s STOP_COOLED_TO_FLOOR exits — see
+`_exit_nat_vent()` call sites in `automation.py` for the current, authoritative
+list, since it has grown more than once and this docstring should not be
+trusted as the enumeration).
 
 As of Issue #696, this is consulted at TWO call sites in
 `check_natural_vent_conditions()`: the paused-by-door reactivation block, and

--- a/docs/nat-vent-lifecycle-spec.md
+++ b/docs/nat-vent-lifecycle-spec.md
@@ -9,7 +9,7 @@
 | What are the 4 nat-vent session states and how do they map to flags? | `INACTIVE`, `ACTIVE_FULL_GATE`, `ACTIVE_SOFT_START`, `PAUSED_REACTIVATION_LOCKOUT` — derived purely from `_natural_vent_active`/`_nat_vent_soft_start`/`_paused_by_door`/`_nat_vent_outdoor_exit_time`. | [State Transitions](#state-transitions) |
 | Where is the derivation computed, and is it load-bearing? | `nat_vent_lifecycle.py::derive_nat_vent_lifecycle_state()`, exposed read-only via `AutomationEngine.nat_vent_lifecycle_state`. Purely observational — not called from any production decision path. | [Scope](#scope) |
 | Does every nat-vent exit hand off through the same choke point? | No — `_exit_nat_vent()` is the choke point for most exits (10 call sites, per `tests/test_nat_vent_exit_lockout_coverage.py`'s AST scan), but the comfort-floor exit inside `check_natural_vent_conditions()`, the away-mode ceiling exit, the ODE ceiling-escalation exit, and two reconcile/bedtime paths mutate the flags directly instead. | [Exit Paths](#exit-paths-not-unified-through-a-single-function) |
-| What is the reactivation lockout and how long is it? | 300s default (`NAT_VENT_REACTIVATION_LOCKOUT_S`). Originally armed only by the outdoor-warm-rise exit; Issue #641 extended arming to the proactive-floor, ceiling-threshold, and fan_thermostat_check's tick-level direction-reversal exits; Issue #696 extended it to the comfort-floor exit and — separately — wired the idle-open re-entry call site (previously unchecked entirely, see next row) to actually consult it. | [State Transitions](#state-transitions) |
+| What is the reactivation lockout and how long is it? | 300s default (`NAT_VENT_REACTIVATION_LOCKOUT_S`). Originally armed only by the outdoor-warm-rise exit; Issue #641 extended arming to the proactive-floor, ceiling-threshold, and fan_thermostat_check's tick-level direction-reversal exits; Issue #696 extended it to the comfort-floor exit and — separately — wired the idle-open re-entry call site (previously unchecked entirely, see next row) to actually consult it; Issue #755 closed the sibling gap #696 found but didn't fix — fan_thermostat_check()'s STOP_COOLED_TO_FLOOR exit now arms it too, on the same disproven "self-complementary at a fixed reading" reasoning #696 already disproved for the comfort-floor exit. | [State Transitions](#state-transitions) |
 | What happens when nat-vent exits and the sensor is still open — pause or grace? | `_exit_nat_vent()` forks: sensor still open → hands off into the pause lifecycle; sensors closed → hands off into the grace lifecycle. See `grace-periods-spec.md` for what happens next in either lifecycle. | [Handoff to Pause/Grace](#handoff-to-pausegrace) |
 | How was this spec's accuracy verified? | Differential replay: `derive_nat_vent_lifecycle_state()` run against the real final engine flags from all 74 golden + 4 pending scenarios (Issue #606), plus 3 hand-reasoned ground-truth scenarios. | [Verification](#verification) |
 | Is every `_exit_nat_vent()` call site's lockout-arming decision enforced, not just documented? | Yes — `tests/test_nat_vent_exit_lockout_coverage.py` AST-scans every call site and requires each to be explicitly classified `"arms lockout"` / `"exempted: <reason>"`, with a positive control that checks the claim against the actual `set_outdoor_exit_time=True` argument (Issue #641). | [Incident: WHF fast-cycling](#incident-whf-fast-cycling-proactive-floor-exit-vs-instant-reactivation-issue-641) |
@@ -285,6 +285,61 @@ the reported incident, elapsed time between exit and reactivation was ≈300.02s
 right at the lockout's edge; the fix closes the "never checked at all" gap
 unconditionally, but does not guarantee every occurrence lands outside the lockout
 window by a comfortable margin. Tracked as separate follow-up work, not fixed here.
+
+### Incident: STOP_COOLED_TO_FLOOR shared #696's disproven reasoning (Issue #755)
+
+Found during #696's own blast-radius check, filed separately rather than expanding that
+fix's scope: `fan_thermostat_check()`'s `STOP_COOLED_TO_FLOOR` exit (Check 2, "cooled to
+target") was exempted from arming the reactivation lockout in
+`tests/test_nat_vent_exit_lockout_coverage.py`'s coverage registry using the exact same
+"self-complementary at a fixed reading" reasoning #696 disproved for
+`nat_vent_temperature_check()`'s `COMFORT_FLOOR` exit — the claim that exit and re-entry
+check the same `comfort_heat`-derived floor and so can't both be satisfied by the same
+indoor reading. It was never disproven for this call site specifically, but shares the
+identical structure: `_exit_nat_vent()` is the same choke point, produces the same
+`_paused_by_door=True`/`_paused_with_hvac_already_off=True` combination when the sensor is
+still open and HVAC was already off (the normal case during WHF-only free cooling), and
+the idle-open re-entry path #696 fixed already consults `is_reactivation_locked_out()` for
+this pause — but that check is a no-op when `_nat_vent_outdoor_exit_time` was never set,
+which was exactly this exit's gap. `fan_thermostat_check()` also runs on every indoor/
+outdoor sensor update (not just the 5-min backstop), so the exposure window is at least as
+wide as #696's.
+
+Fix: armed `set_outdoor_exit_time=True` on this exit, identical in shape to #696's
+`COMFORT_FLOOR` fix. No FSM/legacy branch split was needed here (unlike #696) —
+`fan_fsm.py`'s `_transition_on_thermostat_check_tick()` only returns the outcome enum and
+deliberately leaves all `_exit_nat_vent()`/exit-time bookkeeping to the shell, so a single
+call-site edit was sufficient. A blast-radius re-check of every other registry entry found
+no further instances of the disproven reasoning — this was the last one.
+
+**When STOP_COOLED_TO_FLOOR is actually the deciding exit, not preempted**: re-reading
+`_handle_temp_update()` (`tools/sim_harness/run_production.py`) and the real
+`_async_thermostat_changed()` listener (`coordinator.py:3860-3887`) found that when a
+nat-vent session is active, `nat_vent_temperature_check()` is always dispatched first on
+the same tick and, since it checks the identical floor, almost always exits (and turns the
+fan off) before `fan_thermostat_check()` gets a turn — its own comment calls the second
+call "idempotent... safe" precisely because the fan is usually already off by then. So in
+practice `STOP_COOLED_TO_FLOOR` is the deciding exit mainly for a CA-owned fan running
+*independent* of a nat-vent session (e.g. a min-runtime cycling fan started via
+`start_min_fan_runtime_cycles()`), the `_was_nat_vent_floor=False` branch — not the
+nat-vent-active case #696's incident was. The fix and its unit-test coverage (below) are
+correct regardless of which branch triggers it, since `_exit_nat_vent()`'s pause/lockout
+mechanics don't depend on the nat-vent-active label; this is a precondition-accuracy note
+for future readers, not a scope change.
+
+**No new pending/golden simulation scenario added** — `tools/simulations/unsupported/
+issue_620_fast_loop_floor_exit_pauses_with_window_open.json` already documents 4 separate,
+failed attempts to isolate `fan_thermostat_check()`'s `STOP_COOLED_TO_FLOOR` outcome
+end-to-end in this harness (the earlier-firing `nat_vent_temperature_check()` intercepts it
+in engine-only mode; the `seed:true` sensor flag is silently ignored in engine-only mode;
+a real coordinator's scheduled triggers pause the sensor first via a different choke point;
+and a neutral-time real-coordinator run produced no observable effect before investigation
+time ran out) — and settled on unit-test coverage in `tests/test_fan_control.py` as the
+verification method for this exact code path instead. Issue #755 follows that same
+precedent rather than re-attempting the harness isolation: `TestFanThermostatCheck::
+test_stop_cooled_to_floor_arms_reactivation_lockout` calls `fan_thermostat_check()`
+directly (bypassing the temp_update dispatch race entirely) and was verified to fail
+against pre-fix code and pass after.
 
 ### Follow-up: rate-limit reporting was misleading and mis-framed as an incident (Issue #649)
 

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -2178,6 +2178,27 @@ class TestFanThermostatCheck:
             "STOP_DEACTIVATE must arm the same reactivation lockout as its sibling STOP_VIA_NAT_VENT_EXIT branch"
         )
 
+    def test_stop_cooled_to_floor_arms_reactivation_lockout(self):
+        """Issue #755: STOP_COOLED_TO_FLOOR previously omitted set_outdoor_exit_time=True on
+        the same "self-complementary at a fixed reading" reasoning already disproven for
+        nat_vent_temperature_check()'s COMFORT_FLOOR exit (Issue #696) — indoor legitimately
+        drifts across the floor between ticks in production, and this tick-level check fires
+        on every sensor update (a higher-frequency trigger than #696's), so the exposure
+        window is at least as wide. Fixed to match its two sibling branches above."""
+        engine = self._engine()
+        engine._natural_vent_active = True
+        engine._fan_active = True
+        engine._sensor_check_callback = lambda: True  # window still open at exit
+
+        asyncio.run(engine.fan_thermostat_check(indoor=68.0, outdoor=60.0, trigger="test"))
+
+        engine._deactivate_fan.assert_awaited()
+        assert engine._natural_vent_active is False
+        assert engine._nat_vent_outdoor_exit_time is not None, (
+            "Issue #755: STOP_COOLED_TO_FLOOR must arm the same reactivation lockout as its "
+            "STOP_VIA_NAT_VENT_EXIT/STOP_DEACTIVATE siblings"
+        )
+
     def test_noop_when_override_active(self):
         """Manual fan override in effect → fast loop is a no-op (user has control)."""
         engine = self._engine()

--- a/tests/test_nat_vent_exit_lockout_coverage.py
+++ b/tests/test_nat_vent_exit_lockout_coverage.py
@@ -93,8 +93,11 @@ _COVERAGE_REGISTRY: dict[tuple[str, int], str] = {
         "nat-vent-active gate — found unarmed during this issue's own coverage audit"
     ),
     ("fan_thermostat_check", 3): (
-        "exempted: STOP_COOLED_TO_FLOOR (Check 2) — same self-complementary-floor reasoning "
-        "as nat_vent_temperature_check's hard-floor exit above"
+        "arms lockout — Issue #755: STOP_COOLED_TO_FLOOR (Check 2) previously exempted on "
+        "the same self-complementary-floor reasoning as nat_vent_temperature_check's "
+        "hard-floor exit — disproven by Issue #696's live incident (indoor drifts across "
+        "the floor between ticks). This tick-level check runs on every sensor update, a "
+        "higher-frequency trigger than #696's, so now sets set_outdoor_exit_time=True too."
     ),
     ("_reconcile_fan_on_startup_locked", 1): (
         "exempted: startup/periodic reconciliation, not a per-tick decision path — runs at "


### PR DESCRIPTION
## Summary
- `fan_thermostat_check()`'s `STOP_COOLED_TO_FLOOR` exit never armed the nat-vent reactivation lockout (`set_outdoor_exit_time=True`), on the same "self-complementary at a fixed reading" reasoning already disproven for `nat_vent_temperature_check()`'s `COMFORT_FLOOR` exit by the live #696 incident (indoor legitimately drifts across the floor between ticks). This check runs on every sensor update, so the exposure window was at least as wide as #696's.
- Fix: pass `set_outdoor_exit_time=True` on this exit, matching its two sibling branches (`STOP_VIA_NAT_VENT_EXIT`, `STOP_DEACTIVATE`) in the same method. No FSM/legacy split needed — `fan_fsm.py` leaves all exit-time bookkeeping to the shell.
- Updated the AST-enforced lockout coverage registry (`tests/test_nat_vent_exit_lockout_coverage.py`) and `nat_vent_reactivation_lockout.py`'s docstring accordingly.
- Blast-radius re-check of every other registry entry found no further instances of the disproven reasoning — this closes the last one.
- No new pending/golden simulation scenario: `tools/simulations/unsupported/issue_620_fast_loop_floor_exit_pauses_with_window_open.json` already documents 4 failed attempts (Issue #620) to isolate this exact code path end-to-end in the harness (`nat_vent_temperature_check()` intercepts it first whenever nat-vent is active). Added a direct unit test instead, following that precedent.
- Version bump to 0.6.75 with RELEASE_NOTES/KNOWN_FIXES/CHANGELOG entries per project convention.

## Test plan
- [x] `tests/test_fan_control.py::TestFanThermostatCheck::test_stop_cooled_to_floor_arms_reactivation_lockout` — new, verified to fail pre-fix and pass post-fix
- [x] `tests/test_nat_vent_exit_lockout_coverage.py` — registry/code agreement tests pass
- [x] Full targeted sweep: `pytest tests/ -k "fan_thermostat or nat_vent"` — 706 passed, 6 skipped
- [x] Full suite: `pytest tests/` — 4823 passed, 6 skipped
- [x] `python tools/simulate.py` — 91/91 golden scenarios passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] `tests/test_version_sync.py` — passes

Closes #755.