### PR TITLE
Add #809: dev-only thermostat simulator + synthetic weather proxy

### DIFF
--- a/dev_tools/ha_test_integrations/README.md
+++ b/dev_tools/ha_test_integrations/README.md
@@ -1,0 +1,141 @@
+# HA Test Integrations (dev-only — never shipped)
+
+Two synthetic Home Assistant custom integrations for locally testing Climate
+Advisor's multi-zone support, built for GitHub issue #809.
+
+## What these are (and are not)
+
+- **Dev-only.** They exist to give a developer a fake climate zone and a fake
+  weather source to point Climate Advisor at, without needing real hardware
+  or multiple physical HVAC zones.
+- **Never shipped.** They live at `dev_tools/ha_test_integrations/`, outside
+  `custom_components/`, which is the real shipped integration. Confirmed:
+  `tools/deploy.py` hardcodes `COMPONENT_DIR = REPO_ROOT / "custom_components" / "climate_advisor"`
+  (see `tools/deploy.py:27`) — it never looks at `dev_tools/`, so `deploy.py`
+  cannot accidentally push these to a production HA instance. They are
+  likewise outside the scope HACS and hassfest validate (both only see
+  `custom_components/climate_advisor/`).
+- **Not covered by any CLAUDE.md release/versioning process** — they have
+  their own tiny `manifest.json` `version: "0.1.0"` that has nothing to do
+  with Climate Advisor's own version in `const.py`/`manifest.json`.
+
+## What they do
+
+### `ca_dev_thermostat_sim`
+
+A `climate` entity (`SimulatedThermostat`) whose indoor temperature evolves
+using the **real** Climate Advisor thermal ODE — it imports and calls
+`_simulate_indoor_physics` directly from
+`custom_components/climate_advisor/coordinator.py` (a pure, module-level
+function, `coordinator.py:9313-9363`) rather than reimplementing the physics.
+This means the simulator can never drift out of sync with production's
+actual thermal model, but it also means **this integration only works when
+`climate_advisor` is installed on the same HA instance** — if the import
+fails, `async_setup_entry` raises `ConfigEntryNotReady` with a clear log
+message instead of silently running wrong math.
+
+Every tick (`tick_seconds`, default 30s) it:
+1. Computes real elapsed wall time since the last tick (not the configured
+   tick interval — this keeps the simulation correct across HA restarts,
+   event-loop delays, or missed ticks over a multi-day run).
+2. Reads outdoor temperature from the configured `outdoor_source` entity
+   (tries the `temperature` attribute first for weather entities, falls back
+   to `.state` for plain sensors).
+3. Calls `_simulate_indoor_physics(...)` with the configured `k_passive`,
+   `k_active_heat`/`k_active_cool` (selected by current `hvac_mode`), and the
+   current target temperature.
+4. Writes the new simulated indoor temperature to HA state.
+
+State survives HA restarts via `RestoreEntity` (current temperature, target
+temperature, and HVAC mode are restored from the last known state).
+
+### `ca_dev_weather_proxy`
+
+A `weather` entity (`SyntheticWeatherEntity`) that produces a smooth,
+deterministic diurnal outdoor temperature curve:
+
+```
+T(hour) = base_temp_f + diurnal_swing_f * sin(2*pi*(hour - phase_offset_h + 6)/24)
+```
+
+With the default `phase_offset_h=15`, temperature peaks at 3pm and troughs at
+3am — a typical outdoor diurnal shape. `async_forecast_daily`/
+`async_forecast_hourly` project the same curve forward so Climate Advisor's
+forecast-dependent logic (classification, target-band scheduling) has
+something realistic to read. The `condition` (sunny/cloudy/rainy/snowy) is
+static, set at config time.
+
+## Manual install
+
+1. Copy each integration folder into your HA config's `custom_components/`
+   directory:
+   ```
+   <ha_config>/custom_components/ca_dev_thermostat_sim/
+   <ha_config>/custom_components/ca_dev_weather_proxy/
+   ```
+2. Restart Home Assistant.
+3. Settings → Devices & Services → Add Integration → search **"Ca Dev
+   Weather Proxy"** first (thermostat sim's `outdoor_source` needs an entity
+   to point at) → fill out the form → Submit.
+4. Settings → Devices & Services → Add Integration → search **"Ca Dev
+   Thermostat Sim"** → set `outdoor_source` to the weather entity created in
+   step 3 (or any real/synthetic sensor) → fill out the rest of the form →
+   Submit.
+5. Point Climate Advisor's config flow at the new `climate.*` and
+   `weather.*` entities the same way you would point it at real hardware.
+
+## Config flow field reference
+
+### `ca_dev_thermostat_sim`
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `name` | text | "Simulated Thermostat" | Entity name |
+| `initial_temp_f` | number | 70.0 | Starting indoor temp (°F) — only used on first setup, later ticks restore from HA state |
+| `k_passive` | number | -0.15 | Envelope decay rate (1/hr), always negative |
+| `k_active_heat` | number | 3.0 | Heating contribution (°F/hr) |
+| `k_active_cool` | number | -3.0 | Cooling contribution (°F/hr), negative |
+| `comfort_heat` | number | 68 | Comfort floor (°F) — passed through to the ODE clamp logic |
+| `comfort_cool` | number | 76 | Comfort ceiling (°F) — passed through to the ODE clamp logic |
+| `outdoor_source` | entity (weather or sensor) | — required | Where outdoor temperature is read from each tick |
+| `tick_seconds` | number | 30 | How often the simulation advances (real elapsed wall time drives the math, not this number) |
+
+### `ca_dev_weather_proxy`
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `name` | text | "Simulated Weather" | Entity name |
+| `base_temp_f` | number | 65.0 | Midline of the diurnal sine curve (°F) |
+| `diurnal_swing_f` | number | 15.0 | +/- amplitude around `base_temp_f` (°F) |
+| `phase_offset_h` | number | 15.0 | Hour-of-day the curve peaks (15 = 3pm) |
+| `condition` | select | sunny | Static weather condition (sunny/cloudy/rainy/snowy) |
+
+## Matching a real home
+
+To make `ca_dev_thermostat_sim` behave like your actual house instead of the
+generic defaults, pull your real learned thermal parameters and use them as
+the config flow values:
+
+```bash
+python tools/learning_db.py --model
+```
+
+Copy the printed `k_passive`, `k_active_heat`/`heating_rate_f_per_hour`, and
+`k_active_cool`/`cooling_rate_f_per_hour` values (see
+`custom_components/climate_advisor/learning.py`'s `get_thermal_model()`) into
+the thermostat sim's config flow.
+
+## Verification note
+
+There is no `homeassistant` pip package in this repo/venv, so nothing here
+was importable or runnable in this session — these files were written
+carefully by HA convention (targeting the `homeassistant: 2024.6.0` minimum
+pinned in `hacs.json`) and need to be installed and exercised on a real HA
+instance by a human before being trusted. The one exception:
+`ca_dev_thermostat_sim/test_sim_math.py` hand-verifies the ODE formula
+transcribed from `_simulate_indoor_physics` (three cases: passive decay,
+active heating, and a clamp-triggering long-dt cooling case) — run it with
+`python dev_tools/ha_test_integrations/ca_dev_thermostat_sim/test_sim_math.py`.
+It is not a substitute for actually importing the real function once
+`homeassistant` is installed; see that script's docstring for why the import
+itself couldn't be tested here and what to do once it can be.

--- a/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/__init__.py
+++ b/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/__init__.py
@@ -1,0 +1,41 @@
+"""CA Dev Thermostat Sim — dev-only synthetic thermostat for testing Climate Advisor.
+
+NOT SHIPPED. Lives outside custom_components/ on purpose: tools/deploy.py,
+HACS, and hassfest all only know about custom_components/climate_advisor.
+See dev_tools/ha_test_integrations/README.md for install/usage instructions
+and issue #809 for background.
+
+This integration reuses the real Climate Advisor ODE step function
+(_simulate_indoor_physics from custom_components/climate_advisor/coordinator.py)
+rather than reimplementing the thermal math, so the simulator can never drift
+from production physics. It therefore requires climate_advisor to be
+installed alongside it on the same Home Assistant instance.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN, PLATFORMS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up CA Dev Thermostat Sim from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = dict(entry.data)
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a CA Dev Thermostat Sim config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+    return unload_ok

--- a/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/climate.py
+++ b/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/climate.py
@@ -1,0 +1,246 @@
+"""Climate platform for CA Dev Thermostat Sim.
+
+Dev-only, never shipped — see dev_tools/ha_test_integrations/README.md.
+
+Reuses the real Climate Advisor ODE step function (_simulate_indoor_physics)
+so this simulator can never drift from production thermal-model behavior
+(DRY rule, CLAUDE.md). That function lives in
+custom_components/climate_advisor/coordinator.py:9313-9363 as a pure,
+module-level function with no instance-state dependency, so it can be
+imported directly.
+
+NOTE ON HA VERSION: ClimateEntity/RestoreEntity's API shape used here
+(hvac_modes, target_temperature, current_temperature, async_get_last_state,
+async_write_ha_state) has been stable since well before hacs.json's pinned
+minimum homeassistant version (2024.6.0), but this was NOT verified against
+a locally-installed `homeassistant` package — none exists in this repo/venv.
+Test on a real Home Assistant instance before relying on it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+from homeassistant.components.climate import ClimateEntity, ClimateEntityFeature, HVACMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    CONF_COMFORT_COOL,
+    CONF_COMFORT_HEAT,
+    CONF_INITIAL_TEMP_F,
+    CONF_K_ACTIVE_COOL,
+    CONF_K_ACTIVE_HEAT,
+    CONF_K_PASSIVE,
+    CONF_OUTDOOR_SOURCE,
+    CONF_TICK_SECONDS,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+try:
+    # The real Climate Advisor ODE step — imported, not reimplemented, so this
+    # simulator tracks production physics automatically. See module docstring.
+    from custom_components.climate_advisor.coordinator import _simulate_indoor_physics
+except ImportError as err:  # pragma: no cover - exercised only without climate_advisor installed
+    _simulate_indoor_physics = None
+    _IMPORT_ERROR = err
+else:
+    _IMPORT_ERROR = None
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the simulated thermostat entity from a config entry."""
+    if _simulate_indoor_physics is None:
+        _LOGGER.error(
+            "CA Dev Thermostat Sim requires the climate_advisor integration to be "
+            "installed alongside it (imports _simulate_indoor_physics from its "
+            "coordinator.py). Import failed: %s",
+            _IMPORT_ERROR,
+        )
+        raise ConfigEntryNotReady(
+            "climate_advisor is not installed — CA Dev Thermostat Sim reuses its "
+            "ODE physics function and cannot run standalone"
+        )
+
+    async_add_entities([SimulatedThermostat(entry)])
+
+
+class SimulatedThermostat(RestoreEntity, ClimateEntity):
+    """A synthetic thermostat whose indoor temperature evolves via the real CA ODE."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_should_poll = False
+    _attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
+    # HEAT_COOL deliberately excluded: this sim has one setpoint
+    # (target_temperature) and one active-mode direction per tick, matching
+    # how Climate Advisor's own automation drives a thermostat (single
+    # setpoint, explicit heat/cool/off mode switches) — not the dual
+    # target_temp_low/target_temp_high range HEAT_COOL implies. Advertising
+    # it without implementing it left the mode silently inert (Issue #809
+    # verification finding).
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL]
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF
+    )
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        """Initialize the simulated thermostat from its config entry data."""
+        self._entry = entry
+        data = entry.data
+        self._attr_unique_id = f"{entry.entry_id}_sim_thermostat"
+        self._attr_name = data.get("name")
+
+        self._k_passive: float = data[CONF_K_PASSIVE]
+        self._k_active_heat: float = data[CONF_K_ACTIVE_HEAT]
+        self._k_active_cool: float = data[CONF_K_ACTIVE_COOL]
+        self._comfort_heat: float = data[CONF_COMFORT_HEAT]
+        self._comfort_cool: float = data[CONF_COMFORT_COOL]
+        self._outdoor_source: str = data[CONF_OUTDOOR_SOURCE]
+        self._tick_seconds: int = int(data[CONF_TICK_SECONDS])
+
+        self._current_temp: float = float(data.get(CONF_INITIAL_TEMP_F, 70.0))
+        self._target_temp: float | None = self._comfort_heat
+        self._hvac_mode: HVACMode = HVACMode.OFF
+        self._last_update_ts: datetime = dt_util.utcnow()
+
+    async def async_added_to_hass(self) -> None:
+        """Restore prior simulated state (if any) and start the tick timer."""
+        await super().async_added_to_hass()
+
+        last_state = await self.async_get_last_state()
+        if last_state is not None:
+            restored_temp = last_state.attributes.get("current_temperature")
+            if restored_temp is not None:
+                try:
+                    self._current_temp = float(restored_temp)
+                except (TypeError, ValueError):
+                    _LOGGER.warning(
+                        "Could not restore current_temperature=%r for %s, keeping initial_temp_f",
+                        restored_temp,
+                        self.entity_id,
+                    )
+
+            restored_target = last_state.attributes.get("temperature")
+            if restored_target is not None:
+                with contextlib.suppress(TypeError, ValueError):
+                    self._target_temp = float(restored_target)
+
+            if last_state.state in (m.value for m in self._attr_hvac_modes):
+                self._hvac_mode = HVACMode(last_state.state)
+        else:
+            _LOGGER.debug(
+                "No prior state for %s — starting from configured initial_temp_f=%.1f",
+                self.entity_id,
+                self._current_temp,
+            )
+
+        # Real elapsed wall time drives the ODE step, not tick_seconds — this
+        # keeps the simulation correct across restarts and missed/delayed ticks.
+        self._last_update_ts = dt_util.utcnow()
+
+        self.async_on_remove(
+            async_track_time_interval(self.hass, self._async_tick, timedelta(seconds=self._tick_seconds))
+        )
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the simulated indoor temperature."""
+        return self._current_temp
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the current target temperature."""
+        return self._target_temp
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        """Return the current HVAC mode."""
+        return self._hvac_mode
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set a new HVAC mode."""
+        self._hvac_mode = hvac_mode
+        self.async_write_ha_state()
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set a new target temperature."""
+        temperature = kwargs.get("temperature")
+        if temperature is None:
+            return
+        self._target_temp = float(temperature)
+        self.async_write_ha_state()
+
+    def _read_outdoor_temp(self) -> float | None:
+        """Read outdoor temp from the configured source, trying weather then sensor shapes."""
+        state = self.hass.states.get(self._outdoor_source)
+        if state is None:
+            return None
+
+        # Weather entities expose temperature as an attribute; plain sensors as .state.
+        attr_temp = state.attributes.get("temperature")
+        if attr_temp is not None:
+            try:
+                return float(attr_temp)
+            except (TypeError, ValueError):
+                pass
+
+        try:
+            return float(state.state)
+        except (TypeError, ValueError):
+            return None
+
+    async def _async_tick(self, now: datetime) -> None:
+        """Advance the simulated indoor temperature by real elapsed wall time."""
+        dt_hours = (now - self._last_update_ts).total_seconds() / 3600.0
+        if dt_hours <= 0:
+            return
+
+        outdoor_temp = self._read_outdoor_temp()
+        if outdoor_temp is None:
+            _LOGGER.warning(
+                "CA Dev Thermostat Sim %s: outdoor_source %s has no usable temperature — skipping tick",
+                self.entity_id,
+                self._outdoor_source,
+            )
+            self._last_update_ts = now
+            return
+
+        if self._hvac_mode == HVACMode.HEAT:
+            k_active = self._k_active_heat
+            mode = "heat"
+        elif self._hvac_mode == HVACMode.COOL:
+            k_active = self._k_active_cool
+            mode = "cool"
+        else:
+            # OFF simulates as passive-only decay toward outdoor temp.
+            k_active = None
+            mode = None
+
+        self._current_temp = _simulate_indoor_physics(
+            self._current_temp,
+            outdoor_temp,
+            self._k_passive,
+            k_active,
+            dt_hours,
+            self._target_temp,
+            comfort_heat=self._comfort_heat,
+            comfort_cool=self._comfort_cool,
+            hvac_mode=mode,
+        )
+        self._last_update_ts = now
+        self.async_write_ha_state()

--- a/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/config_flow.py
+++ b/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/config_flow.py
@@ -1,0 +1,89 @@
+"""Config flow for CA Dev Thermostat Sim.
+
+Dev-only, never shipped — see dev_tools/ha_test_integrations/README.md.
+Follows the selector conventions used by custom_components/climate_advisor's
+own config_flow.py (vol.Schema + homeassistant.helpers.selector).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.helpers import selector
+
+from .const import (
+    CONF_COMFORT_COOL,
+    CONF_COMFORT_HEAT,
+    CONF_INITIAL_TEMP_F,
+    CONF_K_ACTIVE_COOL,
+    CONF_K_ACTIVE_HEAT,
+    CONF_K_PASSIVE,
+    CONF_OUTDOOR_SOURCE,
+    CONF_TICK_SECONDS,
+    DEFAULT_COMFORT_COOL,
+    DEFAULT_COMFORT_HEAT,
+    DEFAULT_INITIAL_TEMP_F,
+    DEFAULT_K_ACTIVE_COOL,
+    DEFAULT_K_ACTIVE_HEAT,
+    DEFAULT_K_PASSIVE,
+    DEFAULT_TICK_SECONDS,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _num(
+    *, min_: float, max_: float, step: float, unit: str | None = None, mode: str = "box"
+) -> selector.NumberSelector:
+    return selector.NumberSelector(
+        selector.NumberSelectorConfig(min=min_, max=max_, step=step, unit_of_measurement=unit, mode=mode)
+    )
+
+
+class CaDevThermostatSimConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for CA Dev Thermostat Sim."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> Any:
+        """Collect the simulated thermostat's identity, physics params, and tick rate."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            return self.async_create_entry(title=user_input["name"], data=user_input)
+
+        schema = vol.Schema(
+            {
+                vol.Required("name", default="Simulated Thermostat"): selector.TextSelector(),
+                vol.Required(CONF_INITIAL_TEMP_F, default=DEFAULT_INITIAL_TEMP_F): _num(
+                    min_=32, max_=110, step=0.1, unit="°F"
+                ),
+                vol.Required(CONF_K_PASSIVE, default=DEFAULT_K_PASSIVE): _num(
+                    min_=-2.0, max_=-0.01, step=0.01, unit="1/hr"
+                ),
+                vol.Required(CONF_K_ACTIVE_HEAT, default=DEFAULT_K_ACTIVE_HEAT): _num(
+                    min_=0.1, max_=20.0, step=0.1, unit="°F/hr"
+                ),
+                vol.Required(CONF_K_ACTIVE_COOL, default=DEFAULT_K_ACTIVE_COOL): _num(
+                    min_=-20.0, max_=-0.1, step=0.1, unit="°F/hr"
+                ),
+                vol.Required(CONF_COMFORT_HEAT, default=DEFAULT_COMFORT_HEAT): _num(
+                    min_=32, max_=110, step=0.5, unit="°F"
+                ),
+                vol.Required(CONF_COMFORT_COOL, default=DEFAULT_COMFORT_COOL): _num(
+                    min_=32, max_=110, step=0.5, unit="°F"
+                ),
+                vol.Required(CONF_OUTDOOR_SOURCE): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain=["weather", "sensor"])
+                ),
+                vol.Required(CONF_TICK_SECONDS, default=DEFAULT_TICK_SECONDS): _num(
+                    min_=5, max_=3600, step=1, unit="s"
+                ),
+            }
+        )
+
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)

--- a/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/const.py
+++ b/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/const.py
@@ -1,0 +1,27 @@
+"""Constants for the CA Dev Thermostat Sim integration.
+
+Dev-only, never shipped — see dev_tools/ha_test_integrations/README.md.
+"""
+
+from __future__ import annotations
+
+DOMAIN = "ca_dev_thermostat_sim"
+
+CONF_INITIAL_TEMP_F = "initial_temp_f"
+CONF_K_PASSIVE = "k_passive"
+CONF_K_ACTIVE_HEAT = "k_active_heat"
+CONF_K_ACTIVE_COOL = "k_active_cool"
+CONF_COMFORT_HEAT = "comfort_heat"
+CONF_COMFORT_COOL = "comfort_cool"
+CONF_OUTDOOR_SOURCE = "outdoor_source"
+CONF_TICK_SECONDS = "tick_seconds"
+
+DEFAULT_INITIAL_TEMP_F = 70.0
+DEFAULT_K_PASSIVE = -0.15
+DEFAULT_K_ACTIVE_HEAT = 3.0
+DEFAULT_K_ACTIVE_COOL = -3.0
+DEFAULT_COMFORT_HEAT = 68.0
+DEFAULT_COMFORT_COOL = 76.0
+DEFAULT_TICK_SECONDS = 30
+
+PLATFORMS = ["climate"]

--- a/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/manifest.json
+++ b/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "ca_dev_thermostat_sim",
+  "name": "CA Dev Thermostat Sim",
+  "codeowners": ["@gunkl"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/gunkl/ClimateAdvisor/tree/main/dev_tools/ha_test_integrations",
+  "integration_type": "service",
+  "iot_class": "calculated",
+  "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues/809",
+  "requirements": [],
+  "version": "0.1.0"
+}

--- a/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/strings.json
+++ b/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/strings.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "CA Dev Thermostat Sim",
+        "description": "Create a synthetic thermostat driven by Climate Advisor's real thermal ODE, for local multi-zone testing. Never shipped with the integration.",
+        "data": {
+          "name": "Name",
+          "initial_temp_f": "Initial indoor temperature (°F)",
+          "k_passive": "k_passive (envelope decay rate, 1/hr, negative)",
+          "k_active_heat": "k_active_heat (°F/hr)",
+          "k_active_cool": "k_active_cool (°F/hr, negative)",
+          "comfort_heat": "Comfort heat floor (°F)",
+          "comfort_cool": "Comfort cool ceiling (°F)",
+          "outdoor_source": "Outdoor temperature source",
+          "tick_seconds": "Simulation tick interval (seconds)"
+        }
+      }
+    }
+  }
+}

--- a/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/test_sim_math.py
+++ b/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/test_sim_math.py
@@ -1,0 +1,166 @@
+"""Verification script for the ODE math used by SimulatedThermostat (climate.py).
+
+NOT a pytest test — plain script, run directly: `python test_sim_math.py`.
+
+Why this isn't a real import test
+----------------------------------
+The plan for this dev tool was to import `_simulate_indoor_physics` directly
+from `custom_components/climate_advisor/coordinator.py` and run it against a
+few known input/output pairs. That import was checked in this environment
+and does NOT work standalone:
+
+    $ python -c "import homeassistant"
+    ModuleNotFoundError: No module named 'homeassistant'
+
+`coordinator.py` imports `homeassistant.*` at module level (EVENT_CALL_SERVICE,
+HomeAssistant, entity_registry, async_track_time_interval, DataUpdateCoordinator,
+dt_util, etc. — see the top of the file), so merely importing the module to reach
+the one pure function inside it requires a working `homeassistant` package. No
+such package is installed in this repo/venv, and none is expected to be (this
+repo is the integration source, not an HA runtime).
+
+So instead, this script hand-derives `_simulate_indoor_physics`'s formula from
+its source (coordinator.py:9313-9363, read in full — not just the signature)
+and re-implements it here ONLY for verification purposes — this file is never
+imported by climate.py or any shipped code, so it does not violate the DRY
+requirement that the real simulator entity call the production function.
+
+The formula, transcribed from the real function:
+
+    k_p = k_passive
+    q = 0.0
+    if setpoint is not None and k_active is not None:
+        if hvac_mode == "heat":
+            if t_start < setpoint: q = abs(k_active)
+        elif hvac_mode == "cool":
+            if t_start > setpoint: q = -abs(k_active)
+        else:
+            # legacy threshold inference (not used by climate.py, which always
+            # passes hvac_mode explicitly)
+            if setpoint >= comfort_heat and t_start < setpoint: q = abs(k_active)
+            elif setpoint <= comfort_cool and t_start > setpoint: q = -abs(k_active)
+
+    exp_kp = exp(k_p * dt_hours)
+    t_next = (
+        t_outdoor + (t_start - t_outdoor) * exp_kp + (q / k_p) * (exp_kp - 1)
+        if k_p != 0 else
+        t_start + q * dt_hours
+    )
+    # Clamp: heating won't overshoot setpoint; cooling won't undershoot.
+    if setpoint is not None:
+        if q > 0: t_next = min(t_next, setpoint)
+        elif q < 0: t_next = max(t_next, setpoint)
+
+Three cases are hand-verified below against a from-scratch re-derivation of
+that formula (computed independently with Python's math.exp, not copy-pasted
+from any cached run) to sanity-check the transcription above matches what
+climate.py actually calls.
+
+If a `homeassistant` package is ever installed in this venv, replace this
+script's `_reference_simulate_indoor_physics` with a real
+`from custom_components.climate_advisor.coordinator import _simulate_indoor_physics`
+import and delete the hand-transcribed copy — the whole point of this file is
+to fall back to hand-verification only when the real import is impossible.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def _reference_simulate_indoor_physics(
+    t_start: float,
+    t_outdoor: float,
+    k_passive: float,
+    k_active: float | None,
+    dt_hours: float,
+    setpoint: float | None,
+    *,
+    comfort_heat: float,
+    comfort_cool: float,
+    hvac_mode: str | None = None,
+) -> float:
+    """Hand-transcribed copy of coordinator.py:9313-9363, for verification only.
+
+    climate.py does NOT use this function — it imports the real one. See the
+    module docstring above for why this duplicate exists.
+    """
+    k_p = k_passive
+    q = 0.0
+    if setpoint is not None and k_active is not None:
+        if hvac_mode == "heat":
+            if t_start < setpoint:
+                q = abs(k_active)
+        elif hvac_mode == "cool":
+            if t_start > setpoint:
+                q = -abs(k_active)
+        else:
+            if setpoint >= comfort_heat and t_start < setpoint:
+                q = abs(k_active)
+            elif setpoint <= comfort_cool and t_start > setpoint:
+                q = -abs(k_active)
+
+    exp_kp = math.exp(k_p * dt_hours)
+    t_next = (
+        t_outdoor + (t_start - t_outdoor) * exp_kp + (q / k_p) * (exp_kp - 1) if k_p != 0 else t_start + q * dt_hours
+    )
+
+    if setpoint is not None:
+        if q > 0:
+            t_next = min(t_next, setpoint)
+        elif q < 0:
+            t_next = max(t_next, setpoint)
+    return t_next
+
+
+def _check(label: str, actual: float, expected: float, tol: float = 1e-9) -> None:
+    ok = abs(actual - expected) < tol
+    status = "PASS" if ok else "FAIL"
+    print(f"[{status}] {label}: actual={actual!r} expected={expected!r}")
+    if not ok:
+        raise SystemExit(1)
+
+
+def main() -> None:
+    print(__doc__.splitlines()[0])
+    print()
+
+    # Case 1: pure passive decay, no HVAC (q=0).
+    # t_next = 60 + (75-60)*exp(-0.15*1) = 60 + 15*0.8607... = 72.9106...
+    _check(
+        "passive decay, k_passive=-0.15, dt=1h",
+        _reference_simulate_indoor_physics(75.0, 60.0, -0.15, None, 1.0, None, comfort_heat=68, comfort_cool=76),
+        72.91061964637586,
+    )
+
+    # Case 2: active heating below setpoint, no clamp reached.
+    _check(
+        "heating below setpoint, k_active_heat=3.0, dt=2h",
+        _reference_simulate_indoor_physics(
+            65.0, 40.0, -0.15, 3.0, 2.0, 70.0, comfort_heat=68, comfort_cool=76, hvac_mode="heat"
+        ),
+        63.70409110340859,
+    )
+
+    # Case 3: active cooling with a long enough dt that the ODE would overshoot
+    # past the setpoint — the clamp must pin the result to exactly setpoint.
+    _check(
+        "cooling, long dt forces clamp to setpoint=76.0",
+        _reference_simulate_indoor_physics(
+            78.0, 95.0, -0.15, -3.0, 20.0, 76.0, comfort_heat=68, comfort_cool=76, hvac_mode="cool"
+        ),
+        76.0,
+    )
+
+    print()
+    print("All hand-verified cases pass. This confirms the formula transcribed")
+    print("from coordinator.py:9313-9363 is internally consistent, but it does")
+    print("NOT confirm the transcription itself is byte-for-byte identical to")
+    print("the real function — that requires a real import, which needs a")
+    print("`homeassistant` package not present in this environment. Verify on")
+    print("a real HA instance, or re-run this check with the import swapped in")
+    print("once `homeassistant` is installed locally.")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/translations/en.json
+++ b/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/translations/en.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "CA Dev Thermostat Sim",
+        "description": "Create a synthetic thermostat driven by Climate Advisor's real thermal ODE, for local multi-zone testing. Never shipped with the integration.",
+        "data": {
+          "name": "Name",
+          "initial_temp_f": "Initial indoor temperature (°F)",
+          "k_passive": "k_passive (envelope decay rate, 1/hr, negative)",
+          "k_active_heat": "k_active_heat (°F/hr)",
+          "k_active_cool": "k_active_cool (°F/hr, negative)",
+          "comfort_heat": "Comfort heat floor (°F)",
+          "comfort_cool": "Comfort cool ceiling (°F)",
+          "outdoor_source": "Outdoor temperature source",
+          "tick_seconds": "Simulation tick interval (seconds)"
+        }
+      }
+    }
+  }
+}

--- a/dev_tools/ha_test_integrations/ca_dev_weather_proxy/__init__.py
+++ b/dev_tools/ha_test_integrations/ca_dev_weather_proxy/__init__.py
@@ -1,0 +1,35 @@
+"""CA Dev Weather Proxy — dev-only synthetic weather source for testing Climate Advisor.
+
+NOT SHIPPED. Lives outside custom_components/ on purpose: tools/deploy.py,
+HACS, and hassfest all only know about custom_components/climate_advisor.
+See dev_tools/ha_test_integrations/README.md for install/usage instructions
+and issue #809 for background.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN, PLATFORMS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up CA Dev Weather Proxy from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = dict(entry.data)
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a CA Dev Weather Proxy config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+    return unload_ok

--- a/dev_tools/ha_test_integrations/ca_dev_weather_proxy/config_flow.py
+++ b/dev_tools/ha_test_integrations/ca_dev_weather_proxy/config_flow.py
@@ -1,0 +1,64 @@
+"""Config flow for CA Dev Weather Proxy.
+
+Dev-only, never shipped — see dev_tools/ha_test_integrations/README.md.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.helpers import selector
+
+from .const import (
+    CONDITION_OPTIONS,
+    CONF_BASE_TEMP_F,
+    CONF_CONDITION,
+    CONF_DIURNAL_SWING_F,
+    CONF_PHASE_OFFSET_H,
+    DEFAULT_BASE_TEMP_F,
+    DEFAULT_CONDITION,
+    DEFAULT_DIURNAL_SWING_F,
+    DEFAULT_PHASE_OFFSET_H,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CaDevWeatherProxyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for CA Dev Weather Proxy."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> Any:
+        """Collect the synthetic weather curve's parameters."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            return self.async_create_entry(title=user_input["name"], data=user_input)
+
+        schema = vol.Schema(
+            {
+                vol.Required("name", default="Simulated Weather"): selector.TextSelector(),
+                vol.Required(CONF_BASE_TEMP_F, default=DEFAULT_BASE_TEMP_F): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=-40, max=130, step=0.5, unit_of_measurement="°F", mode="box")
+                ),
+                vol.Required(CONF_DIURNAL_SWING_F, default=DEFAULT_DIURNAL_SWING_F): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=0, max=60, step=0.5, unit_of_measurement="°F", mode="box")
+                ),
+                vol.Required(CONF_PHASE_OFFSET_H, default=DEFAULT_PHASE_OFFSET_H): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=0, max=24, step=0.5, unit_of_measurement="hr", mode="box")
+                ),
+                vol.Required(CONF_CONDITION, default=DEFAULT_CONDITION): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=CONDITION_OPTIONS,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
+            }
+        )
+
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)

--- a/dev_tools/ha_test_integrations/ca_dev_weather_proxy/const.py
+++ b/dev_tools/ha_test_integrations/ca_dev_weather_proxy/const.py
@@ -1,0 +1,22 @@
+"""Constants for the CA Dev Weather Proxy integration.
+
+Dev-only, never shipped — see dev_tools/ha_test_integrations/README.md.
+"""
+
+from __future__ import annotations
+
+DOMAIN = "ca_dev_weather_proxy"
+
+CONF_BASE_TEMP_F = "base_temp_f"
+CONF_DIURNAL_SWING_F = "diurnal_swing_f"
+CONF_PHASE_OFFSET_H = "phase_offset_h"
+CONF_CONDITION = "condition"
+
+DEFAULT_BASE_TEMP_F = 65.0
+DEFAULT_DIURNAL_SWING_F = 15.0
+DEFAULT_PHASE_OFFSET_H = 15.0
+DEFAULT_CONDITION = "sunny"
+
+CONDITION_OPTIONS = ["sunny", "cloudy", "rainy", "snowy"]
+
+PLATFORMS = ["weather"]

--- a/dev_tools/ha_test_integrations/ca_dev_weather_proxy/manifest.json
+++ b/dev_tools/ha_test_integrations/ca_dev_weather_proxy/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "ca_dev_weather_proxy",
+  "name": "CA Dev Weather Proxy",
+  "codeowners": ["@gunkl"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/gunkl/ClimateAdvisor/tree/main/dev_tools/ha_test_integrations",
+  "integration_type": "service",
+  "iot_class": "calculated",
+  "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues/809",
+  "requirements": [],
+  "version": "0.1.0"
+}

--- a/dev_tools/ha_test_integrations/ca_dev_weather_proxy/strings.json
+++ b/dev_tools/ha_test_integrations/ca_dev_weather_proxy/strings.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "CA Dev Weather Proxy",
+        "description": "Create a synthetic weather source with a smooth diurnal temperature curve, for local multi-zone testing. Never shipped with the integration.",
+        "data": {
+          "name": "Name",
+          "base_temp_f": "Base temperature (°F)",
+          "diurnal_swing_f": "Diurnal swing (°F, +/- around base)",
+          "phase_offset_h": "Phase offset (hours; 15 = peak at 3pm)",
+          "condition": "Weather condition"
+        }
+      }
+    }
+  }
+}

--- a/dev_tools/ha_test_integrations/ca_dev_weather_proxy/translations/en.json
+++ b/dev_tools/ha_test_integrations/ca_dev_weather_proxy/translations/en.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "CA Dev Weather Proxy",
+        "description": "Create a synthetic weather source with a smooth diurnal temperature curve, for local multi-zone testing. Never shipped with the integration.",
+        "data": {
+          "name": "Name",
+          "base_temp_f": "Base temperature (°F)",
+          "diurnal_swing_f": "Diurnal swing (°F, +/- around base)",
+          "phase_offset_h": "Phase offset (hours; 15 = peak at 3pm)",
+          "condition": "Weather condition"
+        }
+      }
+    }
+  }
+}

--- a/dev_tools/ha_test_integrations/ca_dev_weather_proxy/weather.py
+++ b/dev_tools/ha_test_integrations/ca_dev_weather_proxy/weather.py
@@ -1,0 +1,153 @@
+"""Weather platform for CA Dev Weather Proxy.
+
+Dev-only, never shipped — see dev_tools/ha_test_integrations/README.md.
+
+Produces a smooth synthetic diurnal temperature curve:
+
+    T(hour) = base_temp_f + diurnal_swing_f * sin(2*pi*(hour - phase_offset_h + 6)/24)
+
+The +6 shift makes phase_offset_h the actual PEAK hour (not a sine
+zero-crossing) so it matches its own field label/description directly.
+With the default phase_offset_h=15, the curve peaks at local hour 15 (3pm)
+and troughs 12 hours later/earlier at local hour 3 (3am) — a typical
+outdoor diurnal shape.
+
+NOTE ON HA VERSION: WeatherEntity's API shape used here (native_temperature,
+condition, async_forecast_daily/async_forecast_hourly returning Forecast
+dicts) has been stable since well before hacs.json's pinned minimum
+homeassistant version (2024.6.0), but this was NOT verified against a
+locally-installed `homeassistant` package — none exists in this repo/venv.
+Test on a real Home Assistant instance before relying on it.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from datetime import timedelta
+
+from homeassistant.components.weather import Forecast, WeatherEntity, WeatherEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    CONF_BASE_TEMP_F,
+    CONF_CONDITION,
+    CONF_DIURNAL_SWING_F,
+    CONF_PHASE_OFFSET_H,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_HOURS_PER_DAY = 24
+_FORECAST_HOURS = 48
+_FORECAST_DAYS = 7
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the synthetic weather entity from a config entry."""
+    async_add_entities([SyntheticWeatherEntity(entry)])
+
+
+def _sine_temp(hour_of_day: float, base_temp_f: float, diurnal_swing_f: float, phase_offset_h: float) -> float:
+    """Return the synthetic outdoor temperature for a given fractional hour-of-day.
+
+    phase_offset_h is the actual peak hour (see module docstring) — the +6
+    shift below converts it into the sine's zero-crossing internally.
+    """
+    shifted = hour_of_day - phase_offset_h + _HOURS_PER_DAY / 4.0
+    return base_temp_f + diurnal_swing_f * math.sin(2 * math.pi * shifted / _HOURS_PER_DAY)
+
+
+class SyntheticWeatherEntity(WeatherEntity):
+    """A synthetic weather source with a smooth sine-wave diurnal temperature curve."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_native_temperature_unit = UnitOfTemperature.FAHRENHEIT
+    _attr_supported_features = WeatherEntityFeature.FORECAST_DAILY | WeatherEntityFeature.FORECAST_HOURLY
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        """Initialize the synthetic weather entity from its config entry data."""
+        data = entry.data
+        self._attr_unique_id = f"{entry.entry_id}_synthetic_weather"
+        self._attr_name = data.get("name")
+
+        self._base_temp_f: float = data[CONF_BASE_TEMP_F]
+        self._diurnal_swing_f: float = data[CONF_DIURNAL_SWING_F]
+        self._phase_offset_h: float = data[CONF_PHASE_OFFSET_H]
+        self._condition: str = data[CONF_CONDITION]
+
+    def _hour_of_day_now(self) -> float:
+        now = dt_util.now()
+        return now.hour + now.minute / 60.0
+
+    @property
+    def native_temperature(self) -> float:
+        """Return the live synthetic outdoor temperature."""
+        return _sine_temp(self._hour_of_day_now(), self._base_temp_f, self._diurnal_swing_f, self._phase_offset_h)
+
+    @property
+    def condition(self) -> str:
+        """Return the configured static condition."""
+        return self._condition
+
+    async def async_forecast_daily(self) -> list[Forecast]:
+        """Project the sine curve forward as a daily forecast (peak-of-day temps).
+
+        Starts at day_offset=0 (today), not 1 — Climate Advisor's day
+        classification looks up today's own forecast entry by date
+        (coordinator.py's _get_forecast) and falls back to a single
+        instantaneous reading (losing the whole point of a synthetic curve)
+        if it's missing.
+        """
+        now = dt_util.now()
+        forecasts: list[Forecast] = []
+        for day_offset in range(_FORECAST_DAYS + 1):
+            forecast_time = now + timedelta(days=day_offset)
+            peak_hour = self._phase_offset_h
+            trough_hour = self._phase_offset_h + _HOURS_PER_DAY / 2.0
+            forecasts.append(
+                Forecast(
+                    datetime=forecast_time.isoformat(),
+                    native_temperature=_sine_temp(
+                        peak_hour, self._base_temp_f, self._diurnal_swing_f, self._phase_offset_h
+                    ),
+                    native_templow=_sine_temp(
+                        trough_hour, self._base_temp_f, self._diurnal_swing_f, self._phase_offset_h
+                    ),
+                    condition=self._condition,
+                )
+            )
+        return forecasts
+
+    async def async_forecast_hourly(self) -> list[Forecast]:
+        """Project the sine curve forward hour-by-hour.
+
+        Starts at hour_offset=0 (the current hour), not 1 — without a
+        current-hour entry, coordinator.py's _extract_current_hour_forecast_temp
+        has no bracketing pair and falls into its edge-clamped-interpolation
+        fallback path every cycle.
+        """
+        now = dt_util.now()
+        forecasts: list[Forecast] = []
+        for hour_offset in range(_FORECAST_HOURS + 1):
+            forecast_time = now + timedelta(hours=hour_offset)
+            hour_of_day = forecast_time.hour + forecast_time.minute / 60.0
+            forecasts.append(
+                Forecast(
+                    datetime=forecast_time.isoformat(),
+                    native_temperature=_sine_temp(
+                        hour_of_day, self._base_temp_f, self._diurnal_swing_f, self._phase_offset_h
+                    ),
+                    condition=self._condition,
+                )
+            )
+        return forecasts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ select = ["E", "W", "F", "I", "UP", "B", "SIM", "T20", "ASYNC"]
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["T20"]
 "tools/*" = ["T20"]
+# dev_tools/ha_test_integrations/ — never-shipped local test tooling (Issue #809),
+# same rationale as tools/*: print() output is the point of a manual verification
+# script, not a lint smell.
+"dev_tools/*" = ["T20"]
 # take_screenshots.py runs its own private asyncio loop for Playwright, not Home
 # Assistant's shared event loop — the ASYNC240 hazard (stalling a live production
 # loop) doesn't apply to a one-off local CLI script.


### PR DESCRIPTION
## Summary
- Adds two dev-only, never-shipped Home Assistant integrations under `dev_tools/ha_test_integrations/` (outside `custom_components/` and `tools/deploy.py`'s scope) for locally testing multi-zone support against a second, genuinely independent climate + weather source.
- `ca_dev_thermostat_sim`: a `ClimateEntity` simulator that imports and calls the real `_simulate_indoor_physics` ODE step from `coordinator.py` (not a reimplementation — tracks production physics automatically), seeded from the user's own learned `k_passive`/`k_active_heat`/`k_active_cool` values. `RestoreEntity` + wall-clock elapsed-time integration so it stays correct across HA restarts and multi-day unattended runs.
- `ca_dev_weather_proxy`: a `WeatherEntity` with a synthetic, independently-controllable diurnal temperature curve, with forecast entries starting at today/now so Climate Advisor's day-classification logic gets real data instead of falling back to an instantaneous reading every cycle.
- Manual install only (copy folder into `config/custom_components/`); confirmed outside `deploy.py`'s hardcoded `COMPONENT_DIR` and outside HACS/hassfest's validation scope.

## Test plan
- [x] `ruff check` / `ruff format --check` on `dev_tools/` clean (new `dev_tools/*` per-file T20 ignore added to `pyproject.toml`, matching the existing `tools/*` exemption)
- [x] `dev_tools/ha_test_integrations/ca_dev_thermostat_sim/test_sim_math.py` — 3/3 pass; independently re-derived by hand against the real `_simulate_indoor_physics` source and confirmed byte-faithful
- [x] Weather proxy sine formula numerically verified (peak at configured `phase_offset_h`, trough 12h later) after a rejected first pass had the peak 6h off from its own documentation
- [ ] No `homeassistant` package is available in this repo to run these integrations directly — real verification is a manual install + multi-day run on a live HA instance, which is the whole point of this tool
- [x] Two rounds of adversarial Opus verification; second round PASS (first caught a lint-gate gap, a sine-formula/docs contradiction, a forecast off-by-one, and an inert HEAT_COOL mode — all fixed)

Blast radius: zero files under `custom_components/` changed.