### PR TITLE
Fix #871: add HVAC hysteresis (deadband) + short-cycle protection to dev thermostat simulator

### DIFF
--- a/dev_tools/ha_test_integrations/README.md
+++ b/dev_tools/ha_test_integrations/README.md
@@ -50,15 +50,41 @@ State survives HA restarts via `RestoreEntity` (current temperature, target
 temperature, HVAC mode, and fan mode are restored from the last known state).
 
 **`hvac_action`** reflects what the thermostat is actually doing each tick —
-`heating`/`cooling` while it's on the correct side of `target_temperature`
-(actively driving), `idle` once it reaches setpoint (still in heat/cool mode
-but not applying capacity, matching a real thermostat), `fan` when
-`hvac_mode` is off and `fan_mode` is `on`, `off` otherwise. This isn't
-cosmetic — 12 separate places in `coordinator.py`/`automation.py` key real
-decisions off a thermostat's `hvac_action` (thermal-observation gating,
-restart-cause classification, etc.); a fixture that never reported it was
-silently defeating all of them, independent of whether `hvac_mode` itself
-was being tracked correctly (Issue #830 fixed that; Issue #833 fixed this).
+`heating`/`cooling` while the compressor is actively running, `idle` while
+in heat/cool mode but not applying capacity, `fan` when `hvac_mode` is off
+and `fan_mode` is `on`, `off` otherwise. This isn't cosmetic — 12 separate
+places in `coordinator.py`/`automation.py` key real decisions off a
+thermostat's `hvac_action` (thermal-observation gating, restart-cause
+classification, etc.); a fixture that never reported it was silently
+defeating all of them, independent of whether `hvac_mode` itself was being
+tracked correctly (Issue #830 fixed that; Issue #833 fixed this).
+
+The compressor no longer switches on/off at the exact setpoint every tick.
+It now models the same two real-thermostat behaviors that made the earlier
+tick-frequency switching unrealistic:
+
+- **Hysteresis (deadband).** The compressor turns *on* only once indoor
+  temperature crosses `target_temperature ± deadband_{heat,cool}_f`, and
+  turns back *off* once indoor temperature returns to `target_temperature`
+  — a 1-2°F swing band, not an exact-setpoint trigger.
+- **Short-cycle protection (dwell timers).** Once the compressor starts, it
+  stays on for at least `min_run_seconds` even if it reaches setpoint
+  sooner; once it stops, it stays off for at least `min_off_seconds` even
+  if the deadband edge is crossed again sooner — equipment-protection dwell
+  timers, matching real compressor behavior.
+
+`hvac_action` correctly reports `idle` in **both** of these holding states —
+while indoor temperature is sitting inside the deadband, and while a
+deadband edge has been crossed but a dwell timer is still blocking the
+transition — not just "at setpoint." Because the ODE step is only ever
+given active capacity (`k_active_heat`/`k_active_cool`) while the compressor
+is actually on, a "commanded but waiting on a dwell timer" tick correctly
+falls back to pure passive decay, matching what a real thermostat's
+envelope does while the compressor is off. The entity's `compressor_on`
+debug attribute (see below) exposes this internal on/off state directly,
+since it's no longer always inferable from `hvac_action` alone once dwell
+timers can hold it in a state you might not expect from indoor temperature
+alone.
 
 **Fan mode** (`ClimateEntityFeature.FAN_MODE`, `auto`/`on`) is supported so
 Climate Advisor's HVAC-fan-only feature (`fan_mode: hvac_fan` or `both` in a
@@ -123,6 +149,20 @@ Reconfigure**. This reloads the entry with the new values immediately.
 | `comfort_cool` | number | 76 | Comfort ceiling (°F) — passed through to the ODE clamp logic |
 | `outdoor_source` | entity (weather or sensor) | — required | Where outdoor temperature is read from each tick |
 | `tick_seconds` | number | 30 | How often the simulation advances (real elapsed wall time drives the math, not this number) |
+| `deadband_heat_f` | number | 1.5 | Heat mode: compressor turns **on** once indoor temp falls to `target_temperature - deadband_heat_f`, and **off** once indoor temp rises back to `target_temperature` |
+| `deadband_cool_f` | number | 1.5 | Cool mode: compressor turns **on** once indoor temp rises to `target_temperature + deadband_cool_f`, and **off** once indoor temp falls back to `target_temperature` |
+| `min_run_seconds` | number | 300 | Equipment-protection dwell timer: minimum time the compressor stays on once started, even if it reaches setpoint sooner |
+| `min_off_seconds` | number | 300 | Equipment-protection dwell timer: minimum time the compressor stays off once stopped, even if a deadband edge is crossed again sooner |
+
+`deadband_heat_f`/`deadband_cool_f` default to 1.5°F to match production's
+`THERMAL_SWING_DEFAULT_F` — the same "real thermostat swing" value Climate
+Advisor itself assumes when it has no better live-measured estimate
+(`docs/08-COMPUTATION-REFERENCE.md` §5e-vii). `min_run_seconds`/
+`min_off_seconds` default to 300s (5 min), a typical compressor short-cycle
+protection interval. All four are new keys — existing config entries
+created before these fields existed load the defaults automatically until
+reconfigured. See "Matching a real home" below for tuning these to a
+specific zone's measured swing.
 
 ### `ca_dev_weather_proxy`
 
@@ -157,8 +197,12 @@ carefully by HA convention (targeting the `homeassistant: 2024.6.0` minimum
 pinned in `hacs.json`) and need to be installed and exercised on a real HA
 instance by a human before being trusted. The one exception:
 `ca_dev_thermostat_sim/test_sim_math.py` hand-verifies the ODE formula
-transcribed from `_simulate_indoor_physics` (three cases: passive decay,
-active heating, and a clamp-triggering long-dt cooling case) — run it with
+transcribed from `_simulate_indoor_physics` (passive decay, active heating,
+and a clamp-triggering long-dt cooling case), plus the deadband/dwell-timer
+switching logic described above (compressor doesn't turn on before crossing
+the deadband edge, doesn't turn off before reaching setpoint, and
+`min_off_seconds`/`min_run_seconds` correctly delay a transition the
+deadband alone would have triggered) — run it with
 `python dev_tools/ha_test_integrations/ca_dev_thermostat_sim/test_sim_math.py`.
 It is not a substitute for actually importing the real function once
 `homeassistant` is installed; see that script's docstring for why the import

--- a/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/climate.py
+++ b/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/climate.py
@@ -38,12 +38,20 @@ from homeassistant.util import dt as dt_util
 from .const import (
     CONF_COMFORT_COOL,
     CONF_COMFORT_HEAT,
+    CONF_DEADBAND_COOL_F,
+    CONF_DEADBAND_HEAT_F,
     CONF_INITIAL_TEMP_F,
     CONF_K_ACTIVE_COOL,
     CONF_K_ACTIVE_HEAT,
     CONF_K_PASSIVE,
+    CONF_MIN_OFF_SECONDS,
+    CONF_MIN_RUN_SECONDS,
     CONF_OUTDOOR_SOURCE,
     CONF_TICK_SECONDS,
+    DEFAULT_DEADBAND_COOL_F,
+    DEFAULT_DEADBAND_HEAT_F,
+    DEFAULT_MIN_OFF_SECONDS,
+    DEFAULT_MIN_RUN_SECONDS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -125,6 +133,14 @@ class SimulatedThermostat(RestoreEntity, ClimateEntity):
         self._comfort_cool: float = data[CONF_COMFORT_COOL]
         self._outdoor_source: str = data[CONF_OUTDOOR_SOURCE]
         self._tick_seconds: int = int(data[CONF_TICK_SECONDS])
+        # New keys (Issue: HVAC hysteresis + short-cycle protection) — read via .get()
+        # with DEFAULT_* fallback, not [...] , so existing entries created before these
+        # keys existed (including the live "Simulated"/"Simulated 2" zones) keep working
+        # unmodified until reconfigured.
+        self._deadband_heat_f: float = float(data.get(CONF_DEADBAND_HEAT_F, DEFAULT_DEADBAND_HEAT_F))
+        self._deadband_cool_f: float = float(data.get(CONF_DEADBAND_COOL_F, DEFAULT_DEADBAND_COOL_F))
+        self._min_run_seconds: float = float(data.get(CONF_MIN_RUN_SECONDS, DEFAULT_MIN_RUN_SECONDS))
+        self._min_off_seconds: float = float(data.get(CONF_MIN_OFF_SECONDS, DEFAULT_MIN_OFF_SECONDS))
 
         self._current_temp: float = float(data.get(CONF_INITIAL_TEMP_F, 70.0))
         self._target_temp: float | None = self._comfort_heat
@@ -140,6 +156,15 @@ class SimulatedThermostat(RestoreEntity, ClimateEntity):
         # read via hvac_action.
         self._actively_driving: bool = False
         self._last_update_ts: datetime = dt_util.utcnow()
+
+        # Compressor on/off state machine (deadband + min-run/min-off dwell). See
+        # _async_tick() for the state transitions. Timestamps are reset (None) on
+        # restart — see async_added_to_hass() — since equipment-protection dwell timers
+        # tracking real wall-clock gaps across an HA restart isn't meaningful for a dev
+        # fixture.
+        self._compressor_on: bool = False
+        self._last_on_ts: datetime | None = None
+        self._last_off_ts: datetime | None = None
 
     async def async_added_to_hass(self) -> None:
         """Restore prior simulated state (if any) and start the tick timer."""
@@ -169,6 +194,9 @@ class SimulatedThermostat(RestoreEntity, ClimateEntity):
             restored_fan_mode = last_state.attributes.get("fan_mode")
             if restored_fan_mode in self._attr_fan_modes:
                 self._fan_mode = restored_fan_mode
+
+            restored_hvac_action = last_state.attributes.get("hvac_action")
+            self._compressor_on = restored_hvac_action in ("heating", "cooling")
         else:
             _LOGGER.debug(
                 "No prior state for %s — starting from configured initial_temp_f=%.1f",
@@ -222,6 +250,21 @@ class SimulatedThermostat(RestoreEntity, ClimateEntity):
     def fan_mode(self) -> str:
         """Return the current fan mode."""
         return self._fan_mode
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the deadband/dwell state machine's internals for debugging.
+
+        Once dwell timers can hold the compressor in an unexpected on/off state, that
+        state is no longer inferable from hvac_action alone — this surfaces it directly.
+        """
+        return {
+            "compressor_on": self._compressor_on,
+            "deadband_heat_f": self._deadband_heat_f,
+            "deadband_cool_f": self._deadband_cool_f,
+            "min_run_seconds": self._min_run_seconds,
+            "min_off_seconds": self._min_off_seconds,
+        }
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set a new HVAC mode."""
@@ -311,24 +354,56 @@ class SimulatedThermostat(RestoreEntity, ClimateEntity):
             return
 
         if self._hvac_mode == HVACMode.HEAT:
-            k_active = self._k_active_heat
-            mode = "heat"
+            mode, deadband = "heat", self._deadband_heat_f
         elif self._hvac_mode == HVACMode.COOL:
-            k_active = self._k_active_cool
-            mode = "cool"
+            mode, deadband = "cool", self._deadband_cool_f
         else:
-            # OFF simulates as passive-only decay toward outdoor temp.
-            k_active = None
-            mode = None
+            mode, deadband = None, None
 
-        # Mirrors _simulate_indoor_physics's own q!=0 condition exactly (coordinator.py)
-        # so hvac_action can't drift out of sync with what the ODE step actually did
-        # this tick — computed from the temperature BEFORE this tick's step, same as
-        # the ODE function reads t_start.
-        self._actively_driving = self._target_temp is not None and (
-            (mode == "heat" and self._current_temp < self._target_temp)
-            or (mode == "cool" and self._current_temp > self._target_temp)
-        )
+        # Compressor on/off state machine: deadband thresholds decide when the
+        # compressor *wants* to change state; min_run/min_off dwell timers can delay
+        # that change (equipment short-cycle protection), same as real HVAC hardware.
+        # See docs/dev-thermostat-sim-hysteresis (plan) for the full design.
+        if mode is None:
+            self._compressor_on = False
+        elif self._target_temp is not None:
+            if not self._compressor_on:
+                wants_on = (mode == "heat" and self._current_temp <= self._target_temp - deadband) or (
+                    mode == "cool" and self._current_temp >= self._target_temp + deadband
+                )
+                can_turn_on = (
+                    self._last_off_ts is None or (now - self._last_off_ts).total_seconds() >= self._min_off_seconds
+                )
+                if wants_on and can_turn_on:
+                    self._compressor_on = True
+                    self._last_on_ts = now
+                    _LOGGER.info(
+                        "CA Dev Thermostat Sim %s: compressor ON (%s, indoor=%.1f target=%.1f)",
+                        self.entity_id,
+                        mode,
+                        self._current_temp,
+                        self._target_temp,
+                    )
+            else:
+                wants_off = (mode == "heat" and self._current_temp >= self._target_temp) or (
+                    mode == "cool" and self._current_temp <= self._target_temp
+                )
+                can_turn_off = (
+                    self._last_on_ts is None or (now - self._last_on_ts).total_seconds() >= self._min_run_seconds
+                )
+                if wants_off and can_turn_off:
+                    self._compressor_on = False
+                    self._last_off_ts = now
+                    _LOGGER.info(
+                        "CA Dev Thermostat Sim %s: compressor OFF (%s, indoor=%.1f target=%.1f)",
+                        self.entity_id,
+                        mode,
+                        self._current_temp,
+                        self._target_temp,
+                    )
+
+        self._actively_driving = self._compressor_on
+        k_active = (self._k_active_heat if mode == "heat" else self._k_active_cool) if self._compressor_on else None
 
         self._current_temp = _simulate_indoor_physics(
             self._current_temp,

--- a/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/config_flow.py
+++ b/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/config_flow.py
@@ -23,18 +23,26 @@ from homeassistant.helpers import selector
 from .const import (
     CONF_COMFORT_COOL,
     CONF_COMFORT_HEAT,
+    CONF_DEADBAND_COOL_F,
+    CONF_DEADBAND_HEAT_F,
     CONF_INITIAL_TEMP_F,
     CONF_K_ACTIVE_COOL,
     CONF_K_ACTIVE_HEAT,
     CONF_K_PASSIVE,
+    CONF_MIN_OFF_SECONDS,
+    CONF_MIN_RUN_SECONDS,
     CONF_OUTDOOR_SOURCE,
     CONF_TICK_SECONDS,
     DEFAULT_COMFORT_COOL,
     DEFAULT_COMFORT_HEAT,
+    DEFAULT_DEADBAND_COOL_F,
+    DEFAULT_DEADBAND_HEAT_F,
     DEFAULT_INITIAL_TEMP_F,
     DEFAULT_K_ACTIVE_COOL,
     DEFAULT_K_ACTIVE_HEAT,
     DEFAULT_K_PASSIVE,
+    DEFAULT_MIN_OFF_SECONDS,
+    DEFAULT_MIN_RUN_SECONDS,
     DEFAULT_TICK_SECONDS,
     DOMAIN,
 )
@@ -84,6 +92,18 @@ def _build_schema(*, defaults: dict[str, Any]) -> vol.Schema:
             vol.Required(CONF_TICK_SECONDS, default=defaults.get(CONF_TICK_SECONDS, DEFAULT_TICK_SECONDS)): _num(
                 min_=5, max_=3600, step=1, unit="s"
             ),
+            vol.Required(
+                CONF_DEADBAND_HEAT_F, default=defaults.get(CONF_DEADBAND_HEAT_F, DEFAULT_DEADBAND_HEAT_F)
+            ): _num(min_=0.1, max_=10.0, step=0.1, unit="°F"),
+            vol.Required(
+                CONF_DEADBAND_COOL_F, default=defaults.get(CONF_DEADBAND_COOL_F, DEFAULT_DEADBAND_COOL_F)
+            ): _num(min_=0.1, max_=10.0, step=0.1, unit="°F"),
+            vol.Required(
+                CONF_MIN_RUN_SECONDS, default=defaults.get(CONF_MIN_RUN_SECONDS, DEFAULT_MIN_RUN_SECONDS)
+            ): _num(min_=0, max_=1800, step=10, unit="s"),
+            vol.Required(
+                CONF_MIN_OFF_SECONDS, default=defaults.get(CONF_MIN_OFF_SECONDS, DEFAULT_MIN_OFF_SECONDS)
+            ): _num(min_=0, max_=1800, step=10, unit="s"),
         }
     )
 

--- a/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/const.py
+++ b/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/const.py
@@ -15,6 +15,10 @@ CONF_COMFORT_HEAT = "comfort_heat"
 CONF_COMFORT_COOL = "comfort_cool"
 CONF_OUTDOOR_SOURCE = "outdoor_source"
 CONF_TICK_SECONDS = "tick_seconds"
+CONF_DEADBAND_HEAT_F = "deadband_heat_f"
+CONF_DEADBAND_COOL_F = "deadband_cool_f"
+CONF_MIN_RUN_SECONDS = "min_run_seconds"
+CONF_MIN_OFF_SECONDS = "min_off_seconds"
 
 DEFAULT_INITIAL_TEMP_F = 70.0
 DEFAULT_K_PASSIVE = -0.15
@@ -23,5 +27,13 @@ DEFAULT_K_ACTIVE_COOL = -6.0
 DEFAULT_COMFORT_HEAT = 68.0
 DEFAULT_COMFORT_COOL = 76.0
 DEFAULT_TICK_SECONDS = 30
+# 1.5°F matches production's THERMAL_SWING_DEFAULT_F (docs/08-COMPUTATION-REFERENCE.md
+# §5e-vii) — the same "real thermostat swing" concept CA assumes about real hardware
+# when it has no better live estimate yet.
+DEFAULT_DEADBAND_HEAT_F = 1.5
+DEFAULT_DEADBAND_COOL_F = 1.5
+# 300s (5 min) matches typical compressor short-cycle equipment protection.
+DEFAULT_MIN_RUN_SECONDS = 300
+DEFAULT_MIN_OFF_SECONDS = 300
 
 PLATFORMS = ["climate"]

--- a/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/test_sim_math.py
+++ b/dev_tools/ha_test_integrations/ca_dev_thermostat_sim/test_sim_math.py
@@ -121,6 +121,72 @@ def _check(label: str, actual: float, expected: float, tol: float = 1e-9) -> Non
         raise SystemExit(1)
 
 
+def _check_bool(label: str, actual: bool, expected: bool) -> None:
+    ok = actual is expected
+    status = "PASS" if ok else "FAIL"
+    print(f"[{status}] {label}: actual={actual!r} expected={expected!r}")
+    if not ok:
+        raise SystemExit(1)
+
+
+class _ReferenceCompressorFSM:
+    """Hand-transcribed copy of climate.py's SimulatedThermostat compressor on/off
+    state machine (deadband + min-run/min-off dwell), for verification only.
+
+    Mirrors the _async_tick() pseudocode exactly: mode/deadband selection, the
+    not-on -> wants_on/can_turn_on branch, and the on -> wants_off/can_turn_off
+    branch. `now` is a plain float of elapsed seconds (no datetime needed for this
+    hand-check — only deltas matter).
+    """
+
+    def __init__(
+        self,
+        *,
+        deadband_heat_f: float = 1.5,
+        deadband_cool_f: float = 1.5,
+        min_run_seconds: float = 300,
+        min_off_seconds: float = 300,
+    ) -> None:
+        self.deadband_heat_f = deadband_heat_f
+        self.deadband_cool_f = deadband_cool_f
+        self.min_run_seconds = min_run_seconds
+        self.min_off_seconds = min_off_seconds
+        self.compressor_on = False
+        self.last_on_ts: float | None = None
+        self.last_off_ts: float | None = None
+
+    def tick(self, *, now: float, hvac_mode: str | None, current_temp: float, target_temp: float | None) -> bool:
+        """Advance the FSM one tick and return the resulting compressor_on state."""
+        if hvac_mode == "heat":
+            mode, deadband = "heat", self.deadband_heat_f
+        elif hvac_mode == "cool":
+            mode, deadband = "cool", self.deadband_cool_f
+        else:
+            mode, deadband = None, None
+
+        if mode is None:
+            self.compressor_on = False
+        elif target_temp is not None:
+            if not self.compressor_on:
+                wants_on = (mode == "heat" and current_temp <= target_temp - deadband) or (
+                    mode == "cool" and current_temp >= target_temp + deadband
+                )
+                can_turn_on = self.last_off_ts is None or (now - self.last_off_ts) >= self.min_off_seconds
+                if wants_on and can_turn_on:
+                    self.compressor_on = True
+                    self.last_on_ts = now
+            else:
+                wants_off = (mode == "heat" and current_temp >= target_temp) or (
+                    mode == "cool" and current_temp <= target_temp
+                )
+                can_turn_off = self.last_on_ts is None or (now - self.last_on_ts) >= self.min_run_seconds
+                if wants_off and can_turn_off:
+                    self.compressor_on = False
+                    self.last_off_ts = now
+
+        return self.compressor_on
+
+
 def main() -> None:
     print(__doc__.splitlines()[0])
     print()
@@ -151,6 +217,59 @@ def main() -> None:
         ),
         76.0,
     )
+
+    # Case 4: heating compressor does NOT turn on before crossing the deadband edge.
+    # target=70, deadband_heat=1.5 -> turn-on threshold is 68.5. At 69.0 (above
+    # threshold), the compressor must stay off.
+    fsm = _ReferenceCompressorFSM(deadband_heat_f=1.5, min_off_seconds=0)
+    on = fsm.tick(now=0, hvac_mode="heat", current_temp=69.0, target_temp=70.0)
+    _check_bool("heat: stays off above deadband edge (69.0 > 68.5)", on, False)
+    on = fsm.tick(now=1, hvac_mode="heat", current_temp=68.5, target_temp=70.0)
+    _check_bool("heat: turns on exactly at deadband edge (68.5 <= 68.5)", on, True)
+
+    # Case 5: cooling compressor does NOT turn on before crossing the deadband edge.
+    # target=76, deadband_cool=1.5 -> turn-on threshold is 77.5.
+    fsm = _ReferenceCompressorFSM(deadband_cool_f=1.5, min_off_seconds=0)
+    on = fsm.tick(now=0, hvac_mode="cool", current_temp=77.0, target_temp=76.0)
+    _check_bool("cool: stays off below deadband edge (77.0 < 77.5)", on, False)
+    on = fsm.tick(now=1, hvac_mode="cool", current_temp=77.5, target_temp=76.0)
+    _check_bool("cool: turns on exactly at deadband edge (77.5 >= 77.5)", on, True)
+
+    # Case 6: once on, compressor does NOT turn off until reaching setpoint — even
+    # though it's already well inside the deadband. min_run_seconds=0 so dwell isn't
+    # the reason it stays on here; only "hasn't reached target yet" is.
+    fsm = _ReferenceCompressorFSM(deadband_heat_f=1.5, min_run_seconds=0, min_off_seconds=0)
+    fsm.tick(now=0, hvac_mode="heat", current_temp=68.0, target_temp=70.0)  # crosses on
+    _check_bool("heat: compressor is on after crossing threshold", fsm.compressor_on, True)
+    on = fsm.tick(now=60, hvac_mode="heat", current_temp=69.9, target_temp=70.0)
+    _check_bool("heat: stays on below setpoint (69.9 < 70.0)", on, True)
+    on = fsm.tick(now=61, hvac_mode="heat", current_temp=70.0, target_temp=70.0)
+    _check_bool("heat: turns off exactly at setpoint (70.0 >= 70.0)", on, False)
+
+    # Case 7: min_run_seconds delays a turn-off that the deadband/setpoint condition
+    # alone would have triggered. Compressor turns on at t=0; setpoint is reached at
+    # t=60s, well before min_run_seconds=300 has elapsed — it must stay on until t=300.
+    fsm = _ReferenceCompressorFSM(deadband_heat_f=1.5, min_run_seconds=300, min_off_seconds=0)
+    fsm.tick(now=0, hvac_mode="heat", current_temp=68.0, target_temp=70.0)  # crosses on
+    on = fsm.tick(now=60, hvac_mode="heat", current_temp=70.0, target_temp=70.0)
+    _check_bool("heat: min_run_seconds holds compressor on despite reaching setpoint", on, True)
+    on = fsm.tick(now=299, hvac_mode="heat", current_temp=70.0, target_temp=70.0)
+    _check_bool("heat: still held on just before min_run_seconds elapses", on, True)
+    on = fsm.tick(now=300, hvac_mode="heat", current_temp=70.0, target_temp=70.0)
+    _check_bool("heat: turns off once min_run_seconds has elapsed", on, False)
+
+    # Case 8: min_off_seconds delays a turn-on that the deadband condition alone would
+    # have triggered. Compressor turns off at t=0 (reaches setpoint); indoor drifts back
+    # below the deadband threshold at t=60s, well before min_off_seconds=300 has
+    # elapsed — it must stay off until t=300.
+    fsm = _ReferenceCompressorFSM(deadband_heat_f=1.5, min_run_seconds=0, min_off_seconds=300)
+    fsm.tick(now=0, hvac_mode="heat", current_temp=68.0, target_temp=70.0)  # crosses on
+    fsm.tick(now=1, hvac_mode="heat", current_temp=70.0, target_temp=70.0)  # crosses off
+    _check_bool("heat: compressor is off after reaching setpoint", fsm.compressor_on, False)
+    on = fsm.tick(now=61, hvac_mode="heat", current_temp=68.0, target_temp=70.0)
+    _check_bool("heat: min_off_seconds holds compressor off despite crossing deadband edge again", on, False)
+    on = fsm.tick(now=301, hvac_mode="heat", current_temp=68.0, target_temp=70.0)
+    _check_bool("heat: turns on once min_off_seconds has elapsed", on, True)
 
     print()
     print("All hand-verified cases pass. This confirms the formula transcribed")

--- a/tools/deploy_dev_sim.py
+++ b/tools/deploy_dev_sim.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Deploy the CA dev-only test fixtures (thermostat sim + weather proxy) to a
+Home Assistant OS instance.
+
+DELIBERATELY SEPARATE FROM tools/deploy.py. That script deploys the shipped
+custom_components/climate_advisor production integration and must never be
+capable of touching dev-only fixtures (or vice versa) — see the invariant
+documented in dev_tools/ha_test_integrations/README.md. This script only ever
+reads/writes dev_tools/ha_test_integrations/ subdirectories and their remote
+custom_components/ca_dev_* counterparts; it has no code path that references
+custom_components/climate_advisor at all.
+
+Backs up, deploys, and optionally restarts two dev fixture integrations on a
+remote HAOS server via SSH, reusing tools/deploy.py's proven connection-safety
+helpers (config loading, SSH arg building, piped tar transfer, atomic
+extract-then-swap, StrictHostKeyChecking=accept-new) rather than duplicating
+them.
+
+Usage:
+    python tools/deploy_dev_sim.py                  # Full deploy
+    python tools/deploy_dev_sim.py --dry-run        # Show what would deploy, no changes
+    python tools/deploy_dev_sim.py --skip-restart   # Deploy without restarting HA
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+from pathlib import Path
+
+# Reuse deploy.py's proven SSH/config helpers directly rather than duplicating them —
+# per the plan, this is preferred over a copy as long as deploy.py's own
+# COMPONENT_DIR-shaped globals aren't relied on (this module builds its own remote
+# paths and tar payloads instead of calling deploy.py's COMPONENT_DIR-scoped
+# functions like remote_path()/deploy_files()/create_backup()/ensure_brand_dir()).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from deploy import (  # noqa: E402
+    Color,
+    _build_component_tar,
+    _split_marked_output,
+    fail,
+    gray,
+    info,
+    load_config,
+    ok,
+    resolve_ssh_identity,
+    run_local,
+    run_ssh,
+    run_ssh_piped,
+    scp_args,
+    setup_logging,
+    ssh_target,
+    step,
+    validate_config,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEV_INTEGRATIONS_ROOT = REPO_ROOT / "dev_tools" / "ha_test_integrations"
+COMPONENT_DIRS = [
+    DEV_INTEGRATIONS_ROOT / "ca_dev_thermostat_sim",
+    DEV_INTEGRATIONS_ROOT / "ca_dev_weather_proxy",
+]
+BACKUP_DIR = REPO_ROOT / "backups"
+BACKUP_KEEP_COUNT = 5
+
+_log = None  # set by setup_logging() import side effect (module-level _log in deploy.py)
+
+
+def remote_path_for(config: dict[str, str], component_dir: Path) -> str:
+    """Remote target path for one dev fixture component directory."""
+    return f"{config['HA_CONFIG_PATH']}/custom_components/{component_dir.name}"
+
+
+def create_backup_for(config: dict[str, str], component_dir: Path) -> bool:
+    """Back up one remote dev-fixture directory (if it exists) before overwriting it.
+
+    Mirrors deploy.py's create_backup() shape but scoped to a single component_dir /
+    remote_path pair, since this script deploys two fixtures per run.
+    """
+    rpath = remote_path_for(config, component_dir)
+    name = component_dir.name
+    step(f"Connecting to {config['HA_HOST']}:{config['HA_SSH_PORT']} and preparing backup for {name}")
+
+    cmd = (
+        f"if [ -d {shlex.quote(rpath)} ]; then "
+        f"tar czf /tmp/ca_dev_backup_{shlex.quote(name)}.tar.gz -C {shlex.quote(rpath)} . && echo TARED; "
+        f"else echo NOEXIST; fi; "
+        f"mkdir -p {shlex.quote(rpath)}"
+    )
+    rc, output = run_ssh(config, cmd)
+    if "TARED" not in output and "NOEXIST" not in output:
+        fail(f"Cannot connect via SSH while backing up {name}. Check .deploy.env and SSH setup.")
+        info("See docs/SSH-SETUP.md for configuration instructions.")
+        return False
+    ok(f"SSH connection successful ({name})")
+
+    if "NOEXIST" in output:
+        info(f"No existing installation found for {name}. Skipping backup.")
+        return True
+    if "TARED" not in output:
+        fail(f"Remote tar failed for {name}: {output}")
+        return True
+
+    BACKUP_DIR.mkdir(exist_ok=True)
+    if sys.platform != "win32":
+        os.chmod(BACKUP_DIR, 0o700)
+    from datetime import datetime
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    local_tar = BACKUP_DIR / f"{name}-{timestamp}.tar.gz"
+    target = ssh_target(config)
+
+    cmd = scp_args(config) + [f"{target}:/tmp/ca_dev_backup_{name}.tar.gz", str(local_tar)]
+    rc, output = run_local(cmd)
+    if rc != 0:
+        fail(f"Backup download failed for {name}: {output}")
+        return True
+
+    ok(f"Backup saved: {local_tar}")
+    return True
+
+
+def prune_backups() -> None:
+    step(f"Pruning old dev-fixture backups (keeping last {BACKUP_KEEP_COUNT} per fixture)")
+    if not BACKUP_DIR.exists():
+        ok("No backups directory yet")
+        return
+
+    for component_dir in COMPONENT_DIRS:
+        name = component_dir.name
+        backups = sorted(BACKUP_DIR.glob(f"{name}-*.tar.gz"), reverse=True)
+        removed = 0
+        for old in backups[BACKUP_KEEP_COUNT:]:
+            old.unlink()
+            removed += 1
+        ok(f"{name}: pruned {removed} old backup(s), {min(len(backups), BACKUP_KEEP_COUNT)} kept")
+
+
+def deploy_one(config: dict[str, str], component_dir: Path) -> tuple[bool, str]:
+    """Tar-and-extract one dev fixture directory to its remote target.
+
+    Same atomic extract-to-temp-then-swap pattern as deploy.py's deploy_files() —
+    extraction happens in a temp dir first, and only the final rm+mv (milliseconds)
+    touches the live directory, minimizing the window exposed to the HA SSH add-on's
+    observed mid-command connection resets.
+    """
+    name = component_dir.name
+    rpath = remote_path_for(config, component_dir)
+    step(f"Deploying {name} to {rpath}")
+
+    tar_bytes = _build_component_tar(component_dir)
+    local_count = sum(1 for f in component_dir.iterdir() if f.name != "__pycache__")
+
+    tmp_dir = f"/tmp/ca_dev_deploy_tmp_{name}"
+    script_steps = [
+        f"rm -f /tmp/ca_dev_backup_{name}.tar.gz",
+        f"rm -rf {shlex.quote(tmp_dir)}",
+        f"mkdir -p {shlex.quote(tmp_dir)}",
+        f"tar xzf - -C {shlex.quote(tmp_dir)}",
+        f"rm -rf {shlex.quote(rpath)}",
+        f"mv {shlex.quote(tmp_dir)} {shlex.quote(rpath)}",
+        "echo ___FILES___",
+        f"ls -1 {shlex.quote(rpath)} | wc -l",
+    ]
+    script = " && ".join(script_steps)
+
+    rc, output = run_ssh_piped(config, script, tar_bytes)
+    sections = _split_marked_output(output)
+
+    if "FILES" not in sections:
+        fail(f"File transfer/extraction failed for {name}")
+        if output:
+            print(f"   {output.strip()}")
+        return False, ""
+
+    remote_count = sections["FILES"].strip()
+    ok(f"Deployed {local_count} files to {rpath} (remote reports {remote_count} files)")
+    return True, ""
+
+
+def restart_and_check_logs(config: dict[str, str]) -> bool:
+    """Restart HA once (covers both fixtures) and grep the log for ca_dev_thermostat_sim.
+
+    A single restart after both fixtures are deployed, not one per fixture — matches
+    the plan's "two tar-and-extract passes" + shared restart/log-tail flow.
+    """
+    step("Restarting HA and checking logs")
+    script = " && ".join(
+        [
+            "echo ___RESTARTING___",
+            "ha core restart",
+            "sleep 60",
+            "echo ___LOGS___",
+            "ha core logs 2>/dev/null | grep -i ca_dev_thermostat_sim | tail -30",
+        ]
+    )
+    rc, output = run_ssh(config, script)
+    sections = _split_marked_output(output)
+
+    if "LOGS" not in sections:
+        fail("HA core restart did not complete successfully (script stopped before log fetch)")
+        if output:
+            print(f"   {output.strip()}")
+        return False
+
+    ok("HA core restart initiated and wait completed")
+    log_output = sections["LOGS"]
+
+    if not log_output.strip():
+        info("No log entries found for ca_dev_thermostat_sim yet.")
+        return True
+
+    lines = log_output.strip().splitlines()
+    error_lines = [line for line in lines if "ERROR" in line]
+    if error_lines:
+        fail("Errors found in HA logs:")
+        for line in error_lines:
+            print(f"   {Color.RED}{line}{Color.RESET}")
+    else:
+        ok("No errors found in recent logs")
+        for line in lines[-5:]:
+            gray(line)
+    return True
+
+
+def main() -> None:
+    if sys.platform == "win32":
+        os.system("")
+
+    parser = argparse.ArgumentParser(
+        description="Deploy CA dev-only test fixtures (ca_dev_thermostat_sim, ca_dev_weather_proxy) to Home Assistant"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show what would deploy, without making changes")
+    parser.add_argument("--skip-restart", action="store_true", help="Deploy without restarting HA")
+    args = parser.parse_args()
+
+    setup_logging()
+
+    config = load_config()
+    config_errors = validate_config(config)
+    if config_errors:
+        for e in config_errors:
+            fail(e)
+        sys.exit(1)
+
+    print(f"{Color.CYAN}============================================{Color.RESET}")
+    print(f"{Color.CYAN}  CA Dev Test Fixture Deployment Tool{Color.RESET}")
+    print(f"{Color.CYAN}  (dev_tools/ha_test_integrations only — never{Color.RESET}")
+    print(f"{Color.CYAN}  touches custom_components/climate_advisor){Color.RESET}")
+    print(f"{Color.CYAN}============================================{Color.RESET}")
+    print(f"  Host: {config['HA_HOST']}:{config['HA_SSH_PORT']}")
+    for component_dir in COMPONENT_DIRS:
+        print(f"  Target: {remote_path_for(config, component_dir)}")
+
+    if args.dry_run:
+        print(f"\n{Color.CYAN}============================================{Color.RESET}")
+        print(f"{Color.YELLOW}  DRY RUN complete. No changes made.{Color.RESET}")
+        print(f"{Color.CYAN}============================================{Color.RESET}")
+        for component_dir in COMPONENT_DIRS:
+            print(f"\nFiles that would be deployed for {component_dir.name}:")
+            for f in sorted(component_dir.rglob("*")):
+                if f.is_file() and "__pycache__" not in f.parts:
+                    gray(str(f.relative_to(component_dir)))
+        sys.exit(0)
+
+    identity = resolve_ssh_identity(config)
+    if identity:
+        info(f"Using SSH key: {identity}")
+    else:
+        info(
+            "No SSH key file resolved (HA_SSH_KEY unset, no default identity file found) — "
+            "relying on ssh-agent or other auth."
+        )
+
+    for component_dir in COMPONENT_DIRS:
+        if not create_backup_for(config, component_dir):
+            sys.exit(1)
+    prune_backups()
+
+    for component_dir in COMPONENT_DIRS:
+        success, _ = deploy_one(config, component_dir)
+        if not success:
+            sys.exit(1)
+
+    if args.skip_restart:
+        info("Skipping restart (--skip-restart). Remember to restart HA manually.")
+    else:
+        if not restart_and_check_logs(config):
+            sys.exit(1)
+
+    print(f"\n{Color.GREEN}============================================{Color.RESET}")
+    print(f"{Color.GREEN}  Dev fixture deployment complete!{Color.RESET}")
+    print(f"{Color.GREEN}============================================{Color.RESET}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- The dev-only `ca_dev_thermostat_sim` fixture (backing the live "Simulated"/"Simulated 2" test zones) switched heating/cooling on/off exactly at the setpoint every tick — no deadband, no minimum dwell time. Adds a configurable deadband (default 1.5°F, matching production's `THERMAL_SWING_DEFAULT_F`) and equipment-protection min-run/min-off dwell timers (default 300s), backward compatible with existing config entries via `.get()` fallback.
- Adds `tools/deploy_dev_sim.py`, a dedicated SSH deploy script scoped only to the two dev fixtures, kept deliberately separate from `tools/deploy.py` so dev fixtures can never reach a production install.
- Scope is entirely dev-only fixture code (`dev_tools/ha_test_integrations/`) — no changes to the shipped `custom_components/climate_advisor` integration.

Closes #871.

## Test plan
- [x] `python dev_tools/ha_test_integrations/ca_dev_thermostat_sim/test_sim_math.py` — 16/16 checks pass
- [x] `ruff check` / `ruff format` clean on all changed files
- [x] `python tools/deploy_dev_sim.py --dry-run` confirmed scoped only to the two dev fixture directories
- [x] Deployed live via `tools/deploy_dev_sim.py`; HA restarted cleanly with both fixtures loaded
- [ ] Reconfigure "Simulated"/"Simulated 2" zones in HA to pick up the new fields and observe realistic cycling (manual, post-merge)