### PR TITLE
Fix #739: WHF reactivated with zero cooldown after a comfort-floor exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.76] — 2026-08-29
+
+- Fix #739: the whole-house fan could reactivate seconds after shutting off because indoor dropped below your comfort floor — pulling in cold outside air again and pushing the home right back under the floor it had just recovered from. The comfort-floor stop now waits out the same 5-minute cooldown every other stop reason already respects.
+
 ## [0.6.75] — 2026-08-29
 
 - Fix #755: closes a gap where the whole-house fan (or HVAC fan) could briefly turn back on right after stopping because indoor cooled to your comfort floor. The fast, tick-level check that stops the fan at the floor now waits out the same 5-minute cooldown other stop reasons already respect, instead of letting the fan restart the moment indoor ticks up by even 1°F.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -4065,8 +4065,22 @@ class AutomationEngine:
                     # _pre_fan_hvac_mode snapshot — those are different restore-target semantics
                     # that need their own decision, not a mechanical swap. Flagged as a known
                     # follow-up, out of scope for #620.
+                    #
+                    # Issue #739: this branch bypasses _exit_nat_vent() entirely, so it never
+                    # armed the reactivation lockout the way every sibling exit reason in this
+                    # method (and, since #696/#755, both COMFORT_FLOOR-class fast-path twins)
+                    # already does — the exact "self-complementary at a fixed reading" gap #696
+                    # disproved, just unnoticed here because this branch's own bypass makes it
+                    # invisible to the _exit_nat_vent()-only AST coverage scan. Confirmed live:
+                    # a comfort-floor exit here on 2026-08-22 left indoor still below the
+                    # 70-72F daytime band, and the WHF reactivated within a minute on a
+                    # ~1F uptick, immediately re-breaching the floor it had just exited to
+                    # protect. Set the exit time directly (this branch has no
+                    # set_outdoor_exit_time kwarg to pass, same as the AWAY_CEILING branch
+                    # below).
                     _vent_floor = exit_decision.vent_floor
                     self._natural_vent_active = False
+                    self._nat_vent_outdoor_exit_time = dt_util.now()
                     await self._deactivate_fan(
                         reason=(f"natural vent exit: indoor {indoor:.1f}°F ≤ comfort floor {_vent_floor:.1f}°F")
                     )

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,16 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.75"
+VERSION = "0.6.76"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.76": [
+        "Fix #739: the whole-house fan could reactivate seconds after shutting off"
+        " because indoor dropped below your comfort floor — pulling in cold outside"
+        " air again and pushing the home right back under the floor it had just"
+        " recovered from. The comfort-floor stop now waits out the same 5-minute"
+        " cooldown every other stop reason already respects.",
+    ],
     "0.6.75": [
         "Fix #755: closes a gap where the whole-house fan (or HVAC fan) could briefly"
         " turn back on right after stopping because indoor cooled to your comfort"
@@ -2366,6 +2373,41 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    739: {
+        "version_fixed": "0.6.76",
+        "title": (
+            "A production incident (2026-08-22) showed the whole-house fan reactivating"
+            " within a minute of a comfort-floor exit — pulling in cold outside air and"
+            " re-breaching the same floor it had just exited to protect, while a"
+            " monitored window stayed open. Root cause: check_natural_vent_conditions()'s"
+            " own COMFORT_FLOOR branch bypasses _exit_nat_vent() entirely (a direct"
+            " _deactivate_fan() call, per its own Issue #620 note), so it never armed"
+            " _nat_vent_outdoor_exit_time — the field the existing 5-minute reactivation"
+            " lockout reads. This is the same 'self-complementary at a fixed reading'"
+            " reasoning already disproved by #696/#755 for two sibling exit branches,"
+            " just on a third call site the AST-scan coverage registry in"
+            " tests/test_nat_vent_exit_lockout_coverage.py structurally cannot see"
+            " (it only keys on literal _exit_nat_vent() calls, and this branch never"
+            " makes one). Fix: set _nat_vent_outdoor_exit_time directly at this call"
+            " site, the same pattern the AWAY_CEILING branch in the same method already"
+            " uses. Blast-radius check: re-read every golden/pending scenario touching a"
+            " comfort-floor exit + reactivation; the one that does (golden scenario"
+            " whf_reactivates_after_sleep_floor_exit, #402) reactivates 70 minutes"
+            " later, far outside the 5-min lockout, so it is unaffected. Verified with a"
+            " direct unit test (test_comfort_floor_exit_arms_reactivation_lockout in"
+            " tests/test_fan_control.py) rather than a new pending scenario, following"
+            " the same precedent #755 used for a similarly race-prone harness path."
+        ),
+        "scope_covered": (
+            "custom_components/climate_advisor/automation.py"
+            " check_natural_vent_conditions() COMFORT_FLOOR branch;"
+            " nat_vent_reactivation_lockout.py docstring correction;"
+            " tests/test_nat_vent_exit_lockout_coverage.py docstring note (no registry"
+            " entry — this call site makes no _exit_nat_vent() call to key on);"
+            " tests/test_fan_control.py new unit test;"
+            " docs/nat-vent-lifecycle-spec.md"
+        ),
+    },
     755: {
         "version_fixed": "0.6.75",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.75"
+  "version": "0.6.76"
 }

--- a/custom_components/climate_advisor/nat_vent_reactivation_lockout.py
+++ b/custom_components/climate_advisor/nat_vent_reactivation_lockout.py
@@ -2,11 +2,25 @@
 
 Guards against rapid re-activation flapping right after an exit that arms
 `_nat_vent_outdoor_exit_time` (originally only the outdoor-warm-rise exit; as
-of Issue #641/#696/#755 also the proactive-floor, ceiling-threshold,
-comfort-floor, and fan_thermostat_check()'s STOP_COOLED_TO_FLOOR exits — see
+of Issue #641/#696/#755/#739 also the proactive-floor, ceiling-threshold,
+comfort-floor (both its `_exit_nat_vent()`-routed fast-path twin and, as of
+#739, `check_natural_vent_conditions()`'s own direct-`_deactivate_fan()`
+branch), and fan_thermostat_check()'s STOP_COOLED_TO_FLOOR exits — see
 `_exit_nat_vent()` call sites in `automation.py` for the current, authoritative
 list, since it has grown more than once and this docstring should not be
 trusted as the enumeration).
+
+Issue #739: `check_natural_vent_conditions()`'s own `COMFORT_FLOOR` branch was
+the last unarmed comfort-floor exit — it bypasses `_exit_nat_vent()` entirely
+(direct `_deactivate_fan()` call, per that branch's own Issue #620 note), so it
+never set this field even after #696/#755 fixed the two `_exit_nat_vent()`-
+routed comfort-floor twins on the same "self-complementary at a fixed reading"
+reasoning. Confirmed live on 2026-08-22: this exit fired with a monitored
+window still open and HVAC already idle, and the WHF reactivated within a
+minute on a ~1F uptick, immediately re-breaching the floor it had just exited
+to protect. Fixed by setting `_nat_vent_outdoor_exit_time` directly at that
+call site, the same pattern the `AWAY_CEILING` branch in the same method
+already used for the identical reason.
 
 As of Issue #696, this is consulted at TWO call sites in
 `check_natural_vent_conditions()`: the paused-by-door reactivation block, and

--- a/docs/nat-vent-lifecycle-spec.md
+++ b/docs/nat-vent-lifecycle-spec.md
@@ -9,7 +9,7 @@
 | What are the 4 nat-vent session states and how do they map to flags? | `INACTIVE`, `ACTIVE_FULL_GATE`, `ACTIVE_SOFT_START`, `PAUSED_REACTIVATION_LOCKOUT` — derived purely from `_natural_vent_active`/`_nat_vent_soft_start`/`_paused_by_door`/`_nat_vent_outdoor_exit_time`. | [State Transitions](#state-transitions) |
 | Where is the derivation computed, and is it load-bearing? | `nat_vent_lifecycle.py::derive_nat_vent_lifecycle_state()`, exposed read-only via `AutomationEngine.nat_vent_lifecycle_state`. Purely observational — not called from any production decision path. | [Scope](#scope) |
 | Does every nat-vent exit hand off through the same choke point? | No — `_exit_nat_vent()` is the choke point for most exits (10 call sites, per `tests/test_nat_vent_exit_lockout_coverage.py`'s AST scan), but the comfort-floor exit inside `check_natural_vent_conditions()`, the away-mode ceiling exit, the ODE ceiling-escalation exit, and two reconcile/bedtime paths mutate the flags directly instead. | [Exit Paths](#exit-paths-not-unified-through-a-single-function) |
-| What is the reactivation lockout and how long is it? | 300s default (`NAT_VENT_REACTIVATION_LOCKOUT_S`). Originally armed only by the outdoor-warm-rise exit; Issue #641 extended arming to the proactive-floor, ceiling-threshold, and fan_thermostat_check's tick-level direction-reversal exits; Issue #696 extended it to the comfort-floor exit and — separately — wired the idle-open re-entry call site (previously unchecked entirely, see next row) to actually consult it; Issue #755 closed the sibling gap #696 found but didn't fix — fan_thermostat_check()'s STOP_COOLED_TO_FLOOR exit now arms it too, on the same disproven "self-complementary at a fixed reading" reasoning #696 already disproved for the comfort-floor exit. | [State Transitions](#state-transitions) |
+| What is the reactivation lockout and how long is it? | 300s default (`NAT_VENT_REACTIVATION_LOCKOUT_S`). Originally armed only by the outdoor-warm-rise exit; Issue #641 extended arming to the proactive-floor, ceiling-threshold, and fan_thermostat_check's tick-level direction-reversal exits; Issue #696 extended it to the comfort-floor exit (`nat_vent_temperature_check()`'s `_exit_nat_vent()`-routed twin) and — separately — wired the idle-open re-entry call site (previously unchecked entirely, see next row) to actually consult it; Issue #755 closed the sibling gap #696 found but didn't fix — fan_thermostat_check()'s STOP_COOLED_TO_FLOOR exit now arms it too; Issue #739 closed the last comfort-floor sibling gap — `check_natural_vent_conditions()`'s own COMFORT_FLOOR branch, which bypasses `_exit_nat_vent()` entirely and so was invisible to the coverage registry, now sets the exit time directly. All three shared the same disproven "self-complementary at a fixed reading" reasoning #696 first disproved. | [State Transitions](#state-transitions) |
 | What happens when nat-vent exits and the sensor is still open — pause or grace? | `_exit_nat_vent()` forks: sensor still open → hands off into the pause lifecycle; sensors closed → hands off into the grace lifecycle. See `grace-periods-spec.md` for what happens next in either lifecycle. | [Handoff to Pause/Grace](#handoff-to-pausegrace) |
 | How was this spec's accuracy verified? | Differential replay: `derive_nat_vent_lifecycle_state()` run against the real final engine flags from all 74 golden + 4 pending scenarios (Issue #606), plus 3 hand-reasoned ground-truth scenarios. | [Verification](#verification) |
 | Is every `_exit_nat_vent()` call site's lockout-arming decision enforced, not just documented? | Yes — `tests/test_nat_vent_exit_lockout_coverage.py` AST-scans every call site and requires each to be explicitly classified `"arms lockout"` / `"exempted: <reason>"`, with a positive control that checks the claim against the actual `set_outdoor_exit_time=True` argument (Issue #641). | [Incident: WHF fast-cycling](#incident-whf-fast-cycling-proactive-floor-exit-vs-instant-reactivation-issue-641) |
@@ -340,6 +340,44 @@ precedent rather than re-attempting the harness isolation: `TestFanThermostatChe
 test_stop_cooled_to_floor_arms_reactivation_lockout` calls `fan_thermostat_check()`
 directly (bypassing the temp_update dispatch race entirely) and was verified to fail
 against pre-fix code and pass after.
+
+### Incident: check_natural_vent_conditions()'s own COMFORT_FLOOR branch shared the same disproven reasoning (Issue #739)
+
+Reported 2026-08-22: the wake-up routine's 06:30 comfort-floor exit (indoor 65°F, well
+below the 68°F floor) left the window open and HVAC off, as expected. But indoor drifted
+back up to ~69°F over the next hour (confirmed against real sensor history — a smooth,
+continuous rise consistent with morning ambient/solar gain, not a sensor glitch), and at
+07:29 the WHF reactivated with zero cooldown, immediately pulling in 59°F outside air and
+re-breaching the same floor it had just exited to protect (a fresh `comfort_undertemp`
+incident at 07:59, and a 2-minute WHF on/off flap around 09:00-09:02). The stated
+reactivation reasoning ("outdoor cooled below indoor," "free cooling still favorable") was
+literally true but not correct for the occupant — reactivating actively worked against the
+comfort floor the exit had just protected.
+
+Distinct from both #696 and #755: `check_natural_vent_conditions()`'s own `COMFORT_FLOOR`
+branch (the direct-`_deactivate_fan()` one described in this branch's own Issue #620 note,
+NOT the `_exit_nat_vent()`-routed fast-path twin in `nat_vent_temperature_check()` that #696
+already fixed) never armed `_nat_vent_outdoor_exit_time` at all. It bypasses
+`_exit_nat_vent()` entirely, so `tests/test_nat_vent_exit_lockout_coverage.py`'s AST-scan
+registry — which keys only on literal `self._exit_nat_vent(...)` calls — cannot see this
+site and never flagged it as unclassified. This is the same "self-complementary at a fixed
+reading" gap #696/#755 already disproved for their respective sibling branches, just on a
+third call site the registry structurally can't reach.
+
+Fix: set `_nat_vent_outdoor_exit_time` directly in this branch (it has no
+`set_outdoor_exit_time` kwarg to pass, since it never calls `_exit_nat_vent()`), the same
+direct-assignment pattern the `AWAY_CEILING` branch in the same method already uses for the
+identical reason. Verified with a direct unit test
+(`TestNatVentComfortFloorExit::test_comfort_floor_exit_arms_reactivation_lockout`), the same
+verification approach #755 used, since this branch is exercised by the existing golden
+scenario `whf_reactivates_after_sleep_floor_exit` (confirmed unaffected — its reactivation
+lands 70 minutes after the exit, far outside the 300s lockout window).
+
+**Blast-radius check**: re-read every golden/pending scenario touching a comfort-floor exit
+followed by reactivation; none exercise a reactivation faster than 5 minutes after this
+specific branch's exit, so no existing scenario needed revision. This closes the last known
+comfort-floor-exit call site with the disproven reasoning; see
+`nat_vent_reactivation_lockout.py`'s module docstring for the current, authoritative list.
 
 ### Follow-up: rate-limit reporting was misleading and mis-framed as an incident (Issue #649)
 

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -1725,6 +1725,25 @@ class TestNatVentComfortFloorExit:
         assert "indoor_temp" in comfort_floor_call[0][1]
         assert "fan_device" in comfort_floor_call[0][1], "Issue #402: exit events must identify the fan mechanism"
 
+    def test_comfort_floor_exit_arms_reactivation_lockout(self):
+        """Issue #739: check_natural_vent_conditions()'s own COMFORT_FLOOR branch bypasses
+        _exit_nat_vent() entirely (it calls _deactivate_fan() directly, per the Issue #620
+        note above), so it never armed _nat_vent_outdoor_exit_time — the field the
+        reactivation lockout reads. Production incident (2026-08-22): this exit fired with a
+        monitored window still open, and the WHF reactivated within a minute on a ~1F uptick,
+        immediately re-breaching the floor it had just exited to protect. Fixed to set the
+        exit time directly, matching the AWAY_CEILING branch in the same method."""
+        engine = _make_nat_vent_engine(indoor_temp=70.0)
+        assert engine._nat_vent_outdoor_exit_time is None
+        with patch(_PATCH_CALL_LATER):
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False
+        assert engine._nat_vent_outdoor_exit_time is not None, (
+            "Issue #739: COMFORT_FLOOR exit via check_natural_vent_conditions() must arm the "
+            "same reactivation lockout as every sibling exit reason in this method"
+        )
+
     def test_comfort_floor_check_skipped_when_not_in_nat_vent(self):
         """_natural_vent_active=False → no service calls even when indoor is below floor."""
         engine = _make_nat_vent_engine(indoor_temp=65.0)

--- a/tests/test_nat_vent_exit_lockout_coverage.py
+++ b/tests/test_nat_vent_exit_lockout_coverage.py
@@ -16,6 +16,19 @@ enforcement shape as ``tests/test_shadow_engine_coverage.py``'s ``_TRACKED_FIELD
 registry and ``tests/test_executor_offload.py``'s ``_BLOCKING_METHODS`` registry. A new
 call site added later without a classification fails immediately, instead of silently
 repeating this bug class a fourth time.
+
+**Known blind spot (Issue #739):** this scanner only sees calls to
+``self._exit_nat_vent(...)`` — a branch that bypasses that function entirely is invisible
+to it. ``check_natural_vent_conditions()``'s own ``COMFORT_FLOOR`` branch does exactly
+that (it calls ``_deactivate_fan()`` directly, per that branch's own Issue #620 note), and
+it silently omitted arming ``_nat_vent_outdoor_exit_time`` for the same reason every other
+exit reason here needs it. There is no registry entry for this site since it makes no
+``_exit_nat_vent()`` call to key on; coverage instead lives in a direct unit test —
+``tests/test_fan_control.py::TestNatVentComfortFloorExit::test_comfort_floor_exit_arms_reactivation_lockout``
+— mirroring how Issue #755's harness-unreachable ``STOP_COOLED_TO_FLOOR`` fix was verified.
+If another bypass-style exit branch (calls ``_deactivate_fan()``/sets
+``_natural_vent_active = False`` directly, without going through ``_exit_nat_vent()``) is
+ever added, it needs its own such test — this scanner structurally cannot catch it.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- `check_natural_vent_conditions()`'s own `COMFORT_FLOOR` branch bypasses `_exit_nat_vent()` entirely (a direct `_deactivate_fan()` call), so it never armed `_nat_vent_outdoor_exit_time` — the field the existing 5-minute reactivation lockout reads.
- Production incident (2026-08-22, #739): this exit fired with a monitored window still open; the WHF reactivated within a minute on a ~1°F uptick, immediately re-breaching the comfort floor it had just exited to protect.
- Same disproven "self-complementary at a fixed reading" reasoning already fixed by #696/#755 for two sibling exit branches — this is the third and last comfort-floor call site with the gap, invisible to `test_nat_vent_exit_lockout_coverage.py`'s AST-scan registry because this branch never calls `_exit_nat_vent()`.
- Fix: set `_nat_vent_outdoor_exit_time` directly at this call site, matching the `AWAY_CEILING` branch's existing pattern in the same method.

## Test plan
- [x] `ruff check`/`ruff format` clean
- [x] New direct unit test `test_comfort_floor_exit_arms_reactivation_lockout` added (fails pre-fix, passes post-fix)
- [x] Full suite: 4824 passed, 6 skipped
- [x] All 91 golden scenarios pass, including `whf_reactivates_after_sleep_floor_exit` (the one golden scenario exercising this exact branch — its reactivation lands 70 min after the exit, well outside the 5-min lockout, so unaffected)
- [x] `test_version_sync.py` passes (0.6.76 in both `const.py` and `manifest.json`)